### PR TITLE
In-app store review prompt (iOS App Store + Google Play)

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "expo-sharing": "~13.1.5",
     "expo-speech-recognition": "~3.1.0",
     "expo-status-bar": "~2.2.3",
+    "expo-store-review": "~8.1.5",
     "expo-web-browser": "~14.2.0",
     "firebase": "^12.4.0",
     "lottie-react-native": "^7.2.2",

--- a/src/components/TakePaymentSheet.tsx
+++ b/src/components/TakePaymentSheet.tsx
@@ -23,6 +23,7 @@ import {
 } from 'react-native';
 import { Text, Button } from 'react-native-paper';
 import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
+import { maybeRequestReview } from '../services/storeReviewService';
 
 import { colors } from '../theme';
 import { formatCurrency } from '../utils/quoteCalculator';
@@ -223,6 +224,10 @@ export function TakePaymentSheet({
           ? { message, url: result.paymentLinkUrl }
           : { message }
       );
+      // Tradie just sent a pay link — phone is in THEIR hand (unlike the
+      // in-person tap-to-pay flow, where the customer may hold the device), so
+      // this is a safe moment to ask for a store review. Rate-limited + F&F.
+      maybeRequestReview('payment_success').catch(() => {});
       onDismiss();
     } catch (error: any) {
       onError(

--- a/src/screens/ViewJobScreen.tsx
+++ b/src/screens/ViewJobScreen.tsx
@@ -49,6 +49,7 @@ import { FollowUpSheet, type FollowUpTone } from '../components/FollowUpSheet';
 import type { Document, DocumentStage } from '../types/document';
 import { documentToQuote, documentToInvoice } from '../types/documentAdapter';
 import { applyStageChange } from '../utils/applyStageChange';
+import { maybeRequestReview } from '../services/storeReviewService';
 import { ensureSquareConnectedForPayment } from '../utils/quoteDeliveryGuard';
 import { applyJobStageChange } from '../utils/applyJobStageChange';
 import { cascadeDeleteJob, pickPaidDocs } from '../utils/deleteJobWithDocs';
@@ -339,6 +340,9 @@ export function ViewJobScreen() {
             });
           }
           await saveJob({ ...job, stage: 'accepted' });
