### PR TITLE
Trustworthy floorplan takeoff: anchor-scale accuracy + visible/editable areas (no new upfront UI)

### DIFF
--- a/functions/src/floorplanScale.test.ts
+++ b/functions/src/floorplanScale.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect } from 'vitest';
+import { applyAnchorScale, FloorplanAnalysis } from './floorplanScale';
+
+function base(overrides: Partial<FloorplanAnalysis>): FloorplanAnalysis {
+  return {
+    detected: true,
+    assumptions: '',
+    confidence: 'low',
+    ...overrides,
+  };
+}
+
+describe('applyAnchorScale — post-scale math', () => {
+  it('scales total area onto the stated dimension', () => {
+    const result = applyAnchorScale(
+      base({
+        totalAreaM2: 590,
+        footprintDims: { lengthM: 25, widthM: 23.6 },
+        calibration: { source: 'stated_total', basisMm: 26850, note: '' },
+      }),
+    );
+    const factor = 26.85 / 25; // ≈ 1.074
+    const expected = 590 * factor * factor;
+    expect(result.totalAreaM2).toBeGreaterThan(expected * 0.99);
+    expect(result.totalAreaM2).toBeLessThan(expected * 1.01);
+    expect(result.scaledToAnchor).toBe(true);
+    expect(result.scaleFactorApplied).toBeCloseTo(1.074, 2);
+    expect(['medium', 'high']).toContain(result.confidence);
+    expect(result.source).toBe('model');
+  });
+
+  it('REGRESSION: a 590 m² read corrects up to ~680 m² under the stated anchor', () => {
+    const result = applyAnchorScale(
+      base({
+        totalAreaM2: 590,
+        footprintDims: { lengthM: 25, widthM: 23.6 },
+        calibration: { source: 'stated_total', basisMm: 26850, note: '' },
+      }),
+    );
+    // 590 × (26.85/25)² ≈ 680.6
+    expect(result.totalAreaM2).toBeCloseTo(680.6, 0);
+  });
+
+  it('scales areas by factor², lengths by factor, removalBinM3 by factor²', () => {
+    const result = applyAnchorScale(
+      base({
+        totalAreaM2: 100,
+        perimeterM: 40,
+        removalAreaM2: 50,
+        removalBinM3: 10,
+        footprintDims: { lengthM: 12, widthM: 12 },
+        calibration: { source: 'stated_total', basisMm: 24000, note: '' },
+      }),
+    );
+    // statedLength = 24m, modelAnchor = 12m → linearFactor = 2, areaFactor = 4
+    expect(result.scaleFactorApplied).toBeCloseTo(2, 5);
+    expect(result.totalAreaM2).toBeCloseTo(400, 5);
+    expect(result.removalAreaM2).toBeCloseTo(200, 5);
+    expect(result.removalBinM3).toBeCloseTo(40, 5);
+    expect(result.perimeterM).toBeCloseTo(80, 5);
+  });
+
+  it('known_dimension is NOT a footprint anchor — returns the analysis unchanged', () => {
+    // known_dimension is a labelled sub-footprint dimension (e.g. a grid bay),
+    // not the overall footprint length, so it must never drive anchor scaling.
+    const input = base({
+      totalAreaM2: 590,
+      footprintDims: { lengthM: 25, widthM: 23.6 },
+      calibration: { source: 'known_dimension', basisMm: 2520, note: '' },
+    });
+    const result = applyAnchorScale(input);
+    expect(result.scaledToAnchor).toBeUndefined();
+    expect(result).toBe(input);
+  });
+
+  it('sanity clamp: an implausibly large correction (>2×) returns unchanged', () => {
+    // statedLength = 30m, modelAnchor = 10m → linearFactor = 3 (out of clamp).
+    const input = base({
+      totalAreaM2: 100,
+      footprintDims: { lengthM: 10, widthM: 10 },
+      calibration: { source: 'stated_total', basisMm: 30000, note: '' },
+    });
+    const result = applyAnchorScale(input);
+    expect(result.scaledToAnchor).toBeUndefined();
+    expect(result.totalAreaM2).toBe(100);
+    expect(result).toBe(input);
+  });
+
+  it('sanity clamp: an implausibly small correction (<0.5×) returns unchanged', () => {
+    // statedLength = 2m, modelAnchor = 10m → linearFactor = 0.2 (out of clamp).
+    const input = base({
+      totalAreaM2: 100,
+      footprintDims: { lengthM: 10, widthM: 10 },
+      calibration: { source: 'stated_total', basisMm: 2000, note: '' },
+    });
+    const result = applyAnchorScale(input);
+    expect(result.scaledToAnchor).toBeUndefined();
+    expect(result.totalAreaM2).toBe(100);
+    expect(result).toBe(input);
+  });
+
+  it('falls back to √totalAreaM2 when footprintDims is absent', () => {
+    const result = applyAnchorScale(
+      base({
+        totalAreaM2: 100, // √100 = 10m model anchor
+        calibration: { source: 'stated_total', basisMm: 20000, note: '' },
+      }),
+    );
+    // statedLength = 20m, modelAnchor = 10m → factor 2, areaFactor 4
+    expect(result.scaleFactorApplied).toBeCloseTo(2, 5);
+    expect(result.totalAreaM2).toBeCloseTo(400, 5);
+  });
+
+  it('scales zones (areas, removal, dims) too', () => {
+    const result = applyAnchorScale(
+      base({
+        totalAreaM2: 100,
+        footprintDims: { lengthM: 10, widthM: 10 },
+        calibration: { source: 'stated_total', basisMm: 20000, note: '' },
+        zones: [
+          {
+            label: 'Room 1',
+            code: 'R1',
+            areaM2: 40,
+            removalAreaM2: 20,
+            dims: { lengthM: 8, widthM: 5 },
+          },
+        ],
+      }),
+    );
+    const zone = result.zones![0];
+    expect(zone.areaM2).toBeCloseTo(160, 5); // ×4
+    expect(zone.removalAreaM2).toBeCloseTo(80, 5); // ×4
+    expect(zone.dims!.lengthM).toBeCloseTo(16, 5); // ×2
+    expect(zone.dims!.widthM).toBeCloseTo(10, 5); // ×2
+  });
+
+  it('÷0 guard: modelAnchorLengthM of 0 returns the analysis unchanged', () => {
+    const input = base({
+      totalAreaM2: 0,
+      footprintDims: { lengthM: 0, widthM: 0 },
+      calibration: { source: 'stated_total', basisMm: 20000, note: '' },
+    });
+    const result = applyAnchorScale(input);
+    expect(result.scaledToAnchor).toBeUndefined();
+    expect(result).toBe(input);
+  });
+
+  it('no stated dimension returns the analysis unchanged', () => {
+    const input = base({
+      totalAreaM2: 100,
+      footprintDims: { lengthM: 10, widthM: 10 },
+      calibration: { source: 'scale_bar', basisMm: 5000, note: '' },
+    });
+    const result = applyAnchorScale(input);
+    expect(result.scaledToAnchor).toBeUndefined();
+    expect(result).toBe(input);
+  });
+
+  it('no calibration at all returns the analysis unchanged', () => {
+    const input = base({ totalAreaM2: 100, footprintDims: { lengthM: 10, widthM: 10 } });
+    const result = applyAnchorScale(input);
+    expect(result.scaledToAnchor).toBeUndefined();
+    expect(result).toBe(input);
+  });
+
+  it('is a no-op (returns unchanged) when the factor is ~1', () => {
+    const input = base({
+      totalAreaM2: 100,
+      confidence: 'high',
+      footprintDims: { lengthM: 10, widthM: 10 },
+      calibration: { source: 'stated_total', basisMm: 10000, note: '' },
+    });
+    const result = applyAnchorScale(input);
+    expect(result.scaledToAnchor).toBeUndefined();
+    expect(result.totalAreaM2).toBe(100);
+  });
+
+  it('does not downgrade an already-high confidence read', () => {
+    const result = applyAnchorScale(
+      base({
+        totalAreaM2: 100,
+        confidence: 'high',
+        footprintDims: { lengthM: 10, widthM: 10 },
+        calibration: { source: 'stated_total', basisMm: 20000, note: '' },
+      }),
+    );
+    expect(result.confidence).toBe('high');
+  });
+});

