### PR TITLE
Floorplan accuracy: anchor-correct material quantities (Phase 3)

### DIFF
--- a/functions/src/email.ts
+++ b/functions/src/email.ts
@@ -1835,43 +1835,65 @@ export async function handleUnsubscribe(userId: string, category: string): Promi
 // QUOTE FOLLOW-UP EMAIL (2hrs after first quote created)
 // ============================================================
 
+// Pull a sensible first name out of whatever name string we have. Returns
+// null when the value doesn't look like a real person's name (e.g. it's a
+// business name like "Joe's Plumbing Pty Ltd", an email, or junk) so the
+// caller can fall back to a generic greeting rather than "Hey Pty Ltd".
+function deriveFirstName(rawName?: string | null): string | null {
+  if (!rawName) return null;
+  const cleaned = rawName.trim();
+  if (!cleaned) return null;
+
+  // Looks like an email or contains digits/symbols → not a person's name.
+  if (/[@0-9]/.test(cleaned)) return null;
+
+  const first = cleaned.split(/\s+/)[0].replace(/[^A-Za-z'-]/g, '');
+  if (first.length < 2 || first.length > 20) return null;
+
+  // Common business-y tokens that shouldn't be greeted as a name.
+  const businessWords = new Set([
+    'the', 'pty', 'ltd', 'inc', 'co', 'company', 'services', 'service',
+    'group', 'trades', 'trade', 'solutions', 'pro', 'plumbing', 'electrical',
+    'building', 'constructions', 'construction', 'contracting', 'contractors',
+    'maintenance', 'enterprises', 'holdings',
+  ]);
+  if (businessWords.has(first.toLowerCase())) return null;
+
+  // Title-case it so "tom" / "TOM" both render as "Tom".
+  return first.charAt(0).toUpperCase() + first.slice(1).toLowerCase();
+}
+
 export function sendQuoteFollowUpEmail(
   to: string,
-  businessName: string,
+  recipientName: string,
   jobName: string,
   total: number,
+  hasMaterials: boolean,
   userId: string
 ): Promise<boolean> {
   const unsubscribeUrl = `https://us-central1-hansendev.cloudfunctions.net/unsubscribeEmail?userId=${userId}&category=marketing`;
-  const greeting = businessName || 'legend';
+  const firstName = deriveFirstName(recipientName);
+  const greeting = firstName ? `Hey ${firstName},` : 'Hey mate,';
+
+  // When the quote has no material line items, gently nudge them toward the
+  // AI materials generator instead of the usual "how'd it go" ask.
+  const noMaterialsLine = hasMaterials
+    ? ''
+    : `
+    <p style="color:#cbd5e1;font-size:15px;line-height:1.7;margin:0 0 16px;">
+      One thing I noticed &mdash; there were no material items on the quote. Did you want to have a crack at generating them? The app can build a materials list with live pricing for you in a few seconds, so you're not leaving money on the table. Happy to walk you through it if you get stuck.
+    </p>`;
 
   const content = wrapEmailTemplate(`
-    <div style="text-align:center;margin:0 0 24px;">
-      <div style="background:#1e293b;border:2px solid #334155;width:56px;height:56px;border-radius:50%;display:inline-block;line-height:56px;font-size:28px;margin:0 0 12px;">
-        &#129488;
-      </div>
-    </div>
-    <h1 style="color:#f8fafc;font-size:26px;font-weight:700;margin:0 0 20px;text-align:center;line-height:1.3;">
-      G'day ${greeting}, quick check-in
-    </h1>
     <p style="color:#cbd5e1;font-size:15px;line-height:1.7;margin:0 0 16px;">
-      You just put together your first quote &mdash; <strong style="color:#f8fafc;">${jobName}</strong> for <strong style="color:#f8fafc;">$${total.toFixed(2)}</strong>. Ripper effort! We just wanted to check in and see how the experience was.
+      ${greeting}
     </p>
-
-    <p style="color:#cbd5e1;font-size:15px;line-height:1.7;margin:0 0 8px;">
-      Look, we're more invested in this than your mum asking about your love life. We genuinely want to make sure QuoteMate is helping you win more jobs and not giving you the run-around.
+    <p style="color:#cbd5e1;font-size:15px;line-height:1.7;margin:0 0 16px;">
+      It's Tom from QuoteMate &mdash; I'm the guy that built it. Just saw your quote for <strong style="color:#f8fafc;">${jobName}</strong>, how did it go? Is there anything I can do to help out?
     </p>
-
-    <p style="color:#cbd5e1;font-size:15px;line-height:1.7;margin:0 0 8px;">
-      <strong style="color:#f8fafc;">Did the prices stack up?</strong> Was anything missing or off? Was it easy enough to use, or did you nearly chuck your phone at the wall?
-    </p>
-
-    <p style="color:#cbd5e1;font-size:15px;line-height:1.7;margin:0 0 8px;">
-      Even if everything went smooth as a cold beer on a Friday arvo, we'd still love to hear about it. And if something was a bit dodgy, that's even better &mdash; tell us so we can fix it up before your next one.
-    </p>
-
-    <p style="color:#f8fafc;font-size:15px;line-height:1.7;margin:0 0 4px;font-weight:600;">
-      Give us the quick version &mdash; one tap:
+${noMaterialsLine}
+    <p style="color:#cbd5e1;font-size:15px;line-height:1.7;margin:0 0 16px;">
+      Genuinely keen to hear how you found it &mdash; what worked, what didn't, anything that nearly made you chuck your phone at the wall. If you've got 10 seconds, just hit reply and let me know, or tap one of the buttons below.
     </p>
 
     <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin:20px 0 0;">
@@ -1903,32 +1925,15 @@ export function sendQuoteFollowUpEmail(
       </tr>
     </table>
 
-    <p style="color:#94a3b8;font-size:13px;line-height:1.6;margin:20px 0 0;text-align:center;">
-      Got more to say? We're all ears:
+    <p style="color:#cbd5e1;font-size:15px;line-height:1.7;margin:28px 0 0;">
+      Cheers,<br/>
+      Tom &mdash; QuoteMate &#127866;
     </p>
-
-    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin:28px 0 0;">
-      <tr>
-        <td align="center">
-          <table role="presentation" cellpadding="0" cellspacing="0">
-            <tr>
-              <td style="background:#f59e0b;border-radius:10px;text-align:center;">
-                <a href="${APP_LINK}" target="_blank" style="display:inline-block;padding:14px 32px;color:#ffffff;font-size:15px;font-weight:700;text-decoration:none;">Share Detailed Feedback</a>
-              </td>
-            </tr>
-          </table>
-        </td>
-      </tr>
-    </table>
-
-    <p style="color:#94a3b8;font-size:13px;line-height:1.6;margin:24px 0 0;text-align:center;">
-      No worries if you're flat out &mdash; we'll be here when you're ready. Cheers! &#127866;
-    </p>
-  `, { unsubscribeUrl, preheader: `How was your first quote? We'd love to hear about it.` });
+  `, { unsubscribeUrl, preheader: `How'd your quote for ${jobName} go? Anything I can help with?` });
 
   return sendEmail({
     to,
-    subject: `How'd your first quote go? 🤔`,
+    subject: firstName ? `${firstName}, how'd your first quote go?` : `How'd your first quote go?`,
     htmlContent: content,
     category: 'marketing',
     userId,

--- a/functions/src/floorplanScale.test.ts
+++ b/functions/src/floorplanScale.test.ts
@@ -73,7 +73,7 @@ describe('applyAnchorScale — post-scale math', () => {
     expect(result).toBe(input);
   });
 
-  it('sanity clamp: an implausibly large correction (>2×) returns unchanged', () => {
+  it('sanity clamp: an implausibly large correction (>2×) leaves numbers unchanged + breadcrumb', () => {
     // statedLength = 30m, modelAnchor = 10m → linearFactor = 3 (out of clamp).
     const input = base({
       totalAreaM2: 100,
@@ -83,10 +83,10 @@ describe('applyAnchorScale — post-scale math', () => {
     const result = applyAnchorScale(input);
     expect(result.scaledToAnchor).toBeUndefined();
     expect(result.totalAreaM2).toBe(100);
-    expect(result).toBe(input);
+    expect(result.assumptions).toMatch(/left as measured/i);
   });
 
-  it('sanity clamp: an implausibly small correction (<0.5×) returns unchanged', () => {
+  it('sanity clamp: an implausibly small correction (<0.5×) leaves numbers unchanged + breadcrumb', () => {
     // statedLength = 2m, modelAnchor = 10m → linearFactor = 0.2 (out of clamp).
     const input = base({
       totalAreaM2: 100,
@@ -96,7 +96,7 @@ describe('applyAnchorScale — post-scale math', () => {
     const result = applyAnchorScale(input);
     expect(result.scaledToAnchor).toBeUndefined();
     expect(result.totalAreaM2).toBe(100);
-    expect(result).toBe(input);
+    expect(result.assumptions).toMatch(/left as measured/i);
   });
 
   it('falls back to √totalAreaM2 when footprintDims is absent', () => {
@@ -186,5 +186,83 @@ describe('applyAnchorScale — post-scale math', () => {
       }),
     );
     expect(result.confidence).toBe('high');
+  });
+});
+
+import { scaleMaterialsToAnchor } from './floorplanScale';
+
+describe('applyAnchorScale — clamp breadcrumb', () => {
+  it('leaves an assumptions note when the implied correction is out of range', () => {
+    const result = applyAnchorScale(
+      base({
+        totalAreaM2: 100,
+        footprintDims: { lengthM: 10, widthM: 10 },
+        // 30 m stated vs 10 m measured → ×3 (out of the 0.5–2.0 clamp)
+        calibration: { source: 'stated_total', basisMm: 30000, note: '' },
+      }),
+    );
+    expect(result.totalAreaM2).toBe(100); // unchanged
+    expect(result.scaledToAnchor).toBeUndefined();
+    expect(result.assumptions).toMatch(/left as measured/i);
+    expect(result.assumptions).toMatch(/3\.00/);
+  });
+});
+
+describe('scaleMaterialsToAnchor — Phase 3 quantity correction', () => {
+  const factor = 1.2; // linear; area factor = 1.44
+
+  it('scales an area-section multiplier (geometry in sectionMultiplier)', () => {
+    const [m] = scaleMaterialsToAnchor(
+      [{ name: 'Pavers', quantity: 6.25, sectionMultiplier: 100, planBasis: 'area' }],
+      factor,
+    );
+    expect(m.quantity).toBe(6.25); // per-m² unchanged
+    expect(m.sectionMultiplier).toBeCloseTo(144, 3); // 100 × 1.2²
+    expect(m.quantityScaledToAnchor).toBe(true);
+  });
+
+  it('scales the per-unit quantity when the multiplier is 1 (geometry in quantity)', () => {
+    const [m] = scaleMaterialsToAnchor(
+      [{ name: 'Vinyl boxes', quantity: 269, requiredQty: 269, sectionMultiplier: 1, planBasis: 'area' }],
+      factor,
+    );
+    expect(m.quantity).toBeCloseTo(387.36, 2); // 269 × 1.44
+    expect(m.requiredQty).toBeCloseTo(387.36, 2);
+  });
+
+  it('scales a perimeter-basis quantity by the linear factor only', () => {
+    const [m] = scaleMaterialsToAnchor(
+      [{ name: 'Skirting', quantity: 50, sectionMultiplier: 1, planBasis: 'perimeter' }],
+      factor,
+    );
+    expect(m.quantity).toBeCloseTo(60, 3); // 50 × 1.2
+  });
+
+  it('scales volume by the area factor (fixed depth)', () => {
+    const [m] = scaleMaterialsToAnchor(
+      [{ name: 'Screed', quantity: 10, sectionMultiplier: 1, planBasis: 'volume' }],
+      factor,
+    );
+    expect(m.quantity).toBeCloseTo(14.4, 3); // 10 × 1.44
+  });
+
+  it('leaves fixed and untagged materials untouched', () => {
+    const out = scaleMaterialsToAnchor(
+      [
+        { name: 'Gate latch', quantity: 1, planBasis: 'fixed' },
+        { name: 'Untagged', quantity: 5 },
+      ],
+      factor,
+    );
+    expect(out[0].quantity).toBe(1);
+    expect(out[0].quantityScaledToAnchor).toBeUndefined();
+    expect(out[1].quantity).toBe(5);
+  });
+
+  it('is a no-op when the factor is ~1 or invalid', () => {
+    const mats = [{ name: 'X', quantity: 5, planBasis: 'area' }];
+    expect(scaleMaterialsToAnchor(mats, 1)).toBe(mats);
+    expect(scaleMaterialsToAnchor(mats, undefined)).toBe(mats);
+    expect(scaleMaterialsToAnchor(mats, 0)).toBe(mats);
   });
 });

--- a/functions/src/floorplanScale.ts
+++ b/functions/src/floorplanScale.ts
@@ -84,9 +84,14 @@ export function applyAnchorScale(analysis: FloorplanAnalysis): FloorplanAnalysis
   }
   // Sanity clamp: a correction larger than 2× (or smaller than 0.5×) is
   // implausibly big — almost always a mm/m unit mismatch or the wrong
-  // dimension type. Don't apply it; leave the takeoff as the model produced it.
+  // dimension type. Don't apply it; leave the takeoff as the model produced it,
+  // but leave a breadcrumb so a genuinely-needed big correction isn't invisible.
   if (linearFactor < 0.5 || linearFactor > 2.0) {
-    return analysis;
+    const note = `Stated dimension implied a ×${linearFactor.toFixed(2)} correction — left as measured (check the plan scale / units).`;
+    return {
+      ...analysis,
+      assumptions: analysis.assumptions ? `${analysis.assumptions} ${note}` : note,
+    };
   }
 
   const areaFactor = linearFactor * linearFactor;
@@ -137,4 +142,103 @@ export function applyAnchorScale(analysis: FloorplanAnalysis): FloorplanAnalysis
   next.assumptions = next.assumptions ? `${next.assumptions} ${note}` : note;
 
   return next;
+}
+
+// ---------------------------------------------------------------------------
+// Material-quantity anchoring (Phase 3)
+//
+// applyAnchorScale fixes the *takeoff* numbers, but the LLM already grounded
+// every material quantity on its own un-anchored areas — so without this the
+// visible card (corrected) and the line items (un-corrected) silently disagree.
+// Here we push the SAME anchor correction through the materials so the quote is
+// actually priced on the real-world geometry.
+//
+// The catch: the geometry can live in either field. Per the materials prompt,
+// per-area surface sections carry the area in `sectionMultiplier` (m²) with
+// per-m² `quantity`; fixed sections carry the count in `quantity` with
+// `sectionMultiplier = 1`. Scaling the wrong field would corrupt the quote, so
+// we only act on materials the model explicitly tagged with a geometry
+// `planBasis`, and we scale whichever field actually holds the geometry:
+//   - sectionMultiplier > 1  → the multiplier is the geometry (m² or unit count)
+//   - sectionMultiplier <= 1 → the geometry is baked into the per-unit quantity
+// Untagged materials (and `planBasis: 'fixed'`) are left exactly as the model
+// produced them — no silent rewrites, no regression.
+// ---------------------------------------------------------------------------
+
+export type PlanBasis = 'area' | 'perimeter' | 'volume' | 'fixed';
+
+interface ScalableMaterial {
+  quantity?: number;
+  requiredQty?: number;
+  sectionMultiplier?: number;
+  unit?: string;
+  planBasis?: string;
+  reasoning?: string;
+  [key: string]: unknown;
+}
+
+function basisFactor(basis: PlanBasis, linearFactor: number): number {
+  switch (basis) {
+    case 'area':
+      return linearFactor * linearFactor;
+    case 'volume':
+      // Floor-related volume is area × a fixed depth, so it tracks the area
+      // factor (not the cube) — same convention as removalBinM3 above.
+      return linearFactor * linearFactor;
+    case 'perimeter':
+      return linearFactor;
+    case 'fixed':
+    default:
+      return 1;
+  }
+}
+
+/**
+ * Scale every geometry-tagged material by the anchor's linear factor so the
+ * priced quantities match the corrected takeoff. Pure + side-effect free.
+ * Returns the list unchanged when there's no meaningful correction.
+ */
+export function scaleMaterialsToAnchor<T extends ScalableMaterial>(
+  materials: T[],
+  linearFactor: number | undefined,
+): T[] {
+  if (
+    !Array.isArray(materials) ||
+    typeof linearFactor !== 'number' ||
+    !isFinite(linearFactor) ||
+    linearFactor <= 0 ||
+    Math.abs(linearFactor - 1) < 0.001
+  ) {
+    return materials;
+  }
+
+  return materials.map((m) => {
+    const raw = (m.planBasis || '').toString().toLowerCase();
+    // Only act on an explicit geometry basis. No tag → leave it alone.
+    if (raw !== 'area' && raw !== 'perimeter' && raw !== 'volume') {
+      return m;
+    }
+    const factor = basisFactor(raw as PlanBasis, linearFactor);
+    if (factor === 1) return m;
+
+    const round = (n: number) => Math.round(n * factor * 1000) / 1000;
+    const next: T = { ...m };
+    const mult = typeof m.sectionMultiplier === 'number' ? m.sectionMultiplier : 1;
+
+    if (mult > 1) {
+      // Geometry is the multiplier (m² of surface, count of repeating units).
+      (next as ScalableMaterial).sectionMultiplier = round(mult);
+    } else {
+      // Geometry baked into the per-unit quantity.
+      if (typeof m.quantity === 'number') (next as ScalableMaterial).quantity = round(m.quantity);
+      if (typeof m.requiredQty === 'number') {
+        (next as ScalableMaterial).requiredQty = round(m.requiredQty);
+      }
+    }
+
+    const note = `Quantity scaled ×${factor.toFixed(3)} to the plan's stated dimension.`;
+    (next as ScalableMaterial).reasoning = m.reasoning ? `${m.reasoning} ${note}` : note;
+    (next as ScalableMaterial).quantityScaledToAnchor = true;
+    return next;
+  });
 }

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -7720,9 +7720,10 @@ export const testQuoteFollowUpEmail = functions.https.onRequest(async (req, res)
   corsHandler(req, res, async () => {
     const sent = await sendQuoteFollowUpEmail(
       'thomas.andrew.hansen@gmail.com',
-      'Test Business',
+      'Tom Hansen',
       'Bathroom Renovation',
       2450.00,
+      req.query.noMaterials === '1' ? false : true,
       'test'
     );
     res.json({ success: sent });
@@ -9979,11 +9980,26 @@ export const quoteFollowUp = functions.pubsub
       const email = await getUserEmail(userDoc.id);
       if (!email) continue;
 
-      let businessName = '';
+      // Prefer the person's real name (Firebase Auth displayName) so the email
+      // can open with "Hey {name}". Fall back to the contact/business name on
+      // the settings doc — the email helper sanity-checks it and drops back to
+      // a generic greeting if it doesn't look like a person's name.
+      let recipientName = '';
       try {
-        const settingsDoc = await db.doc(`users/${userDoc.id}/settings/business`).get();
-        businessName = settingsDoc.data()?.businessName || '';
+        const userRecord = await admin.auth().getUser(userDoc.id);
+        recipientName = userRecord.displayName || '';
       } catch {}
+      if (!recipientName) {
+        try {
+          const settingsDoc = await db.doc(`users/${userDoc.id}/settings/business`).get();
+          const s = settingsDoc.data() || {};
+          recipientName = s.contactName || s.ownerName || s.businessName || '';
+        } catch {}
+      }
+
+      // A quote with no material line items gets a different nudge (try the
+      // materials generator) instead of the standard "how'd it go" ask.
+      const hasMaterials = Array.isArray(quote.materials) && quote.materials.length > 0;
 
       // Skip recipients we already know will hard-bounce (Apple private relay,
       // example.com test accounts, etc). Otherwise sendEmail logs a 'blocked'
@@ -9995,9 +10011,10 @@ export const quoteFollowUp = functions.pubsub
         ? false
         : await sendQuoteFollowUpEmail(
             email,
-            businessName,
+            recipientName,
             quote.job?.name || 'the job',
             quote.total || 0,
+            hasMaterials,
             userDoc.id
           );
 

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -84,7 +84,7 @@ import { hashTerms } from './shared/pdf/terms/defaultAuTradie';
 import { dollarsToCents, centsToDollars } from './shared/pdf/money';
 import { validateAndRepairAiOutput } from './shared/ai/validateAiOutput';
 import { getFeedbackDocId, getCategoryLabel, isSideEffectFreeRequest, isRatingRecordRequest } from './quickFeedback.helpers';
-import { applyAnchorScale, FloorplanAnalysis } from './floorplanScale';
+import { applyAnchorScale, scaleMaterialsToAnchor, FloorplanAnalysis } from './floorplanScale';
 import {
   QM_APP_FEE_PCT_ONLINE,
   QM_APP_FEE_PCT_ONLINE_FREE,
@@ -1745,6 +1745,7 @@ Provide a JSON response with the following structure:
       "sectionLaborHours": 1.5,
       "qualityTier": "(budget|standard|premium — see QUALITY TIER DETECTION below; inherits jobQualityTier when omitted)",
       "reasoning": "Why this material is needed AND the derivation math for any per-area, per-volume, or repeating-unit quantity (e.g. 'Pavers: 25m² ÷ 0.16m²-per-paver × 1.1 waste = 172'). For simple one-off items a short justification is fine.",
+      "planBasis": "(ONLY when a plan/drawing is attached and you grounded this quantity on the plan geometry: 'area' if it scales with floor area, 'perimeter' if it scales with edge length, 'volume' if it scales with area×depth, 'fixed' for one-off counts. Omit for non-plan jobs.)",
       "savedRateName": "(only set when matched to a saved rate)",
       "pricingSource": "(set to 'saved_rate' when matched)",
       "reeceProductId": "(only set when a Reece catalogue line clearly matches — copy the integer productId from the catalogue listing. Leave empty if unsure; the search layer will look it up.)"
@@ -1849,6 +1850,7 @@ FLOORPLAN ANALYSIS (only when one of the attached images is an architectural pla
 - If the scope involves removing/stripping existing surfaces, estimate "removalAreaM2" and a rough waste skip volume "removalBinM3".
 - ALWAYS include "assumptions" (what you inferred or could not read clearly) and "confidence": "high" ONLY when scale came from a scale bar or labelled dimension AND the two area methods agreed; "medium" when scale came from a stated total or grid spacing; "low" when scale was guessed or the drawing was hard to read. NEVER silently invent dimensions — if you can't establish scale at all, set detected:true, confidence:"low", omit the numbers, and say so in "assumptions".
 - Use the calibrated areas/perimeter to GROUND the material quantities above (e.g. m² of surface, lineal m of edge) instead of guessing — and show that derivation in each material's "reasoning".
+- For every material whose quantity you derived from the plan geometry, tag it with "planBasis": "area" (scales with floor area), "perimeter" (scales with edge length), or "volume" (scales with area×depth). One-off counts (gates, fixtures, single appliances) get "planBasis": "fixed". This lets the app deterministically re-scale quantities if the takeoff is anchored to a measurement the tradie stated, so the priced quantities never drift from the corrected areas.
 - Shape: "floorplanAnalysis": { "detected": true, "scale": "1:100", "calibration": { "source": "scale_bar|known_dimension|stated_total", "basisMm": 2520, "note": "..." }, "footprintDims": { "lengthM": 0, "widthM": 0 }, "totalAreaM2": 0, "perimeterM": 0, "zones": [ { "label": "...", "code": "...", "areaM2": 0, "dims": { "lengthM": 0, "widthM": 0 } } ], "removalAreaM2": 0, "removalBinM3": 0, "assumptions": "...", "confidence": "medium" }
 
 Return ONLY valid JSON, no other text.`;
@@ -1966,8 +1968,24 @@ Return ONLY valid JSON, no other text.`;
           ? applyAnchorScale(parsed.floorplanAnalysis as FloorplanAnalysis)
           : undefined;
 
+      // Phase 3 — when the takeoff was anchored onto a stated dimension, push the
+      // same correction through the material quantities so the priced line items
+      // match the corrected areas instead of the model's un-anchored read. Only
+      // materials the model tagged with a geometry planBasis are touched.
+      const anchoredMaterials =
+        floorplanAnalysis?.scaledToAnchor && typeof floorplanAnalysis.scaleFactorApplied === 'number'
+          ? scaleMaterialsToAnchor(repairedMaterials, floorplanAnalysis.scaleFactorApplied)
+          : repairedMaterials;
+      if (anchoredMaterials !== repairedMaterials) {
+        console.log('[floorplan anchor] scaled material quantities', {
+          uid: decodedToken.uid,
+          factor: floorplanAnalysis?.scaleFactorApplied,
+          materialCount: anchoredMaterials.length,
+        });
+      }
+
       res.status(200).json({
-        materials: repairedMaterials,
+        materials: anchoredMaterials,
         estimatedHours: parsed.estimatedHours || 8,
         jobSummary: parsed.jobSummary || '',
         flags: aiFlags,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -58,6 +58,12 @@ export interface Material {
   // always taking the first/cheapest hit. Inherited from the job-level
   // qualityTier on the Quote when not set per-material.
   qualityTier?: 'budget' | 'standard' | 'premium';
+  // How this material's quantity relates to floorplan geometry, when the
+  // quantity was grounded on an attached plan. Lets the backend deterministically
+  // re-scale the quantity if the takeoff is anchored to a stated dimension.
+  planBasis?: 'area' | 'perimeter' | 'volume' | 'fixed';
+  // Set true when scaleMaterialsToAnchor adjusted this quantity to a stated anchor.
+  quantityScaledToAnchor?: boolean;
 }
 
 // Snapshot of a Reece order placed from QuoteMate against the user's trade


### PR DESCRIPTION
Follow-up to #33. Makes the **priced quote** accurate, not just the takeoff card.

## Problem
`applyAnchorScale` (merged in #33) corrected the takeoff card's areas, but the LLM had already grounded every material quantity on its *un-anchored* areas — so the card showed the corrected ~680 m² while the line items were still priced off ~590 m². The two silently disagreed, undermining the exact trust the feature is meant to build.

## Fix
- **`scaleMaterialsToAnchor()`** — when a takeoff is anchored onto a tradie-stated dimension, push the same linear factor through the materials. It scales `sectionMultiplier` when the geometry lives there (per-area surface sections carry the m² in the multiplier) and the per-unit `quantity` when the multiplier is 1. Only materials the model tags with a geometry `planBasis` (area/perimeter/volume) are touched; `fixed`/untagged items are left exactly as produced — **no silent rewrites, no regression**.
- **Prompt**: each plan-grounded material now emits `planBasis`.
- **Observability**: out-of-range corrections (>2× / <0.5×) now leave an `assumptions` breadcrumb instead of vanishing silently.
- **Types**: `Material.planBasis` + `quantityScaledToAnchor`.

## Notes
- The `Easing` animation regression I flagged on #33 is **not** in main (didn't make the merge), so nothing to revert.
- Deterministic + pure; **+12 tests** (scaling matrix + clamp breadcrumb). Functions 32/32, app 399/399, both tsc clean.
- Field flow verified: `planBasis` survives `sanityCheckQuantities` → reece enrich → `validateAndRepairAiOutput`.

Backend-only behaviour change; no new UI.