### PR TITLE
Step 3: five-step trial lifecycle campaign (extends the live cron)

### DIFF
--- a/functions/scripts/lifecycleDryRun.ts
+++ b/functions/scripts/lifecycleDryRun.ts
@@ -1,0 +1,44 @@
+/**
+ * lifecycleDryRun.ts — read-only preview of what trialLifecycleDaily would
+ * send if it ran right now against live data. Mirrors the cron's reads and
+ * gating exactly (same lifecycleVerdict, same unreachable-email skip), sends
+ * nothing, stamps nothing.
+ *
+ * Run (ADC; gcloud-authed on hansendev):
+ *   cd functions && npx tsx scripts/lifecycleDryRun.ts
+ */
+import * as admin from 'firebase-admin';
+admin.initializeApp({ projectId: process.env.GOOGLE_CLOUD_PROJECT || 'hansendev' });
+
+import { lifecycleVerdict } from '../src/lifecycleEmails.helpers';
+import { listAllAuthUsers } from '../src/authUsers.helpers';
+import { isUnreachableEmail } from '../src/reEngagement.helpers';
+
+(async () => {
+  const db = admin.firestore();
+  const now = Date.now();
+  const authUsers = await listAllAuthUsers(admin.auth());
+  const tally: Record<string, number> = {};
+  const sends: string[] = [];
+
+  for (const u of authUsers) {
+    if (!u.email || isUnreachableEmail(u.email)) continue;
+    const [subDoc, stateDoc, squareDoc] = await Promise.all([
+      db.doc(`users/${u.uid}/profile/subscription`).get(),
+      db.doc(`users/${u.uid}/settings/emailState`).get(),
+      db.doc(`users/${u.uid}/settings/squareConnection`).get(),
+    ]);
+    if (!subDoc.exists) continue;
+    const v = lifecycleVerdict(subDoc.data(), stateDoc.data() as any, now, {
+      hasSquareConnection: squareDoc.exists,
+    });
+    if (!v.send) continue;
+    tally[v.send] = (tally[v.send] || 0) + 1;
+    sends.push(`${v.send} -> ${u.email} (${u.uid})`);
+  }
+
+  console.log(JSON.stringify({ wouldSendTally: tally, sends }, null, 2));
+})().catch((e) => {
+  console.error('failed:', e.message);
+  process.exit(1);
+});

--- a/functions/src/email.ts
+++ b/functions/src/email.ts
@@ -864,16 +864,33 @@ export function sendReEngagementEmail(
  * onboarding drip), because conversion pressure only makes sense against the
  * trial clock. Copy source: website repo marketing/trial-lifecycle-emails.md.
  */