--- a/functions/src/floorplanScale.ts
+++ b/functions/src/floorplanScale.ts
@@ -1,0 +1,140 @@
+/**
+ * Anchor-scale correction for floorplan takeoffs.
+ *
+ * The vision model echoes the outer bounding-box dimensions it measured off the
+ * plan (`footprintDims`) and a `calibration` describing the real-world anchor
+ * the user supplied (a stated total or a known dimension). When the two
+ * disagree the model's pixel-derived measurement is wrong by a constant linear
+ * factor, so every area is off by that factor squared. We scale the whole
+ * takeoff back onto the user's real-world anchor here.
+ *
+ * Kept as a pure, side-effect-free function (separate from index.ts) so the
+ * money-path math is unit-testable in isolation. The shape mirrors
+ * `FloorplanAnalysis` in src/types — declared locally because functions/ is a
+ * standalone TypeScript project that doesn't include the app src tree.
+ */
+
+export interface FloorplanZone {
+  label: string;
+  code?: string;
+  areaM2?: number;
+  removalAreaM2?: number;
+  dims?: { lengthM: number; widthM: number };
+}
+
+export interface FloorplanAnalysis {
+  detected: boolean;
+  scale?: string;
+  calibration?: {
+    source: 'scale_bar' | 'known_dimension' | 'stated_total';
+    basisMm?: number;
+    note: string;
+  };
+  footprintDims?: { lengthM: number; widthM: number };
+  totalAreaM2?: number;
+  perimeterM?: number;
+  zones?: FloorplanZone[];
+  removalAreaM2?: number;
+  removalBinM3?: number;
+  scaledToAnchor?: boolean;
+  scaleFactorApplied?: number;
+  source?: 'model' | 'user';
+  assumptions: string;
+  confidence: 'low' | 'medium' | 'high';
+}
+
+/**
+ * Rescale a detected floorplan takeoff so its measurements match the
+ * real-world anchor the user supplied. Returns the analysis unchanged when
+ * there's no usable anchor, no usable model measurement, or the correction is
+ * a no-op — so this can never regress a takeoff that was already correct.
+ */
+export function applyAnchorScale(analysis: FloorplanAnalysis): FloorplanAnalysis {
+  // The real-world length to anchor onto: the stated *overall* footprint
+  // length the tradie supplied, captured in calibration.basisMm (millimetres).
+  // Only `stated_total` describes the outer footprint — `known_dimension` is a
+  // labelled sub-footprint dimension (e.g. a single grid bay) and using it as
+  // the footprint length would catastrophically mis-scale the whole takeoff.
+  let statedLengthM: number | undefined;
+  if (
+    analysis.calibration &&
+    analysis.calibration.source === 'stated_total' &&
+    typeof analysis.calibration.basisMm === 'number' &&
+    isFinite(analysis.calibration.basisMm) &&
+    analysis.calibration.basisMm > 0
+  ) {
+    statedLengthM = analysis.calibration.basisMm / 1000;
+  }
+  if (statedLengthM === undefined || statedLengthM <= 0 || !isFinite(statedLengthM)) {
+    return analysis;
+  }
+
+  // What the model actually measured off the plan — its outer bounding box if
+  // it echoed one, else the side of a square with the same area.
+  const modelAnchorLengthM =
+    analysis.footprintDims?.lengthM ?? Math.sqrt(analysis.totalAreaM2 ?? 0);
+  if (modelAnchorLengthM <= 0 || !isFinite(modelAnchorLengthM)) {
+    return analysis;
+  }
+
+  const linearFactor = statedLengthM / modelAnchorLengthM;
+  // No meaningful correction — leave the takeoff exactly as the model produced it.
+  if (Math.abs(linearFactor - 1) < 0.001) {
+    return analysis;
+  }
+  // Sanity clamp: a correction larger than 2× (or smaller than 0.5×) is
+  // implausibly big — almost always a mm/m unit mismatch or the wrong
+  // dimension type. Don't apply it; leave the takeoff as the model produced it.
+  if (linearFactor < 0.5 || linearFactor > 2.0) {
+    return analysis;
+  }
+
+  const areaFactor = linearFactor * linearFactor;
+  const next: FloorplanAnalysis = { ...analysis };
+
+  if (typeof next.totalAreaM2 === 'number') {
+    next.totalAreaM2 = next.totalAreaM2 * areaFactor;
+  }
+  if (typeof next.removalAreaM2 === 'number') {
+    next.removalAreaM2 = next.removalAreaM2 * areaFactor;
+  }
+  // The footprint grows by area, but skip depth is fixed → volume scales by
+  // the area factor, not the cube.
+  if (typeof next.removalBinM3 === 'number') {
+    next.removalBinM3 = next.removalBinM3 * areaFactor;
+  }
+  if (typeof next.perimeterM === 'number') {
+    next.perimeterM = next.perimeterM * linearFactor;
+  }
+  if (Array.isArray(next.zones)) {
+    next.zones = next.zones.map((z) => {
+      const zone: FloorplanZone = { ...z };
+      if (typeof zone.areaM2 === 'number') zone.areaM2 = zone.areaM2 * areaFactor;
+      if (typeof zone.removalAreaM2 === 'number') {
+        zone.removalAreaM2 = zone.removalAreaM2 * areaFactor;
+      }
+      if (zone.dims) {
+        zone.dims = {
+          lengthM: zone.dims.lengthM * linearFactor,
+          widthM: zone.dims.widthM * linearFactor,
+        };
+      }
+      return zone;
+    });
+  }
+
+  next.scaledToAnchor = true;
+  next.scaleFactorApplied = linearFactor;
+  next.source = 'model';
+
+  // Anchoring onto a real-world measurement is a meaningful confidence boost —
+  // never downgrade an already-confident read.
+  if (next.confidence !== 'medium' && next.confidence !== 'high') {
+    next.confidence = 'medium';
+  }
+
+  const note = `Measurements scaled to match the stated dimension (×${linearFactor.toFixed(3)}).`;
+  next.assumptions = next.assumptions ? `${next.assumptions} ${note}` : note;
+
+  return next;
+}

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -83,6 +83,7 @@ import { hashTerms } from './shared/pdf/terms/defaultAuTradie';
 import { dollarsToCents, centsToDollars } from './shared/pdf/money';
 import { validateAndRepairAiOutput } from './shared/ai/validateAiOutput';
 import { getFeedbackDocId, getCategoryLabel, isSideEffectFreeRequest, isRatingRecordRequest } from './quickFeedback.helpers';