+          // Quote accepted (not via the tap-to-pay flow, which leads straight
+          // into payment) — opportunistic store-review ask, rate-limited.
+          maybeRequestReview('quote_accepted').catch(() => {});
           break;
         case 'takeDeposit':
           if (actionableDoc && actionableDoc.type === 'quote') {

--- a/src/services/storeReviewService.ts
+++ b/src/services/storeReviewService.ts
@@ -1,0 +1,92 @@
+/**
+ * Store review prompt.
+ *
+ * Asks the user for an App Store / Play Store rating at a genuine high-
+ * satisfaction moment (payment received, quote accepted) — but heavily rate-
+ * limited so we never nag:
+ *   - no-op on web and on devices where the native sheet isn't available;
+ *   - at most once per app session (in-memory flag, resets on app restart);
+ *   - only after the user has had at least one PRIOR happy moment;
+ *   - not within ~90 days of the last prompt;
+ *   - the OS additionally caps how often its native sheet actually appears
+ *     (~3/yr on iOS), so requestReview() may silently do nothing — which is
+ *     fine, we still back off.
+ *
+ * Persistent state lives in Firestore at users/{uid}/settings/appReview.
+ * Every path is fire-and-forget and swallows errors: review logic must never
+ * affect the surrounding payment / quote flow.
+ */
+import { Platform } from 'react-native';
+import * as StoreReview from 'expo-store-review';
+import { doc, getDoc, setDoc, serverTimestamp, increment, type DocumentReference } from 'firebase/firestore';
+import { auth, db } from '../config/firebase';
+
+const NINETY_DAYS_MS = 90 * 24 * 60 * 60 * 1000;
+
+// Once-per-app-session guard. Intentionally in-memory (not persisted) so it
+// resets when the app process restarts — the 90-day cooldown below is what
+// enforces the long-term cap.
+let promptedThisSession = false;
+
+export type HappyEvent = 'payment_success' | 'quote_accepted';
+
+interface AppReviewState {
+  lastPromptedAt?: number;
+  promptCount?: number;
+  happyEvents?: number;
+}
+
+function reviewDocRef(): DocumentReference | null {
+  const uid = auth.currentUser?.uid;
+  return uid ? doc(db, `users/${uid}/settings/appReview`) : null;
+}
+
+async function readState(ref: DocumentReference | null): Promise<AppReviewState> {
+  if (!ref) return {};
+  try {
+    const snap = await getDoc(ref);
+    return snap.exists() ? (snap.data() as AppReviewState) : {};
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Call from a genuine happy moment. Records the event and, if every gate
+ * passes, shows the native review prompt. Never throws.
+ */
+export async function maybeRequestReview(_event: HappyEvent): Promise<void> {
+  try {
+    if (Platform.OS === 'web') return;
+
+    const ref = reviewDocRef();
+    const state = await readState(ref);
+    const priorHappyEvents = state.happyEvents || 0;
+    // Record this happy moment atomically. increment() avoids the lost-update
+    // race when two happy moments land close together (e.g. quote accepted then
+    // a deposit shared seconds later) — a plain read-+1-write would drop one.
+    if (ref) {
+      await setDoc(ref, { happyEvents: increment(1), updatedAt: serverTimestamp() }, { merge: true });
+    }
+
+    if (promptedThisSession) return;
+    if (priorHappyEvents < 1) return; // require at least one EARLIER happy moment
+    if (state.lastPromptedAt && Date.now() - state.lastPromptedAt < NINETY_DAYS_MS) return;
+    if (!(await StoreReview.isAvailableAsync())) return;
+    if (!(await StoreReview.hasAction())) return;
+
+    await StoreReview.requestReview();
+
+    // Back off whether or not the OS actually showed the sheet.
+    promptedThisSession = true;
+    if (ref) {
+      await setDoc(
+        ref,
+        { lastPromptedAt: Date.now(), promptCount: increment(1), updatedAt: serverTimestamp() },
+        { merge: true },
+      );
+    }
+  } catch {
+    // Swallow — a failed review prompt must never disrupt the caller.
+  }
+}


### PR DESCRIPTION
Implements the **In-app store review prompt** ticket (`h5LuzwtsAkf0FBRl7Jgn`) — asks tradies for an App Store / Play Store rating at a genuine happy moment, heavily rate-limited so it never nags.

## What changed
- New `src/services/storeReviewService.ts`: `maybeRequestReview(event)` shows the native `StoreReview.requestReview()` sheet only when every gate passes — not web, native sheet available, ≥1 prior happy moment, not within 90 days of the last prompt, once per app session. State persists in Firestore `users/{uid}/settings/appReview`. Fully fire-and-forget; never throws into the caller.
- Triggers (both tradie-only, phone in the tradie's hand):
  - Quote accepted via **Mark Approved** (`ViewJobScreen.tsx`)
  - **Pay link sent** (`TakePaymentSheet.tsx` → `handleShareLink`)
- Added `expo-store-review` (autolinked, Expo SDK 53-compatible).

## Multi-agent pipeline notes
- **Explorer:** mapped the Firebase modular-SDK + AsyncStorage patterns, the payment-success path, and the quote-accept paths.
- **Bug-auditor (fixed):** the happy-event counter was a non-atomic read-modify-write (lost-update race when two happy moments land close together). Now uses Firestore `increment(1)` and gates on the *prior* persisted count.
- **UX-auditor (fixed):** the prompt originally fired on the in-person Tap-to-Pay/card path — exactly when the **customer** may be holding the phone. Moved to the Share-Pay-Link path; the Tap-to-Pay flow deliberately does not prompt.
- **QA-verify:** `npx tsc --noEmit` passes clean. Native sheet behaviour needs a physical-device check (`StoreReview` no-ops on simulators/web).

Implements ticket h5LuzwtsAkf0FBRl7Jgn