### PR TITLE
Add 'Convert to invoice' to a 3-dots menu on document rows

### DIFF
--- a/src/components/AlertModal.tsx
+++ b/src/components/AlertModal.tsx
@@ -30,6 +30,7 @@ interface AlertModalProps {
   primaryButtonAction?: () => void;
   secondaryButtonText?: string;
   secondaryButtonAction?: () => void;
+  primaryButtonLoading?: boolean;
   secondaryButtonLoading?: boolean;
   secondaryActionComponent?: React.ReactNode;
 }
@@ -100,6 +101,7 @@ export function AlertModal({
   primaryButtonAction,
   secondaryButtonText,
   secondaryButtonAction,
+  primaryButtonLoading = false,
   secondaryButtonLoading = false,
   secondaryActionComponent,
 }: AlertModalProps) {
@@ -393,6 +395,8 @@ export function AlertModal({
               style={styles.button}
               buttonColor={themeColors.buttonColor}
               textColor={colors.white}
+              loading={primaryButtonLoading}
+              disabled={primaryButtonLoading}
             >
               {primaryButtonText}
             </Button>

--- a/src/components/DocumentRow.tsx
+++ b/src/components/DocumentRow.tsx
@@ -217,7 +217,7 @@ export function DocumentRow({
               ]}
             >
               <MaterialCommunityIcons
-                name={'dots-vertical' as any}
+                name={'file-replace' as any}
                 size={18}
                 color={colors.primary}
               />

--- a/src/components/DocumentRow.tsx
+++ b/src/components/DocumentRow.tsx
@@ -29,6 +29,11 @@ interface DocumentRowProps {
   onSend?: (doc: Document) => void;
   /** When supplied, a card quick-action renders on the right. */
   onTakePayment?: (doc: Document) => void;
+  /**
+   * When supplied and the doc is a convertible quote, a 3-dots overflow
+   * action renders that lets the tradie convert the quote to an invoice.
+   */
+  onConvertToInvoice?: (doc: Document) => void;
 }
 
 function stageShortLabel(stage: Document['stage']): string {
@@ -74,10 +79,18 @@ export function DocumentRow({
   onPaymentPress,
   onSend,
   onTakePayment,
+  onConvertToInvoice,
 }: DocumentRowProps) {
   const meta = STAGE_META[doc.stage];
   const label = stageShortLabel(doc.stage);
-  const hasQuickActions = !!(onSend || onTakePayment);
+  // Convert-to-invoice is only legal on a quote that hasn't already been
+  // invoiced and is sitting in a stage where conversion makes sense.
+  const canConvert =
+    !!onConvertToInvoice &&
+    doc.type === 'quote' &&
+    !doc.invoicedAt &&
+    (doc.stage === 'draft' || doc.stage === 'quote_accepted');
+  const hasQuickActions = !!(onSend || onTakePayment || canConvert);
   // Doc stage chip is mostly redundant noise on the row — payment state
   // already lives in PaymentChip, and the job-level timeline above tells
   // the "where is it" story. Keep the chip only for the terminal-paid
@@ -185,6 +198,26 @@ export function DocumentRow({
             >
               <MaterialCommunityIcons
                 name={'credit-card-outline' as any}
+                size={18}
+                color={colors.primary}
+              />
+            </Pressable>
+          ) : null}
+          {canConvert ? (
+            <Pressable
+              onPress={(e) => {
+                e.stopPropagation();
+                selectionTap();
+                onConvertToInvoice!(doc);
+              }}
+              hitSlop={6}
+              style={({ pressed }) => [
+                styles.actionButton,
+                pressed && styles.actionButtonPressed,
+              ]}
+            >
+              <MaterialCommunityIcons
+                name={'dots-vertical' as any}
                 size={18}
                 color={colors.primary}
               />

--- a/src/hooks/useAlertModal.tsx
+++ b/src/hooks/useAlertModal.tsx
@@ -84,6 +84,7 @@ export function useAlertModal() {
       primaryButtonAction={wrappedPrimary}
       secondaryButtonText={opts.secondaryButtonText}
       secondaryButtonAction={wrappedSecondary}
+      primaryButtonLoading={busy && !!wrappedPrimary}
       secondaryButtonLoading={busy && !!wrappedSecondary}
     />
   ) : null;

--- a/src/screens/ViewJobScreen.tsx
+++ b/src/screens/ViewJobScreen.tsx
@@ -289,9 +289,10 @@ export function ViewJobScreen() {
       primaryKeepsOpen: true,
       primaryButtonAction: async () => {
         try {
-          await convertDocumentToInvoice(doc.id);
+          const converted = await convertDocumentToInvoice(doc.id);
           dismissAlert();
           setConvertSnackbar(true);
+          if (converted) openEditorForDoc(converted, 'materials');
         } catch (err) {
           showAlert({
             type: 'error',

--- a/src/screens/ViewJobScreen.tsx
+++ b/src/screens/ViewJobScreen.tsx
@@ -10,7 +10,7 @@
 import React, { useState, useMemo, useEffect, useRef } from 'react';
 import { View, StyleSheet, Pressable, Linking, Platform, TouchableOpacity } from 'react-native';
 import { NestableScrollContainer } from 'react-native-draggable-flatlist';
-import { Text, Card, Button, TextInput } from 'react-native-paper';
+import { Text, Card, Button, TextInput, Snackbar } from 'react-native-paper';
 import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
 import { useNavigation, useRoute } from '@react-navigation/native';
 import { formatDistanceToNow } from 'date-fns';
@@ -72,6 +72,7 @@ export function ViewJobScreen() {
   const saveQuote = useStore((s) => s.saveQuote);
   const saveInvoice = useStore((s) => s.saveInvoice);
   const createInvoiceFromQuote = useStore((s) => s.createInvoiceFromQuote);
+  const convertDocumentToInvoice = useStore((s) => s.convertDocumentToInvoice);
   const duplicateDocumentForJob = useStore((s) => s.duplicateDocumentForJob);
   const setCurrentQuote = useStore((s) => s.setCurrentQuote);
   const setCurrentInvoice = useStore((s) => s.setCurrentInvoice);
@@ -100,6 +101,7 @@ export function ViewJobScreen() {
   const [pendingAction, setPendingAction] = useState<JobActionId | null>(null);
   const [reeceConnected, setReeceConnected] = useState<boolean | null>(null);
   const { showAlert, alertNode } = useAlertModal();
+  const [convertSnackbar, setConvertSnackbar] = useState(false);
   const [notesDraft, setNotesDraft] = useState(job?.notes ?? '');
 
   useEffect(() => {
@@ -276,6 +278,29 @@ export function ViewJobScreen() {
       return;
     }
     setPaymentSheetDoc(doc);
+  };
+
+  const handleConvertToInvoice = (doc: Document) => {
+    showAlert({
+      type: 'warning',
+      title: 'Convert to invoice?',
+      message: "This quote will become an invoice and can't be sent as a quote again.",
+      primaryButtonText: 'Convert',
+      primaryButtonAction: async () => {
+        try {
+          await convertDocumentToInvoice(doc.id);
+          setConvertSnackbar(true);
+        } catch (err) {
+          showAlert({
+            type: 'error',
+            title: 'Conversion failed',
+            message: 'Save the document first, then try again.',
+          });
+        }
+      },
+      secondaryButtonText: 'Cancel',
+      secondaryButtonAction: () => {},
+    });
   };
 
   const openTakePaymentForDoc = (doc: Document) => {
@@ -741,6 +766,7 @@ export function ViewJobScreen() {
             onEdit={openEditorForDoc}
             onStagePress={setDocStageSheetDoc}
             onPaymentPress={handlePaymentChipPress}
+            onConvertToInvoice={handleConvertToInvoice}
             extra={reeceOrderEntry}
           />
         ) : null}
@@ -761,6 +787,7 @@ export function ViewJobScreen() {
             onEdit={openEditorForDoc}
             onStagePress={setDocStageSheetDoc}
             onPaymentPress={handlePaymentChipPress}
+            onConvertToInvoice={handleConvertToInvoice}
             extra={reeceOrderEntry}
           />
         ) : null}
@@ -865,6 +892,14 @@ export function ViewJobScreen() {
 
       {alertNode}
 
+      <Snackbar
+        visible={convertSnackbar}
+        onDismiss={() => setConvertSnackbar(false)}
+        duration={3000}
+      >
+        Converted to invoice
+      </Snackbar>
+
     </View>
   );
 }
@@ -882,6 +917,7 @@ interface ScopeBlockProps {
   onEdit: (doc: Document, step: ScopeStep) => void;
   onStagePress: (doc: Document) => void;
   onPaymentPress: (doc: Document) => void;
+  onConvertToInvoice: (doc: Document) => void;
   /** Optional slot rendered between the primary doc card and the
    *  "Also on this job" section. Used for the Order-from-Reece entry. */
   extra?: React.ReactNode;
@@ -893,6 +929,7 @@ function ScopeBlock({
   onEdit,
   onStagePress,
   onPaymentPress,
+  onConvertToInvoice,
   extra,
 }: ScopeBlockProps) {
   if (!primaryDoc) {
@@ -934,6 +971,9 @@ function ScopeBlock({
               onView={(d) => onEdit(d, 'materials')}
               onStagePress={onStagePress}
               onPaymentPress={onPaymentPress}
+              onConvertToInvoice={
+                doc.type === 'quote' ? onConvertToInvoice : undefined
+              }
             />
           ))}
         </View>

--- a/src/screens/ViewJobScreen.tsx
+++ b/src/screens/ViewJobScreen.tsx
@@ -100,7 +100,7 @@ export function ViewJobScreen() {
   } | null>(null);
   const [pendingAction, setPendingAction] = useState<JobActionId | null>(null);
   const [reeceConnected, setReeceConnected] = useState<boolean | null>(null);
-  const { showAlert, alertNode } = useAlertModal();
+  const { showAlert, dismissAlert, alertNode } = useAlertModal();
   const [convertSnackbar, setConvertSnackbar] = useState(false);
   const [notesDraft, setNotesDraft] = useState(job?.notes ?? '');
 
@@ -285,16 +285,18 @@ export function ViewJobScreen() {
       type: 'warning',
       title: 'Convert to invoice?',
       message: "This quote will become an invoice and can't be sent as a quote again.",
-      primaryButtonText: 'Convert',
+      primaryButtonText: 'Convert to invoice',
+      primaryKeepsOpen: true,
       primaryButtonAction: async () => {
         try {
           await convertDocumentToInvoice(doc.id);
+          dismissAlert();
           setConvertSnackbar(true);
         } catch (err) {
           showAlert({
             type: 'error',
             title: 'Conversion failed',
-            message: 'Save the document first, then try again.',
+            message: 'Something went wrong. Pull to refresh and try again.',
           });
         }
       },


### PR DESCRIPTION
<!-- qm-ticket:issue28 -->
Closes #28

## What changed

Added a `file-replace` overflow action to `DocumentRow` that lets tradies convert a secondary quote to an invoice directly from the "Also on this job" list in `ViewJobScreen`. Tapping the icon shows a confirm dialog, converts the quote in-place (reusing the existing `convertDocumentToInvoice` store action), opens the invoice editor (`MaterialsList` step), and shows a 3-second snackbar.

**Files changed:**
- `src/components/DocumentRow.tsx` — new optional `onConvertToInvoice?: (doc: Document) => void` prop; renders a `file-replace` Pressable when `canConvert` (quote, !invoicedAt, stage in {draft, quote_accepted})
- `src/screens/ViewJobScreen.tsx` — `handleConvertToInvoice` wired through `ScopeBlock` to `DocumentRow`; uses `useAlertModal` + `primaryKeepsOpen` for the confirm; navigates to invoice editor via `openEditorForDoc` on success; Snackbar toast
- `src/components/AlertModal.tsx` — added `primaryButtonLoading` prop (mirrors existing `secondaryButtonLoading`) to disable primary button while action is in flight
- `src/hooks/useAlertModal.tsx` — wires `primaryButtonLoading={busy && !!wrappedPrimary}` to prevent double-tap

## Bug / UX / Simplicity / QA findings and resolutions

**Bug (blocking) — error modal silently swallowed:**
The `primaryButtonAction` called `showAlert(error)` inside a `try/catch`, but the hook's `wrappedPrimary` auto-dismissed the modal in `finally`, overwriting the error opts. Fixed by adding `primaryKeepsOpen: true` and calling `dismissAlert()` manually on the success path so the error `showAlert` is never clobbered.

**Bug (blocking) — primary button not protected against double-tap:**
`busy` was only wired to `secondaryButtonLoading`; the primary Button had no `loading`/`disabled` props. A second tap while `convertDocumentToInvoice` was in flight could produce a duplicate invoice number. Fixed by adding `primaryButtonLoading` to `AlertModal` and `useAlertModal` (mirrors the existing secondary pattern).

**UX (blocking) — error copy was wrong/unreachable:**
"Save the document first" can't fire for real network failures (the store swallows those). Changed to "Something went wrong. Pull to refresh and try again."

**UX (blocking) — confirm button label too bare:**
"Convert" alone is ambiguous on a destructive action. Changed to "Convert to invoice" — unambiguous when skim-read.

**UX (medium) — "opens the invoice" not implemented:**
Spec says "navigates to the new invoice." Added `openEditorForDoc(converted, 'materials')` after dismissal — navigates to the `NewInvoice → MaterialsList` editor using the returned optimistic doc.

**UX / Simplicity (minor) — wrong icon for a direct action:**
`dots-vertical` signals an overflow menu; this button fires one action directly. Changed to `file-replace` — the same icon already used by `ActionSheet` for this action.

**Simplicity — no bloat:** No new dependencies, no new store actions, no new screens. Net ~86 lines across 4 files. Reuses `convertDocumentToInvoice`, `useAlertModal`, `openEditorForDoc`, `Snackbar`, `styles.actionButton`, and `selectionTap` — all pre-existing.

**QA — AC2/AC3/AC4/AC5 verified by static analysis + `npx tsc --noEmit` (0 src/ errors) + `npx vitest run` (66 passed / 0 failed).** AC1 (in-device tap → convert → navigate) requires manual device verification.

**Known limitation:** The Convert action appears only on _secondary_ doc rows (the "Also on this job" list). The primary job quote renders via `JobScopeCard`, which is out of scope per the ticket spec targeting `DocumentRow`. The primary quote conversion is covered by the existing sticky action bar / SendSwitcher.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EATVFzZVWcvVqkAZDJ9tPc)_