### PR TITLE
Step 2: Founding Member scarcity — cap-only (real 'X of 100 spots left')

### DIFF
--- a/functions/src/adminCrm.ts
+++ b/functions/src/adminCrm.ts
@@ -20,7 +20,7 @@ import type { DocumentStage, DocumentType } from './shared/document/types';
 // so the admin CRM callables and the funnel analytics helpers share one source
 // of truth (and the latter stays unit-testable without firebase). See
 // subscription.helpers.ts.
-import { ts, deriveSubFields } from './subscription.helpers';
+import { ts, deriveSubFields, isBilledSub } from './subscription.helpers';
 import { listAllAuthUsers as drainAuthUsers } from './authUsers.helpers';
 import {
   computeFunnelStats,
@@ -36,6 +36,7 @@ import {
   type EventFunnelPayload,
   type UserEventFlags,
 } from './eventFunnel.helpers';
+import { foundingOfferStatus } from './foundingOffer';
 
 const db = () => admin.firestore();
 
@@ -1865,7 +1866,9 @@ const EVENT_WINDOW_DAYS = 30;
 // The full, uncached computation. Same join style as computeFunnelPayload,
 // plus the two Path-B signals (squareConnection doc, real square payments) and
 // the event-derived paywall/checkout flags.
-export async function computeEventFunnelPayload(): Promise<EventFunnelPayload> {
+export async function computeEventFunnelPayload(): Promise<
+  EventFunnelPayload & { foundingTaken: number }
+> {
   const firestore = db();
   const now = Date.now();
   const cutoff = admin.firestore.Timestamp.fromMillis(now - EVENT_WINDOW_DAYS * 24 * 60 * 60 * 1000);
@@ -1913,7 +1916,14 @@ export async function computeEventFunnelPayload(): Promise<EventFunnelPayload> {
     };
   });
 
-  return rollupEventFunnel(inputs, now, EVENT_WINDOW_DAYS);
+  // Founding-member count over the FULL subs map, not just users with auth
+  // records — a billed sub whose auth account was deleted still holds a spot.
+  let foundingTaken = 0;
+  for (const sub of subs.values()) {
+    if (isBilledSub(sub)) foundingTaken++;
+  }
+
+  return { ...rollupEventFunnel(inputs, now, EVENT_WINDOW_DAYS), foundingTaken };
 }
 
 // Every 6h (offset from the 15-min lazy funnel cache — this one is heavier
@@ -1923,12 +1933,20 @@ export const aggregateEventFunnel = functions
   .pubsub.schedule('every 6 hours')
   .timeZone('Australia/Sydney')
   .onRun(async () => {
-    const payload = await computeEventFunnelPayload();
+    const { foundingTaken, ...payload } = await computeEventFunnelPayload();
     await db().collection('adminStats').doc('eventFunnel').set({ payload, generatedAt: Date.now() });
+
+    // Founding-member cap status → config/ (public read, server-only write)
+    // so the paywall renders a REAL "X of 100 spots left". Same cadence as
+    // the funnel; the count only moves when someone subscribes.
+    const founding = foundingOfferStatus(foundingTaken);
+    await db().collection('config').doc('foundingOffer').set({ ...founding, generatedAt: Date.now() });
+
     console.log(
       `aggregateEventFunnel: users=${payload.shared.signups}, monetized=${payload.monetized.count} ` +
         `(pro=${payload.monetized.viaPro}, square=${payload.monetized.viaSquare}), ` +
-        `trialToMonetized=${(payload.conversion.trialToMonetized * 100).toFixed(1)}%`
+        `trialToMonetized=${(payload.conversion.trialToMonetized * 100).toFixed(1)}%, ` +
+        `foundingSpotsLeft=${founding.spotsLeft}/${founding.cap}`
     );
   });
 