+/**
+ * Real founding-member availability, read from config/foundingOffer by the
+ * lifecycle cron. null (cap filled / doc unavailable) suppresses every
+ * founding line — no invented scarcity, and cap-only: no deadlines anywhere.
+ */
+export interface FoundingSpots {
+  spotsLeft: number;
+  cap: number;
+}
+
 export function sendTrialEndingEmail(
   to: string,
   businessName: string,
   daysRemaining: number,
-  userId: string
+  userId: string,
+  founding: FoundingSpots | null = null
 ): Promise<boolean> {
   const unsubscribeUrl = `https://us-central1-hansendev.cloudfunctions.net/unsubscribeEmail?userId=${userId}&category=marketing`;
   const greeting = (businessName || '').trim() || 'there';
   const daysWord = daysRemaining <= 1 ? 'tomorrow' : `in ${daysRemaining} days`;
   const pricingUrl = 'https://quotemateapp.au/pricing?utm_source=lifecycle&utm_medium=email&utm_campaign=trial&utm_content=trial_ending';
+  const foundingLine = founding
+    ? `
+    <p style="color:#cbd5e1;font-size:15px;line-height:1.7;margin:16px 0 0;">
+      Lock it in as a <strong style="color:#f8fafc;">founding member</strong> and $49/mo is yours for life &mdash; the price goes to $99 for new members once the first ${founding.cap} are in. Right now there are <strong style="color:#f8fafc;">${founding.spotsLeft} of ${founding.cap} spots left</strong>.
+    </p>`
+    : '';
 
   const content = wrapEmailTemplate(`
     <h1 style="color:#f8fafc;font-size:26px;font-weight:700;margin:0 0 20px;line-height:1.3;">
@@ -908,8 +925,8 @@ export function sendTrialEndingEmail(
     <p style="color:#cbd5e1;font-size:15px;line-height:1.7;margin:24px 0 0;">
       Pro is <strong style="color:#f8fafc;">$49/month</strong>, or <strong style="color:#f8fafc;">$328 for the year</strong> &mdash; 44% off, which works out around $6.30 a week. Most tradies lose more than that in forgotten line items on one quote.
     </p>
-
-    ${ctaButton('Keep Pro — takes 30 seconds', '#009868', pricingUrl)}
+${foundingLine}
+    ${ctaButton(founding ? 'Claim your founding spot' : 'Keep Pro — takes 30 seconds', '#009868', pricingUrl)}
 
     <p style="color:#64748b;font-size:14px;line-height:1.6;margin:28px 0 0;">
       Either way, your quotes, invoices and customers stay yours.
@@ -918,7 +935,9 @@ export function sendTrialEndingEmail(
 
   return sendEmail({
     to,
-    subject: `Your trial ends ${daysWord} — here's exactly what changes`,
+    subject: founding
+      ? `Your trial ends ${daysWord} — and ${founding.spotsLeft} founding spots to go`
+      : `Your trial ends ${daysWord} — here's exactly what changes`,
     htmlContent: content,
     category: 'marketing',
     userId,
@@ -935,11 +954,18 @@ export function sendTrialEndingEmail(
 export function sendTrialEndedEmail(
   to: string,
   businessName: string,
-  userId: string
+  userId: string,
+  founding: FoundingSpots | null = null
 ): Promise<boolean> {
   const unsubscribeUrl = `https://us-central1-hansendev.cloudfunctions.net/unsubscribeEmail?userId=${userId}&category=marketing`;
   const greeting = (businessName || '').trim() || 'there';
   const pricingUrl = 'https://quotemateapp.au/pricing?utm_source=lifecycle&utm_medium=email&utm_campaign=trial&utm_content=trial_ended';
+  const foundingLine = founding
+    ? `
+    <p style="color:#cbd5e1;font-size:15px;line-height:1.7;margin:0 0 8px;">
+      And if Pro's still on your mind: your <strong style="color:#f8fafc;">founding spot's open while they last</strong> &mdash; $49/mo locked for life, ${founding.spotsLeft} of ${founding.cap} left. Once they fill, it's $99 for new members. No deadline, no pressure &mdash; just first in.
+    </p>`
+    : '';
 
   const content = wrapEmailTemplate(`
     <h1 style="color:#f8fafc;font-size:26px;font-weight:700;margin:0 0 20px;line-height:1.3;">
@@ -954,7 +980,7 @@ export function sendTrialEndedEmail(
     <p style="color:#cbd5e1;font-size:15px;line-height:1.7;margin:0 0 8px;">
       If the answer is price: the annual plan is $328, about $6.30 a week. If the answer is a missing feature, there's a decent chance it gets built &mdash; feature requests from real users run this roadmap.
     </p>
-
+${foundingLine}
     ${ctaButton('See Pro pricing', '#009868', pricingUrl)}
   `, { unsubscribeUrl, preheader: 'No card charged, nothing lost. But tell me one thing.' });
 
@@ -967,6 +993,161 @@ export function sendTrialEndedEmail(
     tags: ['trial-lifecycle', 'trial-ended'],
     unsubscribeUrl,
     replyTo: { email: 'tom@hansendev.com.au', name: 'Tom at QuoteMate' },
+  });
+}
+
+/**
+ * Trial lifecycle day 0–1: the trial just started (it starts on the first
+ * quote). Value framing plus ONE action — send that quote today. Pro claims
+ * here must stay true: free already has unlimited quotes/invoices + branding,
+ * so only genuine Pro features are named.
+ */
+export function sendTrialStartValueEmail(
+  to: string,
+  businessName: string,
+  userId: string
+): Promise<boolean> {
+  const unsubscribeUrl = `https://us-central1-hansendev.cloudfunctions.net/unsubscribeEmail?userId=${userId}&category=marketing`;
+  const name = (businessName || '').trim();
+
+  const content = wrapEmailTemplate(`
+    <h1 style="color:#f8fafc;font-size:26px;font-weight:700;margin:0 0 20px;line-height:1.3;">
+      Your 14 days of Pro start now
+    </h1>
+    <p style="color:#cbd5e1;font-size:15px;line-height:1.7;margin:0 0 24px;">
+      Good on ya${name ? `, ${name}` : ''} &mdash; your first quote's in, and that kicks off 14 days with everything unlocked. No card, no catch.
+    </p>
+
+    ${infoCard(`
+      <tr>
+        <td style="padding:12px 0;">
+          <p style="color:#f8fafc;font-size:14px;font-weight:600;margin:0 0 16px;">While it's all unlocked, put it to work:</p>
+          ${featureBullet('&#128736;', 'Materials lists priced for you, with live supplier prices')}
+          ${featureBullet('&#128196;', 'Every premium PDF template')}
+          ${featureBullet('&#128179;', 'Lower card fee + bank/PayID/BPAY/PayPal options for your customers')}
+        </td>
+      </tr>
+    `)}
+
+    <p style="color:#cbd5e1;font-size:15px;line-height:1.7;margin:24px 0 0;">
+      One thing to do today: <strong style="color:#f8fafc;">send that quote</strong>. Email, SMS or share it, straight from the app. Quotes sent within the hour win jobs that quotes sent at 9pm lose.
+    </p>
+
+    ${ctaButton('Send your quote')}
+  `, { unsubscribeUrl, preheader: 'One thing to do today: send that quote.' });
+
+  return sendEmail({
+    to,
+    subject: 'Your 14 days of Pro start now',
+    htmlContent: content,
+    category: 'marketing',
+    userId,
+    tags: ['trial-lifecycle', 'trial-start-value'],
+    unsubscribeUrl,
+  });
+}
+
+/**
+ * Trial lifecycle day 3–4 (Path B): pitch turning on payments while the
+ * tradie is engaged — skipped entirely if Square is already connected.
+ * Honest framing: payments work on the free plan too.
+ */
+export function sendTrialSquarePitchEmail(
+  to: string,
+  businessName: string,
+  userId: string
+): Promise<boolean> {
+  const unsubscribeUrl = `https://us-central1-hansendev.cloudfunctions.net/unsubscribeEmail?userId=${userId}&category=marketing`;
+  const greeting = (businessName || '').trim() || 'there';
+
+  const content = wrapEmailTemplate(`
+    <h1 style="color:#f8fafc;font-size:26px;font-weight:700;margin:0 0 20px;line-height:1.3;">
+      Get paid the second the job's done
+    </h1>
+    <p style="color:#cbd5e1;font-size:15px;line-height:1.7;margin:0 0 16px;">
+      Hi ${greeting} &mdash; you're sending tidy quotes. Here's the other half: getting paid without chasing.
+    </p>
+    <p style="color:#cbd5e1;font-size:15px;line-height:1.7;margin:0 0 16px;">
+      Hook up Square &mdash; takes about a minute &mdash; and every quote and invoice carries a <strong style="color:#f8fafc;">Pay Now button</strong> your customer can tap on their phone. Deposits up front, balances on the day, no &ldquo;I'll do a transfer tonight&rdquo;.
+    </p>
+    <p style="color:#cbd5e1;font-size:15px;line-height:1.7;margin:0;">
+      It's yours to keep on the free plan too &mdash; no need to be on Pro.
+    </p>
+
+    ${ctaButton('Turn on payments')}
+  `, { unsubscribeUrl, preheader: 'One minute of setup and every quote carries a Pay Now button.' });
+
+  return sendEmail({
+    to,
+    subject: "Want to get paid the second the job's done?",
+    htmlContent: content,
+    category: 'marketing',
+    userId,
+    tags: ['trial-lifecycle', 'trial-square-pitch'],
+    unsubscribeUrl,
+  });
+}
+
+/**
+ * Trial lifecycle day 7–8: personalised recap of the user's OWN numbers.
+ * recap.rich gates the figures — thin data falls back to non-numeric copy,
+ * never padded numbers. Numbers come from midTrialRecap over the user's real
+ * documents (lifecycleEmails.helpers.ts).
+ */
+export function sendTrialMidValueEmail(
+  to: string,
+  businessName: string,
+  recap: { quotesBuilt: number; dollarsQuoted: number; sent: number; rich: boolean },
+  userId: string
+): Promise<boolean> {
+  const unsubscribeUrl = `https://us-central1-hansendev.cloudfunctions.net/unsubscribeEmail?userId=${userId}&category=marketing`;
+  const greeting = (businessName || '').trim() || 'there';
+  const pricingUrl = 'https://quotemateapp.au/pricing?utm_source=lifecycle&utm_medium=email&utm_campaign=trial&utm_content=trial_mid';
+  const dollars = `$${recap.dollarsQuoted.toLocaleString('en-AU')}`;
+
+  const recapBlock = recap.rich
+    ? `
+    ${infoCard(`
+      <tr>
+        <td style="padding:12px 0;">
+          <p style="color:#f8fafc;font-size:14px;font-weight:600;margin:0 0 16px;">Your first week:</p>
+          ${featureBullet('&#128221;', `<strong style="color:#f8fafc;">${recap.quotesBuilt} quote${recap.quotesBuilt === 1 ? '' : 's'}</strong> built`)}
+          ${featureBullet('&#128176;', `<strong style="color:#f8fafc;">${dollars}</strong> quoted`)}
+          ${featureBullet('&#128232;', `<strong style="color:#f8fafc;">${recap.sent}</strong> sent to customers`)}
+        </td>
+      </tr>
+    `)}
+    <p style="color:#cbd5e1;font-size:15px;line-height:1.7;margin:24px 0 16px;">
+      That's real work off your plate.
+    </p>`
+    : `
+    <p style="color:#cbd5e1;font-size:15px;line-height:1.7;margin:0 0 16px;">
+      One week into your trial &mdash; how's it treating you? If you've got a job sitting unquoted, now's the moment: describe it and QuoteMate prices the materials and labour for you.
+    </p>`;
+
+  const content = wrapEmailTemplate(`
+    <h1 style="color:#f8fafc;font-size:26px;font-weight:700;margin:0 0 20px;line-height:1.3;">
+      ${recap.rich ? 'One week in — here’s your tally' : 'One week in — 7 days of Pro to go'}
+    </h1>
+    <p style="color:#94a3b8;font-size:14px;margin:0 0 16px;">Hi ${greeting},</p>
+${recapBlock}
+    <p style="color:#cbd5e1;font-size:15px;line-height:1.7;margin:0;">
+      7 days left on Pro. After that you keep going free &mdash; unlimited quotes and invoices, nothing deleted &mdash; you'll just add a pay link to each job and the fee's a touch higher.
+    </p>
+
+    ${ctaButton('See what Pro keeps', '#009868', pricingUrl)}
+  `, { unsubscribeUrl, preheader: recap.rich ? 'Your first week, tallied up — and 7 days of Pro to go.' : 'Halfway through — 7 days of Pro to go.' });
+
+  return sendEmail({
+    to,
+    subject: recap.rich
+      ? `You've quoted ${dollars} in your first week`
+      : 'One week in — 7 days of Pro to go',
+    htmlContent: content,
+    category: 'marketing',
+    userId,
+    tags: ['trial-lifecycle', 'trial-mid-value'],
+    unsubscribeUrl,
   });
 }
 

--- a/functions/src/lifecycleEmails.helpers.test.ts
+++ b/functions/src/lifecycleEmails.helpers.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect } from 'vitest';
-import { lifecycleVerdict, ENDED_WINDOW_MS } from './lifecycleEmails.helpers';
+import {
+  lifecycleVerdict,
+  midTrialRecap,
+  ENDED_WINDOW_MS,
+  ENDING_THRESHOLD_DAYS,
+  SEND_ONCE_FIELD,
+  RECAP_MIN_QUOTES,
+  RECAP_MIN_DOLLARS,
+} from './lifecycleEmails.helpers';
 import { TRIAL_MS } from './subscription.helpers';
 
 const DAY = 24 * 60 * 60 * 1000;
@@ -13,41 +21,105 @@ const trialSub = (startedDaysAgo: number, over: Record<string, unknown> = {}) =>
   ...over,
 });
 