+import { applyAnchorScale, FloorplanAnalysis } from './floorplanScale';
 import {
   QM_APP_FEE_PCT_ONLINE,
   QM_APP_FEE_PCT_ONLINE_FREE,
@@ -1841,11 +1842,13 @@ FLOORPLAN ANALYSIS (only when one of the attached images is an architectural pla
   3. a total dimension the tradie stated in the job description (source "stated_total").
   When references disagree, prefer a real-world measurement the tradie supplied over a hard-to-read drawing, and note the discrepancy.
 - Derive every "areaM2", "dims" and "perimeterM" by measuring against that single scale — never by guessing. Compute "totalAreaM2" two independent ways and reconcile them: (a) the overall footprint from its outer dimensions, and (b) the sum of the zone areas. If they differ by more than ~15%, re-measure, report the reconciled figure, and lower "confidence".
+- ALWAYS echo "footprintDims": { "lengthM", "widthM" } — the overall outer bounding-box dimensions you measured for the whole plan (the longer side is "lengthM"). Report exactly what you measured here; do not pre-adjust it.
+- If the tradie stated any real-world measurement in the job description (a total length, a wall run, a room dimension), treat that as ground truth and record it in "calibration" — it overrides anything read off the drawing.
 - "perimeterM" is the outer boundary length (drives skirting/edging/cornice/kerb/fence runs). "zones" are the distinct regions you can identify, each { "label", "code" (a printed room number or area/finish code if shown, else omit), "areaM2", "dims": { "lengthM", "widthM" } }.
 - If the scope involves removing/stripping existing surfaces, estimate "removalAreaM2" and a rough waste skip volume "removalBinM3".
 - ALWAYS include "assumptions" (what you inferred or could not read clearly) and "confidence": "high" ONLY when scale came from a scale bar or labelled dimension AND the two area methods agreed; "medium" when scale came from a stated total or grid spacing; "low" when scale was guessed or the drawing was hard to read. NEVER silently invent dimensions — if you can't establish scale at all, set detected:true, confidence:"low", omit the numbers, and say so in "assumptions".
 - Use the calibrated areas/perimeter to GROUND the material quantities above (e.g. m² of surface, lineal m of edge) instead of guessing — and show that derivation in each material's "reasoning".
-- Shape: "floorplanAnalysis": { "detected": true, "scale": "1:100", "calibration": { "source": "scale_bar|known_dimension|stated_total", "basisMm": 2520, "note": "..." }, "totalAreaM2": 0, "perimeterM": 0, "zones": [ { "label": "...", "code": "...", "areaM2": 0, "dims": { "lengthM": 0, "widthM": 0 } } ], "removalAreaM2": 0, "removalBinM3": 0, "assumptions": "...", "confidence": "medium" }
+- Shape: "floorplanAnalysis": { "detected": true, "scale": "1:100", "calibration": { "source": "scale_bar|known_dimension|stated_total", "basisMm": 2520, "note": "..." }, "footprintDims": { "lengthM": 0, "widthM": 0 }, "totalAreaM2": 0, "perimeterM": 0, "zones": [ { "label": "...", "code": "...", "areaM2": 0, "dims": { "lengthM": 0, "widthM": 0 } } ], "removalAreaM2": 0, "removalBinM3": 0, "assumptions": "...", "confidence": "medium" }
 
 Return ONLY valid JSON, no other text.`;
 
@@ -1959,7 +1962,7 @@ Return ONLY valid JSON, no other text.`;
         parsed.floorplanAnalysis &&
         typeof parsed.floorplanAnalysis === 'object' &&
         parsed.floorplanAnalysis.detected === true
-          ? parsed.floorplanAnalysis
+          ? applyAnchorScale(parsed.floorplanAnalysis as FloorplanAnalysis)
           : undefined;
 
       res.status(200).json({

--- a/src/components/FloorplanTakeoffCard.tsx
+++ b/src/components/FloorplanTakeoffCard.tsx
@@ -1,0 +1,279 @@
+/**
+ * FloorplanTakeoffCard — read-only takeoff summary for a job whose photos
+ * included an architectural plan/drawing.
+ *
+ * Surfaces the measured geometry (total area, per-zone areas, perimeter, waste
+ * volume) plus a confidence chip and an assumptions footnote, so the tradie can
+ * see and sanity-check what was read off the plan instead of trusting silently
+ * baked-in numbers. Read-only in this PR — no edit affordances yet.
+ */
+
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import { Text } from 'react-native-paper';
+import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
+
+import { FloorplanAnalysis } from '../types';
+import { resolvedTakeoff } from '../services/floorplanTakeoff';
+import { colors } from '../theme';
+
+interface FloorplanTakeoffCardProps {
+  analysis: FloorplanAnalysis;
+}
+
+const CONFIDENCE_META: Record<
+  FloorplanAnalysis['confidence'],
+  { label: string; color: string; bg: string }
+> = {
+  high: { label: 'High confidence', color: colors.success, bg: colors.successBg },
+  medium: { label: 'Medium confidence', color: colors.warning, bg: colors.warningBg },
+  low: { label: 'Low confidence', color: colors.error, bg: colors.errorBg },
+};
+
+function fmt(n: number): string {
+  // Trim trailing zeros: 12.50 → "12.5", 12.00 → "12".
+  return Number(n.toFixed(1)).toString();
+}
+
+// One-line guidance under the confidence chip so the tradie knows what the
+// chip means for the numbers, rather than just colour-coded anxiety.
+const CONFIDENCE_GUIDANCE: Record<FloorplanAnalysis['confidence'], string> = {
+  low: 'Measurements may be approximate — check before quoting',
+  medium: 'Measurements estimated from plan',
+  high: "Measurements match the plan's stated scale",
+};
+
+export function FloorplanTakeoffCard({ analysis }: FloorplanTakeoffCardProps) {
+  const takeoff = resolvedTakeoff(analysis);
+  const zones = (takeoff.zones ?? []).filter(
+    (z) => typeof z.areaM2 === 'number' && z.areaM2 > 0,
+  );
+  const conf = CONFIDENCE_META[takeoff.confidence] ?? CONFIDENCE_META.medium;
+  const assumptions = (takeoff.assumptions ?? '').trim();
+
+  const totalArea = typeof takeoff.totalAreaM2 === 'number' ? takeoff.totalAreaM2 : 0;
+  const perimeter = typeof takeoff.perimeterM === 'number' ? takeoff.perimeterM : 0;
+  const removalBin = typeof takeoff.removalBinM3 === 'number' ? takeoff.removalBinM3 : 0;
+
+  // A detected plan with no usable metrics renders as a hollow header (just a
+  // title + confidence chip), which reads as "measured" while showing nothing.
+  // Don't show the card at all in that case.
+  const hasAnyContent =
+    totalArea > 0 || perimeter > 0 || removalBin > 0 || zones.length > 0 || !!assumptions;
+  if (!hasAnyContent) {
+    return null;
+  }
+
+  const guidance = CONFIDENCE_GUIDANCE[takeoff.confidence];
+
+  return (
+    <View style={styles.card}>
+      <View style={styles.header}>
+        <View style={styles.headerLeft}>
+          <View style={styles.iconBadge}>
+            <MaterialCommunityIcons
+              name={'ruler-square' as any}
+              size={16}
+              color={colors.primary}
+            />
+          </View>
+          <Text style={styles.title}>Measured from plan</Text>
+        </View>
+        <View style={[styles.confChip, { backgroundColor: conf.bg }]}>
+          <Text style={[styles.confLabel, { color: conf.color }]}>{conf.label}</Text>
+        </View>
+      </View>
+
+      {guidance ? <Text style={styles.guidance}>{guidance}</Text> : null}
+
+      {typeof takeoff.totalAreaM2 === 'number' && takeoff.totalAreaM2 > 0 ? (
+        <MetricRow
+          icon="vector-square"
+          label="Total area"
+          value={`${fmt(takeoff.totalAreaM2)} m²`}
+        />
+      ) : null}
+
+      {typeof takeoff.perimeterM === 'number' && takeoff.perimeterM > 0 ? (
+        <MetricRow
+          icon="vector-polyline"
+          label="Perimeter"
+          value={`${fmt(takeoff.perimeterM)} m`}
+        />
+      ) : null}
+
+      {typeof takeoff.removalBinM3 === 'number' && takeoff.removalBinM3 > 0 ? (
+        <MetricRow
+          icon="dump-truck"
+          label="Waste volume"
+          value={`${fmt(takeoff.removalBinM3)} m³`}
+        />
+      ) : null}
+
+      {zones.length > 0 ? (
+        <View style={styles.zonesBlock}>
+          <Text style={styles.zonesHeading}>Areas</Text>
+          {zones.map((z, i) => (
+            <View key={`${z.code ?? z.label}-${i}`} style={styles.zoneRow}>
+              {z.code ? (
+                <View style={styles.zoneChip}>
+                  <Text style={styles.zoneChipText}>{z.code}</Text>
+                </View>
+              ) : null}
+              <Text style={styles.zoneLabel} numberOfLines={1}>
+                {z.label}
+              </Text>
+              <Text style={styles.zoneValue}>{fmt(z.areaM2!)} m²</Text>
+            </View>
+          ))}
+        </View>
+      ) : null}
+
+      {assumptions ? <Text style={styles.assumptions}>{assumptions}</Text> : null}
+    </View>
+  );
+}
+
+function MetricRow({
+  icon,
+  label,
+  value,
+}: {
+  icon: string;
+  label: string;
+  value: string;
+}) {
+  return (
+    <View style={styles.row}>
+      <View style={styles.rowIcon}>
+        <MaterialCommunityIcons name={icon as any} size={18} color={colors.primary} />
+      </View>
+      <Text style={styles.rowLabel}>{label}</Text>
+      <Text style={styles.rowValue}>{value}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    marginHorizontal: 16,
+    marginBottom: 12,
+    padding: 12,
+    borderRadius: 16,
+    backgroundColor: colors.surface,
+    gap: 8,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    paddingBottom: 8,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+  },
+  headerLeft: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    flex: 1,
+    minWidth: 0,
+  },
+  iconBadge: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    backgroundColor: colors.primaryBg,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  title: {
+    fontSize: 14,
+    fontWeight: '700',
+    color: colors.text,
+    flex: 1,
+  },
+  confChip: {
+    paddingHorizontal: 10,
+    paddingVertical: 5,
+    borderRadius: 999,
+    flexShrink: 0,
+  },
+  confLabel: {
+    fontSize: 11,
+    fontWeight: '700',
+  },
+  guidance: {
+    fontSize: 12,
+    color: colors.textSecondary,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    padding: 10,
+    borderRadius: 12,
+    backgroundColor: colors.surfaceGray3,
+  },
+  rowIcon: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    backgroundColor: colors.primaryBg,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  rowLabel: {
+    flex: 1,
+    fontSize: 13,
+    color: colors.text,
+  },
+  rowValue: {
+    fontSize: 14,
+    fontWeight: '700',
+    color: colors.text,
+  },
+  zonesBlock: {
+    gap: 6,
+    paddingTop: 2,
+  },
+  zonesHeading: {
+    fontSize: 11,
+    fontWeight: '700',
+    color: colors.textMuted,
+    textTransform: 'uppercase',
+    letterSpacing: 0.4,
+  },
+  zoneRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  zoneChip: {
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    borderRadius: 6,
+    backgroundColor: colors.surfaceGray3,
+  },
+  zoneChipText: {
+    fontSize: 11,
+    fontWeight: '700',
+    color: colors.textMuted,
+  },
+  zoneLabel: {
+    flex: 1,
+    fontSize: 13,
+    color: colors.text,
+  },
+  zoneValue: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: colors.text,
+  },
+  assumptions: {
+    fontSize: 12,
+    color: colors.textMuted,
+    fontStyle: 'italic',
+    lineHeight: 17,
+    paddingTop: 2,
+  },
+});

--- a/src/screens/NewQuote/JobDetailsScreen.tsx
+++ b/src/screens/NewQuote/JobDetailsScreen.tsx
@@ -911,6 +911,7 @@ export function JobDetailsScreen() {
           ...job,
           name: jobName || analysis.jobSummary || 'Custom Job',
           estimatedHours: analysis.estimatedHours,
+          ...(analysis.floorplanAnalysis ? { floorplanAnalysis: analysis.floorplanAnalysis } : {}),
         };
 
         // Get the latest document state and update it

--- a/src/screens/NewQuote/MaterialsListScreen.tsx
+++ b/src/screens/NewQuote/MaterialsListScreen.tsx
@@ -55,6 +55,7 @@ import { shouldRunReeceFirst } from '../../services/supplierPriority';
 // screen's mount cheap — see Phase 7 of the perf plan.
 import { getTradeCategoryById, getTradeNicheById, TRADE_CATEGORIES } from '../../constants/tradeCategories';
 import { MaterialItemCard } from '../../components/MaterialItemCard';
+import { FloorplanTakeoffCard } from '../../components/FloorplanTakeoffCard';
 import { InlineAddMaterialRow } from '../../components/InlineAddMaterialRow';
 import { ActionSheet, type ActionSheetOption } from '../../components/ActionSheet';
 import { SupplierListCaptureModal } from '../../components/SupplierListCaptureModal';
@@ -1944,7 +1945,14 @@ export function MaterialsListScreen() {
     </TouchableOpacity>
   ) : null;
 
-  const listHeader = <WebContainer>{reeceBanner}</WebContainer>;
+  const listHeader = (
+    <WebContainer>
+      {currentQuote?.job?.floorplanAnalysis?.detected && (
+        <FloorplanTakeoffCard analysis={currentQuote.job.floorplanAnalysis} />
+      )}
+      {reeceBanner}
+    </WebContainer>
+  );
 
   const listEmpty = (
     <WebContainer>

--- a/src/services/__tests__/floorplanTakeoff.test.ts
+++ b/src/services/__tests__/floorplanTakeoff.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { resolvedTakeoff, floorplanQuantityForUnit } from '../floorplanTakeoff';
+import { FloorplanAnalysis } from '../../types';
+
+function base(overrides: Partial<FloorplanAnalysis>): FloorplanAnalysis {
+  return {
+    detected: true,
+    assumptions: '',
+    confidence: 'medium',
+    ...overrides,
+  };
+}
+
+describe('resolvedTakeoff', () => {
+  it('returns model values when no corrected overrides exist', () => {
+    const analysis = base({ totalAreaM2: 100, perimeterM: 40, removalBinM3: 5 });
+    const r = resolvedTakeoff(analysis);
+    expect(r.totalAreaM2).toBe(100);
+    expect(r.perimeterM).toBe(40);
+    expect(r.removalBinM3).toBe(5);
+  });
+
+  it('returns corrected values field-by-field when corrected present', () => {
+    const analysis = base({
+      totalAreaM2: 100,
+      perimeterM: 40,
+      removalBinM3: 5,
+      corrected: { totalAreaM2: 120, removalBinM3: 8, editedAt: '2026-06-21T00:00:00Z' },
+    });
+    const r = resolvedTakeoff(analysis);
+    expect(r.totalAreaM2).toBe(120); // overridden
+    expect(r.perimeterM).toBe(40); // falls through to model
+    expect(r.removalBinM3).toBe(8); // overridden
+  });
+});
+
+describe('floorplanQuantityForUnit', () => {
+  const analysis = base({ totalAreaM2: 100, perimeterM: 40, removalBinM3: 5 });
+
+  it('maps m² → totalAreaM2, m → perimeterM, m³ → removalBinM3', () => {
+    expect(floorplanQuantityForUnit(analysis, 'm²')).toBe(100);
+    expect(floorplanQuantityForUnit(analysis, 'm')).toBe(40);
+    expect(floorplanQuantityForUnit(analysis, 'm³')).toBe(5);
+  });
+
+  it('returns undefined when the field is missing', () => {
+    const partial = base({ totalAreaM2: 100 });
+    expect(floorplanQuantityForUnit(partial, 'm')).toBeUndefined();
+    expect(floorplanQuantityForUnit(partial, 'm³')).toBeUndefined();
+  });
+});

--- a/src/services/__tests__/normaliseFloorplanAnalysis.test.ts
+++ b/src/services/__tests__/normaliseFloorplanAnalysis.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { normaliseFloorplanAnalysis } from '../floorplanNormalise';
+
+const detected = { detected: true, confidence: 'medium', assumptions: '' };
+
+describe('normaliseFloorplanAnalysis — new fields', () => {
+  it('coerces valid footprintDims (both fields finite > 0)', () => {
+    const r = normaliseFloorplanAnalysis({
+      ...detected,
+      footprintDims: { lengthM: 25, widthM: 10 },
+    });
+    expect(r?.footprintDims).toEqual({ lengthM: 25, widthM: 10 });
+  });
+
+  it('drops footprintDims when one field is NaN or ≤ 0', () => {
+    expect(
+      normaliseFloorplanAnalysis({
+        ...detected,
+        footprintDims: { lengthM: 25, widthM: 0 },
+      })?.footprintDims,
+    ).toBeUndefined();
+    expect(
+      normaliseFloorplanAnalysis({
+        ...detected,
+        footprintDims: { lengthM: 'abc', widthM: 10 },
+      })?.footprintDims,
+    ).toBeUndefined();
+  });
+
+  it('coerces scaleFactorApplied, dropping non-finite/negative', () => {
+    expect(
+      normaliseFloorplanAnalysis({ ...detected, scaleFactorApplied: 1.074 })
+        ?.scaleFactorApplied,
+    ).toBe(1.074);
+    expect(
+      normaliseFloorplanAnalysis({ ...detected, scaleFactorApplied: -1 })
+        ?.scaleFactorApplied,
+    ).toBeUndefined();
+    expect(
+      normaliseFloorplanAnalysis({ ...detected, scaleFactorApplied: 'nope' })
+        ?.scaleFactorApplied,
+    ).toBeUndefined();
+  });
+
+  it('preserves scaledToAnchor boolean', () => {
+    expect(
+      normaliseFloorplanAnalysis({ ...detected, scaledToAnchor: true })?.scaledToAnchor,
+    ).toBe(true);
+    expect(
+      normaliseFloorplanAnalysis({ ...detected, scaledToAnchor: 'true' })?.scaledToAnchor,
+    ).toBeUndefined();
+  });
+
+  it('preserves source when model/user, drops anything else', () => {
+    expect(normaliseFloorplanAnalysis({ ...detected, source: 'model' })?.source).toBe(
+      'model',
+    );
+    expect(normaliseFloorplanAnalysis({ ...detected, source: 'user' })?.source).toBe(
+      'user',
+    );
+    expect(
+      normaliseFloorplanAnalysis({ ...detected, source: 'bogus' })?.source,
+    ).toBeUndefined();
+  });
+});

--- a/src/services/floorplanNormalise.ts
+++ b/src/services/floorplanNormalise.ts
@@ -1,0 +1,64 @@
+import { FloorplanAnalysis } from '../types';
+
+/**
+ * Coerce a raw floorplanAnalysis blob from the LLM into our typed shape, or
+ * undefined when no plan was detected. Keeps only sane numeric values so a
+ * hallucinated area never silently inflates quantities downstream.
+ *
+ * Pure + dependency-free (no react-native/firebase/@env) so it's unit-testable
+ * in isolation; re-exported from llmService for callers.
+ */
+export function normaliseFloorplanAnalysis(raw: any): FloorplanAnalysis | undefined {
+  if (!raw || typeof raw !== 'object' || raw.detected !== true) return undefined;
+  const num = (v: any): number | undefined => {
+    const n = typeof v === 'number' ? v : parseFloat(v);
+    return Number.isFinite(n) && n > 0 ? n : undefined;
+  };
+  const confidence: FloorplanAnalysis['confidence'] =
+    raw.confidence === 'high' || raw.confidence === 'low' ? raw.confidence : 'medium';
+  const zones = Array.isArray(raw.zones)
+    ? raw.zones
+        .map((z: any) => ({
+          label: (z?.label || z?.code || 'Zone').toString(),
+          code: z?.code ? z.code.toString() : undefined,
+          areaM2: num(z?.areaM2),
+          removalAreaM2: num(z?.removalAreaM2),
+          dims:
+            num(z?.dims?.lengthM) && num(z?.dims?.widthM)
+              ? { lengthM: num(z.dims.lengthM)!, widthM: num(z.dims.widthM)! }
+              : undefined,
+        }))
+        .slice(0, 100)
+    : undefined;
+  return {
+    detected: true,
+    scale: raw.scale ? raw.scale.toString() : undefined,
+    calibration:
+      raw.calibration && typeof raw.calibration === 'object'
+        ? {
+            source:
+              raw.calibration.source === 'scale_bar' ||
+              raw.calibration.source === 'known_dimension' ||
+              raw.calibration.source === 'stated_total'
+                ? raw.calibration.source
+                : 'stated_total',
+            basisMm: num(raw.calibration.basisMm),
+            note: (raw.calibration.note || '').toString(),
+          }
+        : undefined,
+    footprintDims:
+      num(raw.footprintDims?.lengthM) && num(raw.footprintDims?.widthM)
+        ? { lengthM: num(raw.footprintDims.lengthM)!, widthM: num(raw.footprintDims.widthM)! }
+        : undefined,
+    totalAreaM2: num(raw.totalAreaM2),
+    perimeterM: num(raw.perimeterM),
+    zones: zones && zones.length ? zones : undefined,
+    removalAreaM2: num(raw.removalAreaM2),
+    removalBinM3: num(raw.removalBinM3),
+    scaledToAnchor: raw.scaledToAnchor === true ? true : undefined,
+    scaleFactorApplied: num(raw.scaleFactorApplied),
+    source: raw.source === 'model' || raw.source === 'user' ? raw.source : undefined,
+    assumptions: (raw.assumptions || '').toString(),
+    confidence,
+  };
+}

--- a/src/services/floorplanTakeoff.ts
+++ b/src/services/floorplanTakeoff.ts
@@ -1,0 +1,33 @@
+import { FloorplanAnalysis } from '../types';
+
+/**
+ * Resolve the takeoff numbers to use, preferring any user-edited `corrected`
+ * overrides over the model-measured values field-by-field. Zone editing is
+ * deferred, so zones pass through as-is.
+ */
+export function resolvedTakeoff(analysis: FloorplanAnalysis) {
+  const c = analysis.corrected;
+  return {
+    totalAreaM2: c?.totalAreaM2 ?? analysis.totalAreaM2,
+    perimeterM: c?.perimeterM ?? analysis.perimeterM,
+    removalBinM3: c?.removalBinM3 ?? analysis.removalBinM3,
+    zones: analysis.zones, // zones editing deferred
+    confidence: analysis.confidence,
+    assumptions: analysis.assumptions,
+  };
+}
+
+/**
+ * Pick the resolved takeoff quantity that matches a measure unit, or undefined
+ * when that quantity isn't available.
+ */
+export function floorplanQuantityForUnit(
+  analysis: FloorplanAnalysis,
+  unit: 'm²' | 'm' | 'm³',
+): number | undefined {
+  const resolved = resolvedTakeoff(analysis);
+  if (unit === 'm²') return resolved.totalAreaM2;
+  if (unit === 'm') return resolved.perimeterM;
+  if (unit === 'm³') return resolved.removalBinM3;
+  return undefined;
+}

--- a/src/services/llmService.ts
+++ b/src/services/llmService.ts
@@ -5,6 +5,7 @@
 
 import { ANTHROPIC_API_KEY, GEMINI_API_KEY } from '@env';
 import { Material, FloorplanAnalysis } from '../types';
+import { normaliseFloorplanAnalysis } from './floorplanNormalise';
 import { Platform } from 'react-native';
 import { auth } from '../config/firebase';
 // Lazy-import FileSystem (only available on native)
@@ -229,57 +230,10 @@ async function analyzeViaFirebaseFunction(
   };
 }
 
-/**
- * Coerce a raw floorplanAnalysis blob from the LLM into our typed shape, or
- * undefined when no plan was detected. Keeps only sane numeric values so a
- * hallucinated area never silently inflates quantities downstream.
- */
-function normaliseFloorplanAnalysis(raw: any): FloorplanAnalysis | undefined {
-  if (!raw || typeof raw !== 'object' || raw.detected !== true) return undefined;
-  const num = (v: any): number | undefined => {
-    const n = typeof v === 'number' ? v : parseFloat(v);
-    return Number.isFinite(n) && n > 0 ? n : undefined;
-  };
-  const confidence: FloorplanAnalysis['confidence'] =
-    raw.confidence === 'high' || raw.confidence === 'low' ? raw.confidence : 'medium';
-  const zones = Array.isArray(raw.zones)
-    ? raw.zones
-        .map((z: any) => ({
-          label: (z?.label || z?.code || 'Zone').toString(),
-          code: z?.code ? z.code.toString() : undefined,
-          areaM2: num(z?.areaM2),
-          dims:
-            num(z?.dims?.lengthM) && num(z?.dims?.widthM)
-              ? { lengthM: num(z.dims.lengthM)!, widthM: num(z.dims.widthM)! }
-              : undefined,
-        }))
-        .slice(0, 100)
-    : undefined;
-  return {
-    detected: true,
-    scale: raw.scale ? raw.scale.toString() : undefined,
-    calibration:
-      raw.calibration && typeof raw.calibration === 'object'
-        ? {
-            source:
-              raw.calibration.source === 'scale_bar' ||
-              raw.calibration.source === 'known_dimension' ||
-              raw.calibration.source === 'stated_total'
-                ? raw.calibration.source
-                : 'stated_total',
-            basisMm: num(raw.calibration.basisMm),
-            note: (raw.calibration.note || '').toString(),
-          }
-        : undefined,
-    totalAreaM2: num(raw.totalAreaM2),
-    perimeterM: num(raw.perimeterM),
-    zones: zones && zones.length ? zones : undefined,
-    removalAreaM2: num(raw.removalAreaM2),
-    removalBinM3: num(raw.removalBinM3),
-    assumptions: (raw.assumptions || '').toString(),
-    confidence,
-  };
-}
+// Coercion lives in a pure, dependency-free module so it stays unit-testable
+// without dragging react-native/firebase into the test runner. Re-exported
+// here for existing callers.
+export { normaliseFloorplanAnalysis };
 
 /**
  * Analyze job description via Google Gemini API (fallback)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -117,6 +117,7 @@ export interface FloorplanZone {
   label: string;          // human label, e.g. "Master bedroom" or "FC01 area"
   code?: string;          // plan-printed code if any (FC01, R1, …)
   areaM2?: number;
+  removalAreaM2?: number; // strip-out / demolition scope for this zone
   dims?: { lengthM: number; widthM: number };
 }
 
@@ -131,11 +132,26 @@ export interface FloorplanAnalysis {
     basisMm?: number;             // the reference length used to set scale
     note: string;
   };
+  // Outer bounding-box dimensions the model measured for the whole plan.
+  footprintDims?: { lengthM: number; widthM: number };
   totalAreaM2?: number;
   perimeterM?: number;            // drives skirting / edging / cornice / kerb
   zones?: FloorplanZone[];
   removalAreaM2?: number;         // strip-out / demolition scope
   removalBinM3?: number;          // estimated waste skip volume
+  // Whether the takeoff was rescaled onto a user-stated/known real-world
+  // dimension, and the linear factor applied.
+  scaledToAnchor?: boolean;
+  scaleFactorApplied?: number;
+  // 'model' = measured/derived, 'user' = manually corrected.
+  source?: 'model' | 'user';
+  // User-edited overrides — when present these win over the measured values.
+  corrected?: {
+    totalAreaM2?: number;
+    perimeterM?: number;
+    removalBinM3?: number;
+    editedAt?: string;
+  };
   assumptions: string;            // what was inferred or could not be read
   confidence: 'low' | 'medium' | 'high';
 }


### PR DESCRIPTION
<!-- qm-ticket:BRd2PGeLkC4uz0kaqEq7 -->
Closes #32

Implemented by the on-demand code agent — it pushed this branch but could not open the PR (GitHub Actions PR-creation is disabled in repo settings). Opened manually. Full implementation summary is in issue #32.