--- a/functions/src/foundingOffer.test.ts
+++ b/functions/src/foundingOffer.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { FOUNDING_CAP, NEXT_PRICE_AUD, foundingOfferStatus } from './foundingOffer';
+
+describe('founding offer constants', () => {
+  it('cap is 100 founding members', () => {
+    expect(FOUNDING_CAP).toBe(100);
+  });
+
+  it('NEXT_PRICE mirrors the app anchor (src/config/pricingConfig.ts REGULAR_PRICE_AUD)', () => {
+    // The struck-through anchor IS the committed post-cap price — if either
+    // side moves, the promise breaks. Update both together.
+    expect(NEXT_PRICE_AUD).toEqual({ monthly: 99, yearly: 658 });
+  });
+});
+
+describe('foundingOfferStatus', () => {
+  it('reports real spots left while under the cap', () => {
+    expect(foundingOfferStatus(0)).toEqual({ taken: 0, cap: 100, spotsLeft: 100, capActive: true });
+    expect(foundingOfferStatus(3)).toEqual({ taken: 3, cap: 100, spotsLeft: 97, capActive: true });
+    expect(foundingOfferStatus(99)).toEqual({ taken: 99, cap: 100, spotsLeft: 1, capActive: true });
+  });
+
+  it('deactivates exactly at the cap — all founding framing must disappear', () => {
+    expect(foundingOfferStatus(100)).toEqual({ taken: 100, cap: 100, spotsLeft: 0, capActive: false });
+  });
+
+  it('never goes negative past the cap', () => {
+    expect(foundingOfferStatus(150)).toEqual({ taken: 150, cap: 100, spotsLeft: 0, capActive: false });
+  });
+
+  it('treats garbage input as zero taken rather than faking scarcity', () => {
+    expect(foundingOfferStatus(-5).taken).toBe(0);
+    expect(foundingOfferStatus(NaN as any).taken).toBe(0);
+    expect(foundingOfferStatus(-5).capActive).toBe(true);
+  });
+});

--- a/functions/src/foundingOffer.ts
+++ b/functions/src/foundingOffer.ts
@@ -1,0 +1,38 @@
+/**
+ * Founding Member offer — CAP-ONLY model (decided 2026-07-16).
+ *
+ * The first FOUNDING_CAP billed subscribers lock the current $49/mo ($328/yr)
+ * price for life; once the cap fills, the store/Stripe base prices genuinely
+ * rise to NEXT_PRICE_AUD (today's struck-through anchor, making it honest)
+ * and existing members are grandfathered.
+ *
+ * Deliberately absent: the per-user 72h post-trial claim window from the
+ * original spec. Apple/Google can't charge different users different prices
+ * for one product without a configured intro offer, and none is configured —
+ * so no per-user deadline appears anywhere in copy until that store ops work
+ * is done. The only scarcity is the cap, and it is real: `taken` is computed
+ * from actual billed subscriptions (isBilledSub — bare isPro flags and
+ * admin_grant comps never count), published by the aggregateEventFunnel cron
+ * to config/foundingOffer (public read, server-only write).
+ */
+export const FOUNDING_CAP = 100;
+
+// Price after the cap fills. MUST equal the app's REGULAR_PRICE_AUD anchor
+// (src/config/pricingConfig.ts) — that anchor is the promise being made.
+export const NEXT_PRICE_AUD = { monthly: 99, yearly: 658 };
+
+export interface FoundingOfferStatus {
+  taken: number;
+  cap: number;
+  /** Never negative, even if billed subs somehow exceed the cap. */
+  spotsLeft: number;
+  /** False once the cap is filled — all founding framing must disappear. */
+  capActive: boolean;
+}
+
+/** Pure status derivation from the real billed-subscriber count. */
+export function foundingOfferStatus(taken: number, cap: number = FOUNDING_CAP): FoundingOfferStatus {
+  const safeTaken = Math.max(0, Math.floor(taken) || 0);
+  const spotsLeft = Math.max(0, cap - safeTaken);
+  return { taken: safeTaken, cap, spotsLeft, capActive: spotsLeft > 0 };
+}

