### PR TITLE
Fix: first-quote feedback records all three ratings at once (email scanner prefetch)

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "build": "tsc",
+    "test": "vitest run",
     "serve": "npm run build && firebase emulators:start --only functions",
     "shell": "npm run build && firebase functions:shell",
     "start": "npm run shell",
@@ -27,7 +28,8 @@
   "devDependencies": {
     "@types/cors": "^2.8.17",
     "@types/node-fetch": "^2.6.13",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "vitest": "^4.1.7"
   },
   "private": true
 }

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -82,6 +82,7 @@ import { getAussieMessage, AussieEvent } from './aussieNotifications';
 import { hashTerms } from './shared/pdf/terms/defaultAuTradie';
 import { dollarsToCents, centsToDollars } from './shared/pdf/money';
 import { validateAndRepairAiOutput } from './shared/ai/validateAiOutput';
+import { getFeedbackDocId, getCategoryLabel, isSideEffectFreeRequest, isRatingRecordRequest } from './quickFeedback.helpers';
 import {
   QM_APP_FEE_PCT_ONLINE,
   QM_APP_FEE_PCT_ONLINE_FREE,
@@ -7463,30 +7464,20 @@ export const updateActivityTimestamp = functions.https.onRequest((req, res) => {
  * Quick feedback from follow-up email — one-tap rating
  */
 export const quickFeedback = functions.https.onRequest(async (req, res) => {
-  // HEAD requests are read-only health checks — never mutate or notify
-  if (req.method === 'HEAD') {
+  // HEAD probes and email-client / link-previewer prefetches must be
+  // side-effect-free (no Firestore write, no founder email). This is the
+  // scanner-prefetch guard — see quickFeedback.helpers.isSideEffectFreeRequest.
+  if (isSideEffectFreeRequest(req.method, req.headers)) {
     res.status(200).end();
     return;
   }
-
-  // Prefetch/preview requests (email clients, link previewers) must be side-effect-free
-  const purpose = req.headers['purpose'] || req.headers['x-purpose'] || req.headers['x-moz'] || req.headers['sec-purpose'] || '';
-  if (typeof purpose === 'string' && (purpose.toLowerCase().includes('prefetch') || purpose.toLowerCase().includes('preview'))) {
-    res.status(200).end();
-    return;
-  }
-
-  const getFeedbackDocId = (uid: string, cat: string | undefined) =>
-    `${uid}__${cat === 're-engagement' ? 're-engagement' : 'first-quote'}`;
-  const getCategoryLabel = (cat: string | undefined) =>
-    cat === 're-engagement' ? 'Re-engagement' : 'First Quote Follow-Up';
 
   // POST = record rating (auto-fired on page load) OR detailed feedback submission
   if (req.method === 'POST') {
     const { userId, rating, category, feedbackId, details, record } = req.body;
 
     // Rating record path: deterministic upsert, founder email only on first create
-    const isRatingRecord = record === true || (!details && !!rating);
+    const isRatingRecord = isRatingRecordRequest({ record, rating, details });
     if (isRatingRecord) {
       const validRatings = ['great', 'okay', 'bad'];
       if (!userId || !rating || !validRatings.includes(rating)) {

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -7463,20 +7463,96 @@ export const updateActivityTimestamp = functions.https.onRequest((req, res) => {
  * Quick feedback from follow-up email — one-tap rating
  */
 export const quickFeedback = functions.https.onRequest(async (req, res) => {
-  // POST = detailed feedback submission after initial rating
+  // HEAD requests are read-only health checks — never mutate or notify
+  if (req.method === 'HEAD') {
+    res.status(200).end();
+    return;
+  }
+
+  // Prefetch/preview requests (email clients, link previewers) must be side-effect-free
+  const purpose = req.headers['purpose'] || req.headers['x-purpose'] || req.headers['x-moz'] || req.headers['sec-purpose'] || '';
+  if (typeof purpose === 'string' && (purpose.toLowerCase().includes('prefetch') || purpose.toLowerCase().includes('preview'))) {
+    res.status(200).end();
+    return;
+  }
+
+  const getFeedbackDocId = (uid: string, cat: string | undefined) =>
+    `${uid}__${cat === 're-engagement' ? 're-engagement' : 'first-quote'}`;
+  const getCategoryLabel = (cat: string | undefined) =>
+    cat === 're-engagement' ? 'Re-engagement' : 'First Quote Follow-Up';
+
+  // POST = record rating (auto-fired on page load) OR detailed feedback submission
   if (req.method === 'POST') {
-    const { userId, rating, feedbackId, details } = req.body;
+    const { userId, rating, category, feedbackId, details, record } = req.body;
+
+    // Rating record path: deterministic upsert, founder email only on first create
+    const isRatingRecord = record === true || (!details && !!rating);
+    if (isRatingRecord) {
+      const validRatings = ['great', 'okay', 'bad'];
+      if (!userId || !rating || !validRatings.includes(rating)) {
+        res.status(400).send('Invalid request');
+        return;
+      }
+
+      const categoryLabel = getCategoryLabel(category);
+      const docId = feedbackId || getFeedbackDocId(userId, category);
+
+      try {
+        const ref = admin.firestore().collection('feedback').doc(docId);
+        let firstCreate = false;
+        await admin.firestore().runTransaction(async (tx) => {
+          firstCreate = false;  // reset on each attempt
+          const snap = await tx.get(ref);
+          if (!snap.exists) {
+            tx.set(ref, {
+              userId,
+              category: categoryLabel,
+              feedback: `Quick rating: ${rating}`,
+              rating,
+              source: 'email-quick-feedback',
+              createdAt: admin.firestore.FieldValue.serverTimestamp(),
+              notifiedAt: admin.firestore.FieldValue.serverTimestamp(),
+            });
+            firstCreate = true;
+          } else {
+            tx.set(ref, {
+              rating,
+              updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+            }, { merge: true });
+          }
+        });
+
+        // Notify admin only on the first rating — never on re-taps
+        if (firstCreate) {
+          const userEmail = await getUserEmail(userId) || 'Unknown';
+          await sendEmail({
+            to: 'thomas.andrew.hansen@gmail.com',
+            subject: `Quick feedback: "${rating}" from ${userEmail} (${categoryLabel})`,
+            htmlContent: `<p>User <strong>${userEmail}</strong> (${userId}) rated their ${categoryLabel} experience: <strong>${rating}</strong></p>`,
+            category: 'transactional',
+            tags: ['quick-feedback-admin'],
+          });
+        }
+
+        res.status(200).json({ success: true });
+      } catch (error: any) {
+        res.status(500).send('Something went wrong');
+      }
+      return;
+    }
+
+    // Detailed feedback submission after initial rating
     if (!userId || !feedbackId) {
       res.status(400).send('Invalid request');
       return;
     }
 
     try {
-      // Update the existing feedback doc with detailed comments
-      await admin.firestore().collection('feedback').doc(feedbackId).update({
+      // Merge detailed comments into the existing deterministic feedback doc
+      await admin.firestore().collection('feedback').doc(feedbackId).set({
         details: (details || '').slice(0, 5000),
         detailsAddedAt: admin.firestore.FieldValue.serverTimestamp(),
-      });
+      }, { merge: true });
 
       // Notify admin about the detailed feedback
       const userEmail = await getUserEmail(userId) || 'Unknown';
@@ -7527,29 +7603,10 @@ export const quickFeedback = functions.https.onRequest(async (req, res) => {
     return;
   }
 
-  const categoryLabel = feedbackCategory === 're-engagement' ? 'Re-engagement' : 'First Quote Follow-Up';
+  // Deterministic doc id — the actual record/email happens via the auto-POST below
+  const docId = getFeedbackDocId(userId, feedbackCategory);
 
   try {
-    // Store the feedback and get the doc ID for the follow-up form
-    const feedbackRef = await admin.firestore().collection('feedback').add({
-      userId,
-      category: categoryLabel,
-      feedback: `Quick rating: ${rating}`,
-      rating,
-      source: 'email-quick-feedback',
-      createdAt: admin.firestore.FieldValue.serverTimestamp(),
-    });
-
-    // Notify admin
-    const userEmail = await getUserEmail(userId) || 'Unknown';
-    await sendEmail({
-      to: 'thomas.andrew.hansen@gmail.com',
-      subject: `Quick feedback: "${rating}" from ${userEmail}`,
-      htmlContent: `<p>User <strong>${userEmail}</strong> (${userId}) rated their first quote experience: <strong>${rating}</strong></p>`,
-      category: 'transactional',
-      tags: ['quick-feedback-admin'],
-    });
-
     const emoji = rating === 'great' ? '&#129321;' : rating === 'okay' ? '&#128528;' : '&#128169;';
     const message = rating === 'great'
       ? "Stoked to hear it! That's made our day."
@@ -7603,6 +7660,15 @@ export const quickFeedback = functions.https.onRequest(async (req, res) => {
         </div>
 
         <script>
+          // Record the rating on real page load (skipped by prefetch/HEAD requests)
+          document.addEventListener('DOMContentLoaded', function() {
+            fetch(window.location.origin + '/quickFeedback', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ userId: '${userId}', rating: '${rating}', category: '${feedbackCategory || ''}', record: true })
+            }).catch(function(){});
+          });
+
           document.getElementById('detailsForm').addEventListener('submit', async function(e) {
             e.preventDefault();
             var details = document.getElementById('details').value.trim();
@@ -7617,7 +7683,7 @@ export const quickFeedback = functions.https.onRequest(async (req, res) => {
                 body: JSON.stringify({
                   userId: '${userId}',
                   rating: '${rating}',
-                  feedbackId: '${feedbackRef.id}',
+                  feedbackId: '${docId}',
                   details: details
                 })
               });

--- a/functions/src/quickFeedback.helpers.test.ts
+++ b/functions/src/quickFeedback.helpers.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getFeedbackDocId,
+  getCategoryLabel,
+  isSideEffectFreeRequest,
+  isRatingRecordRequest,
+} from './quickFeedback.helpers';
+
+describe('getFeedbackDocId — deterministic, idempotent per user+category', () => {
+  it('buckets first-quote (default/undefined/unknown) to one stable id', () => {
+    expect(getFeedbackDocId('u1', undefined)).toBe('u1__first-quote');
+    expect(getFeedbackDocId('u1', 'first-quote')).toBe('u1__first-quote');
+    expect(getFeedbackDocId('u1', 'whatever')).toBe('u1__first-quote');
+  });
+  it('buckets re-engagement separately', () => {
+    expect(getFeedbackDocId('u1', 're-engagement')).toBe('u1__re-engagement');
+  });
+  it('is stable across calls so re-taps/prefetches upsert one doc, not append', () => {
+    expect(getFeedbackDocId('u1', undefined)).toBe(getFeedbackDocId('u1', undefined));
+    expect(getFeedbackDocId('u1', 're-engagement')).not.toBe(getFeedbackDocId('u1', undefined));
+  });
+});
+
+describe('getCategoryLabel — fixes the re-engagement mislabel', () => {
+  it('labels re-engagement vs first-quote correctly', () => {
+    expect(getCategoryLabel('re-engagement')).toBe('Re-engagement');
+    expect(getCategoryLabel(undefined)).toBe('First Quote Follow-Up');
+    expect(getCategoryLabel('first-quote')).toBe('First Quote Follow-Up');
+  });
+});
+
+describe('isSideEffectFreeRequest — the scanner/prefetch guard (root-cause fix)', () => {
+  it('treats HEAD (any case) as side-effect-free', () => {
+    expect(isSideEffectFreeRequest('HEAD', {})).toBe(true);
+    expect(isSideEffectFreeRequest('head', {})).toBe(true);
+  });
+  it('detects prefetch/preview across every purpose header variant', () => {
+    expect(isSideEffectFreeRequest('GET', { purpose: 'prefetch' })).toBe(true);
+    expect(isSideEffectFreeRequest('GET', { 'x-purpose': 'preview' })).toBe(true);
+    expect(isSideEffectFreeRequest('GET', { 'x-moz': 'prefetch' })).toBe(true);
+    expect(isSideEffectFreeRequest('GET', { 'sec-purpose': 'prefetch;prerender' })).toBe(true);
+  });
+  it('is case-insensitive and tolerates array header values', () => {
+    expect(isSideEffectFreeRequest('GET', { purpose: 'Prefetch' })).toBe(true);
+    expect(isSideEffectFreeRequest('GET', { 'sec-purpose': ['prefetch'] })).toBe(true);
+  });
+  it('lets a real human GET/POST through so the rating still records', () => {
+    expect(isSideEffectFreeRequest('GET', {})).toBe(false);
+    expect(isSideEffectFreeRequest('GET', { purpose: 'navigate' })).toBe(false);
+    expect(isSideEffectFreeRequest('POST', {})).toBe(false);
+  });
+});
+
+describe('isRatingRecordRequest — POST routing (rating record vs detailed feedback)', () => {
+  it('is a rating record when record:true', () => {
+    expect(isRatingRecordRequest({ record: true })).toBe(true);
+    expect(isRatingRecordRequest({ record: true, rating: 'great' })).toBe(true);
+  });
+  it('is a rating record when a rating is present with no details', () => {
+    expect(isRatingRecordRequest({ rating: 'okay' })).toBe(true);
+  });
+  it('is NOT a rating record when details are supplied (detailed-feedback path)', () => {
+    expect(isRatingRecordRequest({ rating: 'great', details: 'loved it' })).toBe(false);
+    expect(isRatingRecordRequest({ details: 'text' })).toBe(false);
+  });
+  it('is NOT a rating record for an empty body', () => {
+    expect(isRatingRecordRequest({})).toBe(false);
+  });
+});

--- a/functions/src/quickFeedback.helpers.ts
+++ b/functions/src/quickFeedback.helpers.ts
@@ -1,0 +1,57 @@
+/**
+ * Pure, dependency-free helpers for the `quickFeedback` HTTPS handler
+ * (see functions/src/index.ts). Extracted so the regression-critical logic —
+ * scanner/prefetch detection, the deterministic (idempotent) feedback doc id,
+ * and POST routing — is unit-testable without Firestore or email.
+ *
+ * Background: corporate email security scanners (Microsoft Safe Links,
+ * Mimecast, Proofpoint, …) fetch every link in an email, which previously
+ * recorded all three ratings (great/okay/bad) at once for one delivered email.
+ */
+
+export type FeedbackCategory = string | undefined;
+
+/**
+ * Deterministic doc id keyed by user + category so re-taps / prefetches upsert
+ * a single record instead of appending a new one each time. Anything that isn't
+ * 're-engagement' falls into the default first-quote bucket.
+ */
+export function getFeedbackDocId(uid: string, category: FeedbackCategory): string {
+  return `${uid}__${category === 're-engagement' ? 're-engagement' : 'first-quote'}`;
+}
+
+/** Human label for the founder notification and the stored record. */
+export function getCategoryLabel(category: FeedbackCategory): string {
+  return category === 're-engagement' ? 'Re-engagement' : 'First Quote Follow-Up';
+}
+
+type HeaderBag = Record<string, string | string[] | undefined>;
+
+function headerValue(v: string | string[] | undefined): string {
+  return Array.isArray(v) ? v.join(',') : v || '';
+}
+
+/**
+ * True when the request is a HEAD probe or an email-client / link-previewer
+ * prefetch — both must be side-effect-free (no Firestore write, no founder
+ * email). This is the core scanner-prefetch guard.
+ */
+export function isSideEffectFreeRequest(method: string | undefined, headers: HeaderBag): boolean {
+  if ((method || '').toUpperCase() === 'HEAD') return true;
+  const purpose = (
+    headerValue(headers.purpose) ||
+    headerValue(headers['x-purpose']) ||
+    headerValue(headers['x-moz']) ||
+    headerValue(headers['sec-purpose'])
+  ).toLowerCase();
+  return purpose.includes('prefetch') || purpose.includes('preview');
+}
+
+/**
+ * A POST is a "record the rating" call (auto-fired on real page load) rather
+ * than a detailed-feedback submission when it explicitly sets record:true, or
+ * carries a rating with no details text.
+ */
+export function isRatingRecordRequest(body: { record?: unknown; rating?: unknown; details?: unknown }): boolean {
+  return body.record === true || (!body.details && !!body.rating);
+}

--- a/functions/vitest.config.ts
+++ b/functions/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+    // src/shared is a symlink to the repo-root shared/ package, which has its
+    // own test setup — don't run those here.
+    exclude: ['**/node_modules/**', 'src/shared/**'],
+    environment: 'node',
+  },
+});


### PR DESCRIPTION
Closes #30
<!-- qm-ticket:gkZrjYpsbm5aIVG9wuLL -->

## Problem
The three rating links in the first-quote follow-up (and re-engagement) emails point at a GET endpoint (`quickFeedback`) that wrote a feedback row **and** emailed the founder on every hit, with no idempotency. Corporate email security scanners (Safe Links / Mimecast / Proofpoint) prefetch every link in an email, so one delivered email recorded all three ratings (great/okay/bad) at once.

## Fix (`functions/src/index.ts`)
- **GET/HEAD/prefetch are side-effect-free** — no Firestore write, no founder email. Handles `Purpose`, `X-Purpose`, `X-Moz`, `Sec-Purpose` prefetch/preview headers.
- The landing page **auto-POSTs the rating on real page load** (`DOMContentLoaded`); scanners that don't execute JS produce zero records.
- POST **upserts a deterministic doc** (`feedback/{userId}__first-quote|re-engagement`) in a transaction — creates once, merge-updates on re-taps; **founder email only on first create** (`notifiedAt` guard, `firstCreate` reset per attempt).
- Re-engagement emails are **labelled correctly** ("Re-engagement", was hardcoded "first quote experience").

(Commit 1 is the agent's implementation from issue #30; this PR was opened manually — see notes.)

## Tests (commit 2)
`functions/` had **no test runner** — added vitest (`^4.1.7`, matching the app) + `npm test`. Extracted the regression-critical logic into a pure, dependency-free module (`quickFeedback.helpers.ts`) and added **12 passing unit tests** covering:
- the **scanner/prefetch guard** across every purpose-header variant (case-insensitive, array values) + HEAD;
- the **deterministic idempotency key** (first-quote vs re-engagement bucketing, stable across calls);
- category labelling; and POST routing (rating-record vs detailed-feedback).

```
Test Files  1 passed (1)
     Tests  12 passed (12)
```

Suggested follow-up: a Firestore-emulator integration test for the transaction idempotency + notify-once path (the unit tests cover the deterministic-id design that guarantees it, not the live transaction).

## Notes
- Cherry-picked onto current `main` (the original agent branch sat on top of the now-squash-merged #29, so a direct PR would re-introduce unrelated UI changes). This PR is **`functions/` only**.
- Unrelated/pre-existing: a full `tsc` reports 2 errors in untouched files (`pdfGenerator.ts` puppeteer `networkidle0` type; `scripts/testQuoteGeneration.ts` missing `dotenv`), surfaced by a fresh install since `functions/package-lock.json` is gitignored. Not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
