### PR TITLE
Step 4a: opt-in Square pay link at send for trial users

### DIFF
--- a/src/components/SendDocumentDialog.tsx
+++ b/src/components/SendDocumentDialog.tsx
@@ -22,7 +22,11 @@ import { formatCurrency } from '../utils/quoteCalculator';
 import { exportDocumentPDF } from '../utils/pdfGenerator';
 import { markDocumentSent } from '../utils/applyStageChange';
 import { useStore } from '../store/useStore';
-import { ensureCanDeliver } from '../utils/quoteDeliveryGuard';
+import {
+  ensureCanDeliver,
+  attachTrialPayLink,
+  shouldOfferTrialPayLink,
+} from '../utils/quoteDeliveryGuard';
 import { ActionSheet, ActionSheetOption } from './ActionSheet';
 import { DocumentEmailPreviewModal } from './DocumentEmailPreviewModal';
 import { SendGateModal } from './SendGateModal';
@@ -60,7 +64,7 @@ export function SendDocumentDialog({
   const quote: Quote = useMemo(() => documentToQuote(doc), [doc]);
   const invoice: Invoice = useMemo(() => documentToInvoice(doc), [doc]);
 
-  const { subscriptionStatus, saveDraft, saveQuote, saveInvoice, createInvoiceFromQuote } = useStore();
+  const { subscriptionStatus, saveDraft, saveQuote, saveInvoice, createInvoiceFromQuote, getEffectivePlan } = useStore();
   const isTrialActive = !!(
     subscriptionStatus?.trialStartedAt && !subscriptionStatus?.trialExpired
   );
@@ -72,6 +76,14 @@ export function SendDocumentDialog({
   const [emailBody, setEmailBody] = useState('');
   const [emailSubject, setEmailSubject] = useState('');
   const [isGeneratingEmail, setIsGeneratingEmail] = useState(false);
+  const [payLinkAttached, setPayLinkAttached] = useState(false);
+  const [isAttachingPayLink, setIsAttachingPayLink] = useState(false);
+
+  // Path B opt-in: offer trial users a Pay Now link at the moment they're
+  // sending real work — connection happens while they're engaged, not at the
+  // post-trial gate. Free users are gated instead; Pro/linked docs need nothing.
+  const offerPayLink =
+    shouldOfferTrialPayLink(getEffectivePlan(), doc) && !payLinkAttached;
 
   const defaultSubject = (() => {
     const businessName = businessSettings?.businessName || 'Your Business';
@@ -92,6 +104,14 @@ export function SendDocumentDialog({
       setEmailPreviewVisible(false);
     }
   }, [visible]);
+
+  // One impression per sheet open — the attach-rate denominator.
+  useEffect(() => {
+    if (actionSheetVisible && offerPayLink) {
+      trackEvent('pay_link_optin_shown', { doc_type: isInvoice ? 'invoice' : 'quote' });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [actionSheetVisible]);
 
   type EmailHandler = {
     draftBody: string | undefined;
@@ -314,8 +334,54 @@ export function SendDocumentDialog({
     onDismiss();
   };
 
+  /**
+   * Trial opt-in: attach a Pay Now link to this doc before it goes out. Not
+   * connected yet → route to SquareIntegrationScreen (square_connected fires
+   * there on OAuth success) and the tradie sends after connecting. Never
+   * blocks — the plain send options above it always work.
+   */
+  const handleAddPayLink = async () => {
+    if (isAttachingPayLink) return;
+    setIsAttachingPayLink(true);
+    try {
+      const result = await attachTrialPayLink(
+        isInvoice ? { kind: 'invoice', doc: invoice } : { kind: 'quote', doc: quote }
+      );
+      trackEvent('pay_link_optin_tapped', {
+        doc_type: isInvoice ? 'invoice' : 'quote',
+        outcome: result.status,
+      });
+      if (result.status === 'connect_required') {
+        setActionSheetVisible(false);
+        onDismiss();
+        navigation.navigate('SquareIntegration' as never);
+      } else if (result.status === 'attached') {
+        setPayLinkAttached(true);
+        Alert.alert(
+          'Pay Now button added',
+          `Your customer can pay this ${isInvoice ? 'invoice' : 'quote'} by card the moment it lands. Send it whichever way suits.`
+        );
+      } else {
+        Alert.alert("Couldn't add the pay link", result.message);
+      }
+    } finally {
+      setIsAttachingPayLink(false);
+    }
+  };
+
   const sendOptions: ActionSheetOption[] = [
-    { icon: 'email-outline', label: 'Email', onPress: handleEmailOption },
+    ...(offerPayLink
+      ? [{
+          icon: 'credit-card-fast-outline',
+          label: isAttachingPayLink
+            ? 'Adding your Pay Now button…'
+            : isInvoice
+              ? 'Get paid on this invoice'
+              : 'Get paid on this quote',
+          onPress: handleAddPayLink,
+        }]
+      : []),
+    { icon: 'email-outline', label: 'Email', onPress: handleEmailOption, divider: offerPayLink },
     { icon: 'message-text', label: 'SMS', onPress: handleSendSMS },
     { icon: 'share-variant', label: 'Share', onPress: handleShareFromDialog },
     { icon: 'file-pdf-box', label: 'Export PDF', onPress: handleExportFromDialog },

--- a/src/services/analyticsService.ts
+++ b/src/services/analyticsService.ts
@@ -59,7 +59,12 @@ export type AnalyticsEvent =
   // Firestore state stays the source of truth.
   | 'trial_started'
   // Path B: Square OAuth completed (client-observed poll success).
-  | 'square_connected';
+  | 'square_connected'
+  // Path B opt-in at send (trial users): the "get paid on this quote" row.
+  // shown = impression per sheet open; tapped carries `outcome`
+  // (connect_required / attached / failed) so attach-rate is measurable.
+  | 'pay_link_optin_shown'
+  | 'pay_link_optin_tapped';
 
 interface BaseProps {
   // Free-form per-event payload. Keep it flat (Firestore indexes flat fields

--- a/src/utils/quoteDeliveryGuard.test.ts
+++ b/src/utils/quoteDeliveryGuard.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const square = vi.hoisted(() => ({
+  checkSquareConnection: vi.fn(),
+  mintInvoicePaymentLink: vi.fn(),
+  mintQuoteDepositPaymentLink: vi.fn(),
+  mintQuoteFullPaymentLink: vi.fn(),
+}));
+vi.mock('../services/squareService', () => square);
+
+const planState = vi.hoisted(() => ({ plan: 'trial' as 'trial' | 'free' | 'pro' }));
+vi.mock('../store/useStore', () => ({
+  useStore: { getState: () => ({ getEffectivePlan: () => planState.plan }) },
+}));
+
+import {
+  attachTrialPayLink,
+  ensureCanDeliver,
+  shouldOfferTrialPayLink,
+} from './quoteDeliveryGuard';
+
+const quote = (over: Record<string, unknown> = {}) =>
+  ({ kind: 'quote', doc: { id: 'q1', ...over } }) as any;
+const invoice = (over: Record<string, unknown> = {}) =>
+  ({ kind: 'invoice', doc: { id: 'i1', ...over } }) as any;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  planState.plan = 'trial';
+  square.checkSquareConnection.mockResolvedValue({ connected: true });
+  square.mintQuoteFullPaymentLink.mockResolvedValue({ paymentLinkUrl: 'https://sq/full' });
+  square.mintQuoteDepositPaymentLink.mockResolvedValue({ paymentLinkUrl: 'https://sq/deposit' });
+  square.mintInvoicePaymentLink.mockResolvedValue({ paymentLinkUrl: 'https://sq/invoice' });
+});
+
+describe('shouldOfferTrialPayLink', () => {
+  it('offers only to trial users whose doc has no link yet', () => {
+    expect(shouldOfferTrialPayLink('trial', {})).toBe(true);
+    expect(shouldOfferTrialPayLink('trial', { squarePaymentLinkUrl: 'https://sq/x' })).toBe(false);
+    // Free users hit the mandatory gate; Pro users aren't pitched here.
+    expect(shouldOfferTrialPayLink('free', {})).toBe(false);
+    expect(shouldOfferTrialPayLink('pro', {})).toBe(false);
+  });
+});
+
+describe('attachTrialPayLink', () => {
+  it('routes to connect when Square is not connected (and never mints)', async () => {
+    square.checkSquareConnection.mockResolvedValue({ connected: false });
+    expect(await attachTrialPayLink(quote())).toEqual({ status: 'connect_required' });
+    expect(square.mintQuoteFullPaymentLink).not.toHaveBeenCalled();
+  });
+
+  it('treats a connection-check failure as connect_required, not an error', async () => {
+    square.checkSquareConnection.mockRejectedValue(new Error('offline'));
+    expect(await attachTrialPayLink(quote())).toEqual({ status: 'connect_required' });
+  });
+
+  it('mints a full-total link for a plain quote', async () => {
+    expect(await attachTrialPayLink(quote())).toEqual({
+      status: 'attached',
+      squarePaymentLinkUrl: 'https://sq/full',
+    });
+    expect(square.mintQuoteFullPaymentLink).toHaveBeenCalledWith('q1');
+  });
+
+  it('mints a deposit link when the quote requires a deposit', async () => {
+    const result = await attachTrialPayLink(quote({ requireDeposit: true, depositPercentage: 20 }));
+    expect(result).toEqual({ status: 'attached', squarePaymentLinkUrl: 'https://sq/deposit' });
+    expect(square.mintQuoteDepositPaymentLink).toHaveBeenCalledWith('q1');
+    expect(square.mintQuoteFullPaymentLink).not.toHaveBeenCalled();
+  });
+
+  it('requireDeposit without a percentage falls back to the full link', async () => {
+    await attachTrialPayLink(quote({ requireDeposit: true, depositPercentage: 0 }));
+    expect(square.mintQuoteFullPaymentLink).toHaveBeenCalledWith('q1');
+  });
+
+  it('mints an invoice link for invoices', async () => {
+    const result = await attachTrialPayLink(invoice());
+    expect(result).toEqual({ status: 'attached', squarePaymentLinkUrl: 'https://sq/invoice' });
+    expect(square.mintInvoicePaymentLink).toHaveBeenCalledWith('i1');
+  });
+
+  it('reuses an existing link without re-minting', async () => {
+    const result = await attachTrialPayLink(quote({ squarePaymentLinkUrl: 'https://sq/existing' }));
+    expect(result).toEqual({ status: 'attached', squarePaymentLinkUrl: 'https://sq/existing' });
+    expect(square.mintQuoteFullPaymentLink).not.toHaveBeenCalled();
+  });
+
+  it('surfaces mint failures as failed with the message', async () => {
+    square.mintQuoteFullPaymentLink.mockRejectedValue(new Error('Square 500'));
+    expect(await attachTrialPayLink(quote())).toEqual({ status: 'failed', message: 'Square 500' });
+  });
+});
+
+describe('ensureCanDeliver (regression — the mandatory free-tier gate)', () => {
+  it('trial and pro pass without a connection round-trip', async () => {
+    for (const plan of ['trial', 'pro'] as const) {
+      planState.plan = plan;
+      expect((await ensureCanDeliver(quote())).ok).toBe(true);
+    }
+    expect(square.checkSquareConnection).not.toHaveBeenCalled();
+  });
+
+  it('free users still require a connection', async () => {
+    planState.plan = 'free';
+    square.checkSquareConnection.mockResolvedValue({ connected: false });
+    const gate = await ensureCanDeliver(quote());
+    expect(gate).toMatchObject({ ok: false, reason: 'connect_square' });
+  });
+
+  it('free + connected mints through the shared routing (deposit rule intact)', async () => {
+    planState.plan = 'free';
+    const gate = await ensureCanDeliver(quote({ requireDeposit: true, depositPercentage: 50 }));
+    expect(gate).toEqual({ ok: true, squarePaymentLinkUrl: 'https://sq/deposit' });
+    expect(square.mintQuoteDepositPaymentLink).toHaveBeenCalledWith('q1');
+  });
+});

--- a/src/utils/quoteDeliveryGuard.ts
+++ b/src/utils/quoteDeliveryGuard.ts
@@ -72,13 +72,7 @@ export async function ensureCanDeliver(target: DeliveryDoc): Promise<DeliveryGat
   }
 
   try {
-    const result =
-      target.kind === 'invoice'
-        ? await squareService.mintInvoicePaymentLink(target.doc.id)
-        : (target.doc.requireDeposit && (target.doc.depositPercentage ?? 0) > 0)
-          ? await squareService.mintQuoteDepositPaymentLink(target.doc.id)
-          : await squareService.mintQuoteFullPaymentLink(target.doc.id);
-    return { ok: true, squarePaymentLinkUrl: result.paymentLinkUrl };
+    return { ok: true, squarePaymentLinkUrl: await mintPaymentLinkForDoc(target) };
   } catch (error: any) {
     return {
       ok: false,
@@ -86,6 +80,72 @@ export async function ensureCanDeliver(target: DeliveryDoc): Promise<DeliveryGat
       message:
         error?.message ||
         'Could not create a Square payment link. Please try again.',
+    };
+  }
+}
+
+/**
+ * Mint the right payment link for a doc: invoice balance, quote deposit (when
+ * a deposit is required), or full quote total. The server writes the link
+ * onto the document, so every customer-facing surface (PDF, hosted page,
+ * invoice email) picks it up from there. Shared by the free-tier gate above
+ * and the trial opt-in below — one routing rule, not two.
+ */
+async function mintPaymentLinkForDoc(target: DeliveryDoc): Promise<string> {
+  const result =
+    target.kind === 'invoice'
+      ? await squareService.mintInvoicePaymentLink(target.doc.id)
+      : (target.doc.requireDeposit && (target.doc.depositPercentage ?? 0) > 0)
+        ? await squareService.mintQuoteDepositPaymentLink(target.doc.id)
+        : await squareService.mintQuoteFullPaymentLink(target.doc.id);
+  return result.paymentLinkUrl;
+}
+
+/**
+ * Whether the send sheet should offer the opt-in "get paid on this quote"
+ * row. Trial users only: free users hit the mandatory gate instead, Pro users
+ * already have payments wherever they've set them up, and a doc that already
+ * carries a link needs nothing. Pure — unit tested.
+ */
+export function shouldOfferTrialPayLink(
+  plan: 'trial' | 'free' | 'pro',
+  doc: Pick<DeliverableDoc, 'squarePaymentLinkUrl'>,
+): boolean {
+  return plan === 'trial' && !doc.squarePaymentLinkUrl;
+}
+
+export type TrialPayLinkResult =
+  | { status: 'connect_required' }
+  | { status: 'attached'; squarePaymentLinkUrl: string }
+  | { status: 'failed'; message: string };
+
+/**
+ * The trial opt-in: attach a Pay Now link to this doc if Square is connected,
+ * or report that the user needs to connect first (caller routes them to
+ * SquareIntegrationScreen). Never blocks a send — the caller proceeds with or
+ * without a link; this exists so tradies wire up payments while they're most
+ * engaged instead of at the post-trial gate.
+ */
+export async function attachTrialPayLink(target: DeliveryDoc): Promise<TrialPayLinkResult> {
+  let connected = false;
+  try {
+    connected = (await checkSquareConnection()).connected;
+  } catch {
+    // Verification failure routes to the integration screen, which shows the
+    // real connection state and offers reconnect.
+  }
+  if (!connected) return { status: 'connect_required' };
+
+  if (target.doc.squarePaymentLinkUrl) {
+    return { status: 'attached', squarePaymentLinkUrl: target.doc.squarePaymentLinkUrl };
+  }
+
+  try {
+    return { status: 'attached', squarePaymentLinkUrl: await mintPaymentLinkForDoc(target) };
+  } catch (error: any) {
+    return {
+      status: 'failed',
+      message: error?.message || 'Could not create a Square payment link. Please try again.',
     };
   }
 }


### PR DESCRIPTION
Path B activation — the biggest untapped lever for trial→monetised 20% (live baseline from the new event funnel: 7 connected, 1 collecting, out of 225 users).

## What it does
- Trial users see a **"Get paid on this quote / invoice"** row at the top of the send sheet (only when the doc has no pay link yet). It never blocks: the plain Email/SMS/Share/PDF options always work.
- Tapping it: **Square connected** → mints the right payment link (invoice balance / quote deposit / full total — same routing as the free-tier gate, now shared via `mintPaymentLinkForDoc`) and confirms; the link surfaces on the PDF, hosted page and invoice email like today. **Not connected** → routes to `SquareIntegrationScreen`, where `square_connected` already fires on OAuth success.
- Free users are untouched (mandatory gate unchanged — regression-tested); Pro users are never pitched.

## Measurement
`pay_link_optin_shown` (impression per sheet open) + `pay_link_optin_tapped` with `outcome: connect_required | attached | failed` — attach rate readable straight from the events collection / future funnel stages.

## Tests
`quoteDeliveryGuard.test.ts` (12 new): offer rule (trial-only, no-link-only), connect routing incl. check-failure, deposit/full/invoice mint routing, existing-link reuse, mint failure surfacing, and free-tier gate regressions. App suite 848 passed, tsc clean.

No deploy steps — app-only change, ships with the next app build/OTA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)