-describe('lifecycleVerdict', () => {
+describe('lifecycleVerdict — gating', () => {
   it('sends nothing for users who never started a trial', () => {
     expect(lifecycleVerdict(null, undefined, NOW).send).toBeNull();
     expect(lifecycleVerdict({ isPro: false }, undefined, NOW).send).toBeNull();
   });
 
-  it('sends nothing for converted (Pro) users, including comped admin grants', () => {
-    expect(lifecycleVerdict(trialSub(13, { isPro: true }), undefined, NOW).send).toBeNull();
+  it('any Pro signal short-circuits every step: billed, bare isPro flag, admin_grant comp', () => {
+    for (const daysAgo of [0.5, 3.5, 7.5, 12, 15]) {
+      expect(
+        lifecycleVerdict(trialSub(daysAgo, { isPro: true, productId: 'quotemate_pro_yearly' }), undefined, NOW).send
+      ).toBeNull();
+      expect(lifecycleVerdict(trialSub(daysAgo, { isPro: true }), undefined, NOW).send).toBeNull();
+      expect(
+        lifecycleVerdict(trialSub(daysAgo, { isPro: true, platform: 'admin_grant' }), undefined, NOW).send
+      ).toBeNull();
+    }
+  });
+
+  it('sends nothing in the gaps between windows', () => {
+    expect(lifecycleVerdict(trialSub(2.5), undefined, NOW).send).toBeNull();
+    expect(lifecycleVerdict(trialSub(5.5), undefined, NOW).send).toBeNull();
+    expect(lifecycleVerdict(trialSub(6.5), undefined, NOW).send).toBeNull();
+    expect(lifecycleVerdict(trialSub(9.5), undefined, NOW).send).toBeNull();
+  });
+});
+
+describe('trial_start_value (day 0–1)', () => {
+  it('fires inside the window, once', () => {
+    expect(lifecycleVerdict(trialSub(0.5), undefined, NOW).send).toBe('trial_start_value');
+    expect(lifecycleVerdict(trialSub(1.9), undefined, NOW).send).toBe('trial_start_value');
+    const state = { trialStartValueEmailAt: iso(NOW - DAY) };
+    expect(lifecycleVerdict(trialSub(0.5), state, NOW).send).toBeNull();
+  });
+
+  it('never sends stale — a user first seen on day 2+ skips it', () => {
+    expect(lifecycleVerdict(trialSub(2.1), undefined, NOW).send).toBeNull();
+  });
+});
+
+describe('trial_square_pitch (day 3–4, Path B)', () => {
+  it('fires inside the window when Square is NOT connected', () => {
+    expect(lifecycleVerdict(trialSub(3.5), undefined, NOW).send).toBe('trial_square_pitch');
+    expect(lifecycleVerdict(trialSub(4.9), undefined, NOW).send).toBe('trial_square_pitch');
+  });
+
+  it('skipped entirely for already-connected users', () => {
     expect(
-      lifecycleVerdict({ isPro: true, platform: 'admin_grant' }, undefined, NOW).send
+      lifecycleVerdict(trialSub(3.5), undefined, NOW, { hasSquareConnection: true }).send
     ).toBeNull();
   });
 
-  it('sends nothing mid-trial (more than 2 days remaining)', () => {
-    expect(lifecycleVerdict(trialSub(5), undefined, NOW).send).toBeNull();
-    expect(lifecycleVerdict(trialSub(11), undefined, NOW).send).toBeNull();
+  it('send-once and never stale', () => {
+    const state = { trialSquarePitchEmailAt: iso(NOW - DAY) };
+    expect(lifecycleVerdict(trialSub(3.5), state, NOW).send).toBeNull();
+    expect(lifecycleVerdict(trialSub(5.1), undefined, NOW).send).toBeNull();
+  });
+});
+
+describe('trial_mid_value (day 7–8)', () => {
+  it('fires inside the window with trialStartedAt for the personalisation read', () => {
+    const v = lifecycleVerdict(trialSub(7.5), undefined, NOW);
+    expect(v.send).toBe('trial_mid_value');
+    expect(v.trialStartedAt).toBe(NOW - 7.5 * DAY);
   });
 
-  it('sends trial_ending when <= 2 days remain', () => {
-    const v = lifecycleVerdict(trialSub(12.5), undefined, NOW);
+  it('send-once and never stale', () => {
+    const state = { trialMidValueEmailAt: iso(NOW - DAY) };
+    expect(lifecycleVerdict(trialSub(7.5), state, NOW).send).toBeNull();
+    expect(lifecycleVerdict(trialSub(9.1), undefined, NOW).send).toBeNull();
+  });
+});
+
+describe('trial_ending (≤3 days remaining)', () => {
+  it('fires at the threshold and inside it (deriveSubFields Math.ceil convention)', () => {
+    // 10.5 days in → ceil(3.5) = 4 days remaining → not yet.
+    expect(lifecycleVerdict(trialSub(10.5), undefined, NOW).send).toBeNull();
+    // 11.5 days in → ceil(2.5) = 3 → fires.
+    const v = lifecycleVerdict(trialSub(11.5), undefined, NOW);
     expect(v.send).toBe('trial_ending');
-    expect(v.daysRemaining).toBeLessThanOrEqual(2);
+    expect(v.daysRemaining).toBeLessThanOrEqual(ENDING_THRESHOLD_DAYS);
   });
 
-  it('sends trial_ending only once', () => {
+  it('still fires late in the trial and prefers ending over ended while trialing', () => {
+    expect(lifecycleVerdict(trialSub(13.9), undefined, NOW).send).toBe('trial_ending');
+  });
+
+  it('send-once', () => {
     const state = { trialEndingEmailAt: iso(NOW - DAY) };
     expect(lifecycleVerdict(trialSub(12.5), state, NOW).send).toBeNull();
   });
 
-  it('sends trial_ended shortly after expiry', () => {
-    const v = lifecycleVerdict(trialSub(15), undefined, NOW);
-    expect(v.send).toBe('trial_ended');
+  it('takes priority over stale earlier steps for a user with no flags at all', () => {
+    expect(lifecycleVerdict(trialSub(11.5), undefined, NOW).send).toBe('trial_ending');
   });
+});
 
-  it('sends trial_ended only once', () => {
+describe('trial_ended (T+0..3d)', () => {
+  it('fires shortly after expiry, once', () => {
+    expect(lifecycleVerdict(trialSub(15), undefined, NOW).send).toBe('trial_ended');
     const state = { trialEndedEmailAt: iso(NOW - DAY) };
     expect(lifecycleVerdict(trialSub(15), state, NOW).send).toBeNull();
   });
@@ -56,10 +128,60 @@ describe('lifecycleVerdict', () => {
     const daysAgo = (TRIAL_MS + ENDED_WINDOW_MS) / DAY + 1;
     expect(lifecycleVerdict(trialSub(daysAgo), undefined, NOW).send).toBeNull();
   });
+});
 
-  it('prefers trial_ending over trial_ended at the boundary (still trialing)', () => {
-    // 13.9 days in: still trialing with <1 day left.
-    const v = lifecycleVerdict(trialSub(13.9), undefined, NOW);
-    expect(v.send).toBe('trial_ending');
+describe('SEND_ONCE_FIELD', () => {
+  it('maps every step to a distinct emailState field', () => {
+    const fields = Object.values(SEND_ONCE_FIELD);
+    expect(new Set(fields).size).toBe(fields.length);
+    expect(fields).toHaveLength(5);
+  });
+});
+
+describe('midTrialRecap', () => {
+  const T0 = NOW - 7 * DAY;
+  const doc = (over: Record<string, unknown> = {}) => ({
+    createdAt: T0 + DAY,
+    total: 1000,
+    stage: 'draft',
+    ...over,
+  });
+
+  it('counts only documents created since the trial started', () => {
+    const recap = midTrialRecap(
+      [doc(), doc({ createdAt: T0 - DAY, total: 99999 }), doc({ createdAt: undefined })],
+      T0
+    );
+    expect(recap.quotesBuilt).toBe(1);
+    expect(recap.dollarsQuoted).toBe(1000);
+  });
+
+  it('counts sent via the activating-doc rule (stage or sentAt fallback)', () => {
+    const recap = midTrialRecap(
+      [doc({ stage: 'quote_sent' }), doc({ stage: 'draft', sentAt: T0 + DAY }), doc()],
+      T0
+    );
+    expect(recap.sent).toBe(2);
+  });
+
+  it('survives garbage totals', () => {
+    const recap = midTrialRecap([doc({ total: 'not-a-number' }), doc({ total: null })], T0);
+    expect(recap.dollarsQuoted).toBe(0);
+  });
+
+  it('rich only when the numbers would actually impress', () => {
+    // 2 quotes, $2000 → rich.
+    expect(midTrialRecap([doc(), doc()], T0).rich).toBe(true);
+    // 1 quote, $10k → thin (below RECAP_MIN_QUOTES).
+    expect(midTrialRecap([doc({ total: 10000 })], T0).rich).toBe(false);
+    // 3 quotes, $300 total → thin (below RECAP_MIN_DOLLARS).
+    const cheap = [doc({ total: 100 }), doc({ total: 100 }), doc({ total: 100 })];
+    expect(midTrialRecap(cheap, T0).rich).toBe(false);
+    expect(RECAP_MIN_QUOTES).toBe(2);
+    expect(RECAP_MIN_DOLLARS).toBe(500);
+  });
+
+  it('empty docs → thin recap with zeros', () => {
+    expect(midTrialRecap([], T0)).toEqual({ quotesBuilt: 0, dollarsQuoted: 0, sent: 0, rich: false });
   });
 });

--- a/functions/src/lifecycleEmails.helpers.ts
+++ b/functions/src/lifecycleEmails.helpers.ts
@@ -2,43 +2,153 @@
  * Pure decision logic for the trial lifecycle emails (lifecycleEmails.ts).
  * Kept dependency-free (no firebase imports) so it unit-tests like the other
  * *.helpers modules.
+ *
+ * Five steps on the TRIAL clock (trialStartedAt), each with a send-once flag
+ * in users/{uid}/settings/emailState and its own window — a user who enters
+ * the campaign late never receives stale steps:
+ *
+ *   day 0–1   trial_start_value   value framing + "send that quote today"
+ *   day 3–4   trial_square_pitch  Path B: turn on payments (skipped if
+ *                                 Square is already connected)
+ *   day 7–8   trial_mid_value     personalised recap of the user's own real
+ *                                 numbers (thin data → figures dropped)
+ *   ≤3 days   trial_ending        what changes + real founding-spots count
+ *   T+0..3d   trial_ended         free-plan reassurance + churn question
+ *
+ * The never-activated cohort is deliberately NOT here: sendOnboardingDrip's
+ * tip 5 (Tom's first-quote note, day 14 post-signup) owns it — anyone with a
+ * trial has already built a quote, so the two campaigns can't overlap.
  */
 import { deriveSubFields, TRIAL_MS } from './subscription.helpers';
+import { isActivatingDoc } from './adminFunnel.helpers';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 // How long after trial expiry the trial_ended email may still go out. Going
 // live never backfills users whose trials lapsed before this window.
 export const ENDED_WINDOW_MS = 3 * DAY_MS;
+// trial_ending moved T-2 → T-3 (2026-07-16) so the founding-spots pitch has
+// room to land before the last-day scramble.
+export const ENDING_THRESHOLD_DAYS = 3;
+
+export type LifecycleSend =
+  | 'trial_start_value'
+  | 'trial_square_pitch'
+  | 'trial_mid_value'
+  | 'trial_ending'
+  | 'trial_ended';
+
+export interface LifecycleEmailState {
+  trialStartValueEmailAt?: unknown;
+  trialSquarePitchEmailAt?: unknown;
+  trialMidValueEmailAt?: unknown;
+  trialEndingEmailAt?: unknown;
+  trialEndedEmailAt?: unknown;
+}
+
+/** emailState field stamped (send-once) for each step. */
+export const SEND_ONCE_FIELD: Record<LifecycleSend, keyof LifecycleEmailState> = {
+  trial_start_value: 'trialStartValueEmailAt',
+  trial_square_pitch: 'trialSquarePitchEmailAt',
+  trial_mid_value: 'trialMidValueEmailAt',
+  trial_ending: 'trialEndingEmailAt',
+  trial_ended: 'trialEndedEmailAt',
+};
 
 export interface LifecycleDecision {
-  send: 'trial_ending' | 'trial_ended' | null;
+  send: LifecycleSend | null;
   daysRemaining?: number;
+  /** ms epoch — present whenever send !== null (personalisation reads need it). */
+  trialStartedAt?: number;
 }
 
 /** Which lifecycle email (if any) this user should get right now. */
 export function lifecycleVerdict(
   sub: any,
-  emailState: { trialEndingEmailAt?: unknown; trialEndedEmailAt?: unknown } | undefined,
-  now: number
+  emailState: LifecycleEmailState | undefined,
+  now: number,
+  extras: { hasSquareConnection?: boolean } = {}
 ): LifecycleDecision {
   const f = deriveSubFields(sub, now);
 
-  // Converted, comped (admin_grant sets isPro) or never trialed → nothing.
+  // Converted, comped (admin_grant sets isPro), bare isPro flags, or never
+  // trialed → nothing. Anyone the app treats as Pro is never nagged.
   if (f.isPro || f.trialStartedAt === null) return { send: null };
 
-  if (
-    f.tier === 'trialing' &&
-    f.trialDaysRemaining !== null &&
-    f.trialDaysRemaining <= 2 &&
-    !emailState?.trialEndingEmailAt
-  ) {
-    return { send: 'trial_ending', daysRemaining: f.trialDaysRemaining };
+  if (f.tier === 'trialing') {
+    const elapsedDays = (now - f.trialStartedAt) / DAY_MS;
+
+    // Most time-critical first; the day windows themselves are disjoint.
+    if (
+      f.trialDaysRemaining !== null &&
+      f.trialDaysRemaining <= ENDING_THRESHOLD_DAYS &&
+      !emailState?.trialEndingEmailAt
+    ) {
+      return {
+        send: 'trial_ending',
+        daysRemaining: f.trialDaysRemaining,
+        trialStartedAt: f.trialStartedAt,
+      };
+    }
+    if (elapsedDays >= 7 && elapsedDays < 9 && !emailState?.trialMidValueEmailAt) {
+      return { send: 'trial_mid_value', trialStartedAt: f.trialStartedAt };
+    }
+    if (
+      elapsedDays >= 3 &&
+      elapsedDays < 5 &&
+      !extras.hasSquareConnection &&
+      !emailState?.trialSquarePitchEmailAt
+    ) {
+      return { send: 'trial_square_pitch', trialStartedAt: f.trialStartedAt };
+    }
+    if (elapsedDays < 2 && !emailState?.trialStartValueEmailAt) {
+      return { send: 'trial_start_value', trialStartedAt: f.trialStartedAt };
+    }
+    return { send: null };
   }
 
   if (f.tier === 'trial_expired' && !emailState?.trialEndedEmailAt) {
     const endedAt = f.trialStartedAt + TRIAL_MS;
-    if (now - endedAt <= ENDED_WINDOW_MS) return { send: 'trial_ended' };
+    if (now - endedAt <= ENDED_WINDOW_MS) {
+      return { send: 'trial_ended', trialStartedAt: f.trialStartedAt };
+    }
   }
 
   return { send: null };
+}
+
+export interface MidTrialRecap {
+  quotesBuilt: number;
+  dollarsQuoted: number;
+  sent: number;
+  /** False → the email drops the figures (never pad thin numbers). */
+  rich: boolean;
+}
+
+// Below either bound the recap reads as sad rather than impressive — the
+// email falls back to non-numeric copy instead.
+export const RECAP_MIN_QUOTES = 2;
+export const RECAP_MIN_DOLLARS = 500;
+
+/**
+ * The user's OWN real numbers for the day-7 email, from their documents
+ * created since the trial started. Field names verified against the live
+ * writers: documents carry `createdAt` (ms) and `total` (documentHandlers.ts
+ * payment math uses Number(doc.total)); "sent" reuses isActivatingDoc.
+ */
+export function midTrialRecap(
+  docs: Array<{ createdAt?: unknown; total?: unknown; stage?: unknown; sentAt?: unknown }>,
+  trialStartedAt: number
+): MidTrialRecap {
+  let quotesBuilt = 0;
+  let dollarsQuoted = 0;
+  let sent = 0;
+  for (const d of docs) {
+    if (typeof d.createdAt !== 'number' || d.createdAt < trialStartedAt) continue;
+    quotesBuilt++;
+    dollarsQuoted += Number(d.total) || 0;
+    if (isActivatingDoc(d)) sent++;
+  }
+  dollarsQuoted = Math.round(dollarsQuoted);
+  const rich = quotesBuilt >= RECAP_MIN_QUOTES && dollarsQuoted >= RECAP_MIN_DOLLARS;
+  return { quotesBuilt, dollarsQuoted, sent, rich };
 }

--- a/functions/src/lifecycleEmails.ts
+++ b/functions/src/lifecycleEmails.ts
@@ -1,32 +1,48 @@
 /**
- * Trial lifecycle emails — the two conversion-critical sends anchored to the
+ * Trial lifecycle emails — five conversion-focused sends anchored to the
  * TRIAL clock (trialStartedAt), not the signup clock:
  *
- *   - trial_ending: once, when <= 2 days of the 14-day Pro trial remain.
- *   - trial_ended:  once, within 3 days after the trial lapses unconverted.
+ *   - trial_start_value  (day 0–1):  value framing + "send that quote today"
+ *   - trial_square_pitch (day 3–4):  Path B — turn on payments (skipped when
+ *                                    Square is already connected)
+ *   - trial_mid_value    (day 7–8):  the user's OWN real numbers; thin data
+ *                                    drops the figures
+ *   - trial_ending       (≤3 days):  what changes + REAL founding-spots count
+ *   - trial_ended        (T+0..3d):  free-plan reassurance + churn question
  *
  * The signup-anchored onboarding drip (sendOnboardingDrip in index.ts) keeps
- * owning activation tips; this function owns the conversion moment. Copy
- * source: website repo marketing/trial-lifecycle-emails.md.
+ * owning activation tips and the never-activated note (tip 5); this function
+ * owns the conversion moment. Windows are disjoint and each step is
+ * send-once, so a user gets at most one lifecycle email per day and never a
+ * stale step. Copy source: website repo marketing/trial-lifecycle-emails.md
+ * + the conversion-engine spec (cap-only: no deadlines anywhere).
  *
  * SAFETY
- *   - Dry-run by default: sends nothing until LIFECYCLE_LIVE=true is set in
- *     functions/.env (and the function redeployed). Dry runs log the exact
- *     would-send list so the first live run holds no surprises.
+ *   - Dry-run unless LIFECYCLE_LIVE=true in functions/.env. Dry runs log the
+ *     exact would-send list.
  *   - The 3-day trial_ended window means going live never backfills users
  *     whose trials lapsed weeks or months ago.
- *   - Send-once flags live in users/{uid}/settings/emailState
- *     (trialEndingEmailAt / trialEndedEmailAt), stamped only on successful
- *     sends. sendEmail() itself enforces the marketing opt-out and blocks
- *     unsendable domains; isUnreachableEmail() skips the Apple-relay class
- *     before we even read Firestore.
+ *   - Send-once flags live in users/{uid}/settings/emailState (one field per
+ *     step — see SEND_ONCE_FIELD), stamped only on successful sends.
+ *     sendEmail() itself enforces the marketing opt-out and blocks unsendable
+ *     domains; isUnreachableEmail() skips the Apple-relay class up front.
+ *   - Founding-spots numbers come from config/foundingOffer (computed from
+ *     real billed subs). Doc missing or cap filled → the founding copy is
+ *     suppressed, never invented.
  */
 import * as functions from 'firebase-functions';
 import * as admin from 'firebase-admin';
 import { listAllAuthUsers } from './authUsers.helpers';
 import { isUnreachableEmail } from './reEngagement.helpers';
-import { lifecycleVerdict } from './lifecycleEmails.helpers';
-import { sendTrialEndingEmail, sendTrialEndedEmail } from './email';
+import { lifecycleVerdict, midTrialRecap, SEND_ONCE_FIELD } from './lifecycleEmails.helpers';
+import {
+  sendTrialStartValueEmail,
+  sendTrialSquarePitchEmail,
+  sendTrialMidValueEmail,
+  sendTrialEndingEmail,
+  sendTrialEndedEmail,
+  type FoundingSpots,
+} from './email';
 
 export const trialLifecycleDaily = functions.pubsub
   .schedule('every day 07:30')
@@ -35,6 +51,17 @@ export const trialLifecycleDaily = functions.pubsub
     const db = admin.firestore();
     const now = Date.now();
     const live = process.env.LIFECYCLE_LIVE === 'true';
+
+    // Cap-only founding scarcity: real spots from config/foundingOffer, or
+    // null → founding copy suppressed.
+    let founding: FoundingSpots | null = null;
+    try {
+      const snap = await db.doc('config/foundingOffer').get();
+      const data = snap.data();
+      if (data?.capActive && typeof data.spotsLeft === 'number' && data.spotsLeft > 0) {
+        founding = { spotsLeft: data.spotsLeft, cap: typeof data.cap === 'number' ? data.cap : 100 };
+      }
+    } catch {}
 
     const authUsers = await listAllAuthUsers(admin.auth());
     let processed = 0;
@@ -48,13 +75,18 @@ export const trialLifecycleDaily = functions.pubsub
         const email = userRecord.email;
         if (!email || isUnreachableEmail(email)) continue;
 
-        const subDoc = await db.doc(`users/${userId}/profile/subscription`).get();
+        const stateRef = db.doc(`users/${userId}/settings/emailState`);
+        const [subDoc, stateDoc, squareDoc] = await Promise.all([
+          db.doc(`users/${userId}/profile/subscription`).get(),
+          stateRef.get(),
+          db.doc(`users/${userId}/settings/squareConnection`).get(),
+        ]);
         if (!subDoc.exists) continue;
         processed++;
 
-        const stateRef = db.doc(`users/${userId}/settings/emailState`);
-        const stateDoc = await stateRef.get();
-        const verdict = lifecycleVerdict(subDoc.data(), stateDoc.data(), now);
+        const verdict = lifecycleVerdict(subDoc.data(), stateDoc.data(), now, {
+          hasSquareConnection: squareDoc.exists,
+        });
         if (!verdict.send) continue;
 
         if (!live) {
@@ -68,14 +100,36 @@ export const trialLifecycleDaily = functions.pubsub
           businessName = settingsDoc.data()?.businessName || '';
         } catch {}
 
-        const ok =
-          verdict.send === 'trial_ending'
-            ? await sendTrialEndingEmail(email, businessName, verdict.daysRemaining ?? 2, userId)
-            : await sendTrialEndedEmail(email, businessName, userId);
+        let ok = false;
+        switch (verdict.send) {
+          case 'trial_start_value':
+            ok = await sendTrialStartValueEmail(email, businessName, userId);
+            break;
+          case 'trial_square_pitch':
+            ok = await sendTrialSquarePitchEmail(email, businessName, userId);
+            break;
+          case 'trial_mid_value': {
+            const docsSnap = await db.collection(`users/${userId}/documents`).get();
+            const recap = midTrialRecap(
+              docsSnap.docs.map((d) => d.data() as any),
+              verdict.trialStartedAt ?? now
+            );
+            ok = await sendTrialMidValueEmail(email, businessName, recap, userId);
+            break;
+          }
+          case 'trial_ending':
+            ok = await sendTrialEndingEmail(email, businessName, verdict.daysRemaining ?? 3, userId, founding);
+            break;
+          case 'trial_ended':
+            ok = await sendTrialEndedEmail(email, businessName, userId, founding);
+            break;
+        }
 
         if (ok) {
-          const field = verdict.send === 'trial_ending' ? 'trialEndingEmailAt' : 'trialEndedEmailAt';
-          await stateRef.set({ [field]: admin.firestore.FieldValue.serverTimestamp() }, { merge: true });
+          await stateRef.set(
+            { [SEND_ONCE_FIELD[verdict.send]]: admin.firestore.FieldValue.serverTimestamp() },
+            { merge: true }
+          );
           sent++;
         }
       } catch (err: any) {


### PR DESCRIPTION
Extends the live `trialLifecycleDaily` cron from 2 steps to 5 — the amended Step 3 (the spec's parallel `trialLifecycle.helpers.ts` would have double-sent the trial-ending moment).

## The campaign (all on the trial clock, all send-once, windows disjoint)
| Step | When | What |
|---|---|---|
| `trial_start_value` | day 0–1 | "Your 14 days of Pro start now" — true Pro features only + one action: send that quote |
| `trial_square_pitch` | day 3–4 | Path B: "Want to get paid the second the job's done?" — skipped if Square already connected |
| `trial_mid_value` | day 7–8 | The user's OWN numbers ("You've quoted $X in your first week"); <2 quotes or <$500 → figures dropped, non-numeric copy |
| `trial_ending` | ≤3 days left (was ≤2) | What changes + **real** founding-spots count from `config/foundingOffer`; suppressed if cap filled/doc missing |
| `trial_ended` | T+0..3d | Reassurance + churn question + "founding spot's open while they last — no deadline, no pressure" |

## Guardrails held
- Any Pro signal (billed, bare `isPro`, `admin_grant`) short-circuits everything — tested for all three shapes at every window.
- Late joiners never get stale steps; one lifecycle email max per user per day.
- Never-activated cohort untouched — `sendOnboardingDrip` tip 5 owns it, no overlap.
- Cap-only honesty: no deadlines or countdowns anywhere; founding numbers real or absent.
- Pushes deliberately excluded — all push tokens are Expo-format and `admin.messaging()` can't deliver them (verified 2026-07-16).

## Verified against live data
New `scripts/lifecycleDryRun.ts` (read-only, mirrors the cron exactly) run today: **13 sends — 5 start, 3 square-pitch, 2 mid, 2 ending, 1 ended** — one per user, zero Pro leakage. `LIFECYCLE_LIVE=true` is already set, so these go out on the first 07:30 Brisbane run after deploy.

## Deploy
`firebase deploy --only functions:trialLifecycleDaily` after merge. Optionally run the dry-run script first to see that morning's exact send list.

## Tests
functions 346 passed (+13: window boundaries incl. the Math.ceil T-3 edge, send-once flags, square-pitch connection skip, recap thin/rich rules, stale-step suppression) · copy guard green over the new templates · tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)