--- a/src/config/pricingConfig.test.ts
+++ b/src/config/pricingConfig.test.ts
@@ -4,6 +4,11 @@ import {
   REGULAR_PRICE_AUD,
   regularPriceLabel,
   discountPercent,
+  yearlyVsMonthlySavingsPercent,
+  monthlyFeeSaving,
+  feeSavingLabel,
+  squareCollectedLast30d,
+  FEE_SAVING_CLAIM_THRESHOLD_AUD,
 } from './pricingConfig';
 
 describe('pricingConfig', () => {
@@ -34,5 +39,64 @@ describe('pricingConfig', () => {
       expect(pct).toBeGreaterThan(0);
       expect(pct).toBeLessThan(100);
     });
+  });
+});
+
+describe('yearlyVsMonthlySavingsPercent', () => {
+  it('derives 44 from the charged prices (replaces the hardcoded badge)', () => {
+    // $328/yr vs $588 (12 × $49) → 44.2% → 44.
+    expect(yearlyVsMonthlySavingsPercent()).toBe(44);
+  });
+});
+
+describe('fee-bleed (Pro upsell from real Square volume only)', () => {
+  it('computes the monthly saving from the fee delta (170 → 100 bps)', () => {
+    expect(monthlyFeeSaving(7400)).toBeCloseTo(51.8);
+    expect(monthlyFeeSaving(1000)).toBeCloseTo(7);
+  });
+
+  it('zero, negative or garbage volume saves nothing', () => {
+    expect(monthlyFeeSaving(0)).toBe(0);
+    expect(monthlyFeeSaving(-500)).toBe(0);
+    expect(monthlyFeeSaving(NaN)).toBe(0);
+  });
+
+  it('labels a real saving with a rounded dollar figure', () => {
+    expect(feeSavingLabel(7400)).toBe(
+      "On your recent volume, Pro's lower fee would keep you about $52/mo"
+    );
+  });
+
+  it('makes NO claim when the saving is thin — never invents value', () => {
+    // $500 collected → $3.50/mo, under the $5 threshold.
+    expect(monthlyFeeSaving(500)).toBeLessThan(FEE_SAVING_CLAIM_THRESHOLD_AUD);
+    expect(feeSavingLabel(500)).toBeNull();
+    expect(feeSavingLabel(0)).toBeNull();
+  });
+});
+
+describe('squareCollectedLast30d', () => {
+  const NOW = Date.parse('2026-07-16T00:00:00.000Z');
+  const DAY = 24 * 60 * 60 * 1000;
+  const pay = (amount: number, daysAgo: number, method?: string) => ({
+    amount,
+    paidAt: NOW - daysAgo * DAY,
+    method,
+  });
+
+  it('sums only square payments inside the 30-day window', () => {
+    const docs = [
+      { payments: [pay(1000, 5, 'square'), pay(500, 10, 'square')] },
+      { payments: [pay(2000, 45, 'square')] }, // too old
+      { payments: [pay(300, 2, 'cash')] }, // manual — no platform fee saved
+      { payments: [{ amount: 400, method: 'square' }] }, // no paidAt — untrusted
+      {}, // no payments at all
+    ];
+    expect(squareCollectedLast30d(docs, NOW)).toBe(1500);
+  });
+
+  it('ignores future-dated payments and empty inputs', () => {
+    expect(squareCollectedLast30d([{ payments: [pay(1000, -2, 'square')] }], NOW)).toBe(0);
+    expect(squareCollectedLast30d([], NOW)).toBe(0);
   });
 });

--- a/src/config/pricingConfig.ts
+++ b/src/config/pricingConfig.ts
@@ -32,3 +32,60 @@ export const regularPriceLabel = (period: BillingPeriod): string =>
 /** Whole-number percent off the regular price, e.g. 51 for $99 → $49. */
 export const discountPercent = (period: BillingPeriod): number =>
   Math.round((1 - ACTUAL_PRICE_AUD[period] / REGULAR_PRICE_AUD[period]) * 100);
+
+/**
+ * Whole-number percent the yearly plan saves vs paying monthly for a year —
+ * derived from the charged prices so the paywall badge can never drift from
+ * reality the way a hardcoded "Save 44%" could. $328 vs $588 → 44.
+ */
+export const yearlyVsMonthlySavingsPercent = (): number =>
+  Math.round((1 - ACTUAL_PRICE_AUD.yearly / (ACTUAL_PRICE_AUD.monthly * 12)) * 100);
+
+// Platform fee on Square payments, in basis points. Free-plan sends carry the
+// higher fee; Pro drops it — the delta is Pro's concrete value for tradies
+// already collecting. Mirrors the server's fee configuration.
+export const FREE_PLAN_FEE_BPS = 170;
+export const PRO_PLAN_FEE_BPS = 100;
+
+/**
+ * Dollars/month Pro's lower fee would keep, given real collected volume over
+ * the last 30 days. Zero for zero/invalid volume — callers show nothing.
+ */
+export const monthlyFeeSaving = (collectedLast30d: number): number => {
+  if (!Number.isFinite(collectedLast30d) || collectedLast30d <= 0) return 0;
+  return (collectedLast30d * (FREE_PLAN_FEE_BPS - PRO_PLAN_FEE_BPS)) / 10000;
+};
+
+/** Below this monthly saving the fee-bleed claim is too thin to make. */
+export const FEE_SAVING_CLAIM_THRESHOLD_AUD = 5;
+
+/**
+ * The paywall's fee-bleed line, or null when the data is too thin to claim
+ * anything. Real volume only — never rendered from invented numbers.
+ */
+export const feeSavingLabel = (collectedLast30d: number): string | null => {
+  const saving = monthlyFeeSaving(collectedLast30d);
+  if (saving < FEE_SAVING_CLAIM_THRESHOLD_AUD) return null;
+  return `On your recent volume, Pro's lower fee would keep you about $${Math.round(saving)}/mo`;
+};
+
+/**
+ * Sum of REAL Square payments (webhook-written, method 'square') collected in
+ * the last 30 days across the user's documents. Manual cash/bank records
+ * don't count — they carry no platform fee, so they save nothing on Pro.
+ */
+export const squareCollectedLast30d = (
+  docs: Array<{ payments?: Array<{ amount?: number; paidAt?: number; method?: string }> }>,
+  nowMs: number,
+): number => {
+  const cutoff = nowMs - 30 * 24 * 60 * 60 * 1000;
+  let total = 0;
+  for (const doc of docs) {
+    for (const p of doc.payments ?? []) {
+      if (p?.method !== 'square') continue;
+      if (typeof p.paidAt !== 'number' || p.paidAt < cutoff || p.paidAt > nowMs) continue;
+      total += Number(p.amount) || 0;
+    }
+  }
+  return total;
+};

--- a/src/screens/PaywallScreen.tsx
+++ b/src/screens/PaywallScreen.tsx
@@ -20,12 +20,19 @@ import { colors } from '../theme';
 import { billingService, SUBSCRIPTION_SKUS } from '../services/billingService';
 import { useSubscriptionStore } from '../store/subscriptionStore';
 import { unifiedBillingService } from '../services/unifiedBillingService';
-import { auth } from '../config/firebase';
+import { auth, db } from '../config/firebase';
+import { doc as firestoreDoc, getDoc } from 'firebase/firestore';
 import { WebContainer } from '../components/WebContainer';
 import { StripeCheckoutModal } from '../components/StripeCheckoutModal';
 import { CancellationReasonModal } from '../components/CancellationReasonModal';
 import { TRIAL_DAYS, TRIAL_MS } from '../utils/trialConfig';
-import { regularPriceLabel, discountPercent } from '../config/pricingConfig';
+import {
+  regularPriceLabel,
+  discountPercent,
+  yearlyVsMonthlySavingsPercent,
+  feeSavingLabel,
+  squareCollectedLast30d,
+} from '../config/pricingConfig';
 import { trackEvent } from '../services/analyticsService';
 import { resolvePurchaseAnalytics } from '../services/paywallAnalytics.helpers';
 
@@ -58,7 +65,7 @@ export function PaywallScreen() {
   const insets = useSafeAreaInsets();
   const proNudge = useMemo(() => PRO_NUDGES[Math.floor(Math.random() * PRO_NUDGES.length)], []);
   const maybeLaterQuip = useMemo(() => MAYBE_LATER_QUIPS[Math.floor(Math.random() * MAYBE_LATER_QUIPS.length)], []);
-  const { subscriptionStatus, loadSubscription } = useStore();
+  const { subscriptionStatus, loadSubscription, documents } = useStore();
   const { quoteCount, setPremium } = useSubscriptionStore();
   const [isUpgrading, setIsUpgrading] = useState(false);
   const [products, setProducts] = useState<any[]>([]);
@@ -71,6 +78,17 @@ export function PaywallScreen() {
   const [productsLoadError, setProductsLoadError] = useState(false);
   const [isRestoring, setIsRestoring] = useState(false);
   const [selectedPlan, setSelectedPlan] = useState<'monthly' | 'yearly'>('yearly');
+  // Founding-member cap status from config/foundingOffer (public read; the
+  // aggregateEventFunnel cron computes it from REAL billed subs). null =
+  // unknown/unavailable → all founding framing is suppressed, never faked.
+  const [founding, setFounding] = useState<{ taken: number; cap: number; spotsLeft: number; capActive: boolean } | null>(null);
+
+  // Fee-bleed: only from the user's real collected Square volume; null when
+  // too thin to claim anything.
+  const feeBleedLine = useMemo(
+    () => feeSavingLabel(squareCollectedLast30d(documents, Date.now())),
+    [documents]
+  );
 
   // Trial status
   const trialExpired = subscriptionStatus?.trialExpired || false;
@@ -93,6 +111,27 @@ export function PaywallScreen() {
     });
     // Mount-only: one view event per paywall visit.
     // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    getDoc(firestoreDoc(db, 'config', 'foundingOffer'))
+      .then((snap) => {
+        const data = snap.exists() ? (snap.data() as any) : null;
+        if (cancelled || !data || typeof data.spotsLeft !== 'number') return;
+        setFounding({
+          taken: data.taken,
+          cap: data.cap,
+          spotsLeft: data.spotsLeft,
+          capActive: !!data.capActive,
+        });
+      })
+      .catch(() => {
+        // Unavailable → founding framing stays hidden. Never invent numbers.
+      });
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   useEffect(() => {
@@ -707,7 +746,7 @@ export function PaywallScreen() {
             onPress={() => setSelectedPlan('yearly')}
           >
             <View style={styles.saveBadge}>
-              <Text style={styles.saveBadgeText}>Save 44%</Text>
+              <Text style={styles.saveBadgeText}>Save {yearlyVsMonthlySavingsPercent()}%</Text>
             </View>
             <Text style={[styles.planOptionLabel, selectedPlan === 'yearly' && styles.planOptionLabelSelected]}>Yearly</Text>
             <Text style={styles.planOptionRegularPrice}>{regularPriceLabel('yearly')}</Text>
@@ -717,10 +756,28 @@ export function PaywallScreen() {
         </View>
       )}
 
-      {!isPro && (
+      {!isPro && founding?.capActive ? (
+        <>
+          {/* Founding-member framing — every number here is real: spotsLeft is
+              computed server-side from billed subs, and the price rise is the
+              committed store/Stripe change once the cap fills. Cap-only model:
+              no personal countdowns anywhere (nothing enforces one yet). */}
+          <Text style={styles.launchOffer}>
+            Founding member price · {founding.spotsLeft} of {founding.cap} spots left
+          </Text>
+          <Text style={styles.foundingNote}>
+            {getProductPrice(SUBSCRIPTION_SKUS.MONTHLY)}/mo locked for life — the price goes to{' '}
+            {regularPriceLabel('monthly')}/mo for new members once the {founding.cap} spots fill.
+          </Text>
+        </>
+      ) : !isPro ? (
         <Text style={styles.launchOffer}>
           Launch offer · {discountPercent(selectedPlan)}% off the regular price
         </Text>
+      ) : null}
+
+      {!isPro && feeBleedLine && (
+        <Text style={styles.foundingNote}>{feeBleedLine} — it pays for itself.</Text>
       )}
 
       {/* Upgrade Section for Free Users */}
@@ -964,6 +1021,15 @@ const styles = StyleSheet.create({
     fontSize: 13,
     marginHorizontal: 20,
     marginTop: -6,
+    marginBottom: 14,
+  },
+  foundingNote: {
+    textAlign: 'center',
+    color: colors.textMuted,
+    fontSize: 12,
+    lineHeight: 17,
+    marginHorizontal: 24,
+    marginTop: -8,
     marginBottom: 14,
   },
   saveBadge: {


### PR DESCRIPTION
Honest scarcity for Path A, built cap-only per the decision: **no per-user 72h window appears anywhere** — with no store intro offer configured it can't be honestly enforced, so the only scarcity is the 100-member cap, and every number is real.

## What it does
- **`foundingOffer.ts`**: `FOUNDING_CAP = 100`, `NEXT_PRICE_AUD = $99/$658` (guard-tested to mirror the app's `REGULAR_PRICE_AUD` anchor — the struck-through price IS the committed post-cap price, which finally makes it honest), pure `foundingOfferStatus` with clamped spots and a hard `capActive` boundary.
- **Cron publishes the count**: `aggregateEventFunnel` now also counts billed subs over the *full* subscriptions map (so a billed sub with a deleted auth account still holds a spot) and writes `config/foundingOffer` — the `config/` collection is public-read / server-only-write, so the app reads it directly.
- **Paywall**: while `capActive`, the "Launch offer" line becomes *"Founding member price · X of 100 spots left"* plus *"$49/mo locked for life — the price goes to $99/mo for new members once the 100 spots fill."* Suppressed entirely (falls back / disappears) when the cap fills or the doc is unavailable — never faked.
- **Derived "Save 44%"**: the yearly badge now computes `yearlyVsMonthlySavingsPercent()` from charged prices.
- **Fee-bleed line** (ties Path B → A): *"On your recent volume, Pro's lower fee would keep you about $X/mo"* — computed only from real webhook-written Square payments in the last 30 days (manual cash never counts), suppressed under $5/mo.

## The commitment this encodes
When the 100th billed subscriber lands (`capActive` flips false), the App Store / Play / Stripe base prices must genuinely rise to $99/$658 with existing members grandfathered — that's a manual ops step at cap-fill time. Until then nothing is dishonest: the cap count is live and the price-rise promise is forward-looking.

## Not included (deliberate)
- 72h post-trial window + `foundingCountdownLabel` — needs the store intro-offer prerequisite first.
- Loosening the TrialBanner ≤3-day dashboard gate — reverses a past deliberate decision (`project_trial_banner_dashboard_gate`); flagged for explicit sign-off.

## Deploy
`firebase deploy --only functions:aggregateEventFunnel` after merge (it gained the config write), then trigger it once so `config/foundingOffer` exists before the next app build ships the paywall change.

## Tests
app 855 passed (+12: savings derivation, fee-bleed math + thin-claim suppression, Square-volume windowing) · functions 333 passed (+6: cap boundaries, garbage-input handling, NEXT_PRICE mirror) · tsc clean both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)