### PR TITLE
Step 4b: Square nudge track — connected-idle + sent-no-paylink

### DIFF
--- a/functions/scripts/lifecycleDryRun.ts
+++ b/functions/scripts/lifecycleDryRun.ts
@@ -11,12 +11,28 @@ import * as admin from 'firebase-admin';
 admin.initializeApp({ projectId: process.env.GOOGLE_CLOUD_PROJECT || 'hansendev' });
 
 import { lifecycleVerdict } from '../src/lifecycleEmails.helpers';
+import { squareNudgeVerdict } from '../src/squareNudge.helpers';
+import { isActivatingDoc } from '../src/adminFunnel.helpers';
+import { docHasSquarePayment } from '../src/eventFunnel.helpers';
+import { ts } from '../src/subscription.helpers';
 import { listAllAuthUsers } from '../src/authUsers.helpers';
 import { isUnreachableEmail } from '../src/reEngagement.helpers';
 
 (async () => {
   const db = admin.firestore();
   const now = Date.now();
+
+  const activatedUids = new Set<string>();
+  const squarePaidUids = new Set<string>();
+  const docsSnap = await db.collectionGroup('documents').get();
+  for (const d of docsSnap.docs) {
+    const uid = d.ref.parent.parent?.id;
+    if (!uid) continue;
+    const data = d.data() as any;
+    if (isActivatingDoc(data)) activatedUids.add(uid);
+    if (docHasSquarePayment(data)) squarePaidUids.add(uid);
+  }
+
   const authUsers = await listAllAuthUsers(admin.auth());
   const tally: Record<string, number> = {};
   const sends: string[] = [];
@@ -32,9 +48,22 @@ import { isUnreachableEmail } from '../src/reEngagement.helpers';
     const v = lifecycleVerdict(subDoc.data(), stateDoc.data() as any, now, {
       hasSquareConnection: squareDoc.exists,
     });
-    if (!v.send) continue;
-    tally[v.send] = (tally[v.send] || 0) + 1;
-    sends.push(`${v.send} -> ${u.email} (${u.uid})`);
+    const send =
+      v.send ??
+      squareNudgeVerdict(
+        {
+          sub: subDoc.data(),
+          emailState: stateDoc.data() as any,
+          hasSquareConnection: squareDoc.exists,
+          connectedAtMs: ts(squareDoc.data()?.connectedAt),
+          hasSquarePayment: squarePaidUids.has(u.uid),
+          hasSentDoc: activatedUids.has(u.uid),
+        },
+        now
+      );
+    if (!send) continue;
+    tally[send] = (tally[send] || 0) + 1;
+    sends.push(`${send} -> ${u.email} (${u.uid})`);
   }
 
   console.log(JSON.stringify({ wouldSendTally: tally, sends }, null, 2));

--- a/functions/src/email.ts
+++ b/functions/src/email.ts
@@ -1151,6 +1151,88 @@ ${recapBlock}
   });
 }
 
+/**
+ * Square nudge: connected ≥5 days, never collected. One send, ever. No
+ * invented social proof — at the current baseline almost nobody has
+ * collected yet, so the pitch is pure mechanics + benefit.
+ */
+export function sendSquareIdleNudgeEmail(
+  to: string,
+  businessName: string,
+  userId: string
+): Promise<boolean> {
+  const unsubscribeUrl = `https://us-central1-hansendev.cloudfunctions.net/unsubscribeEmail?userId=${userId}&category=marketing`;
+  const greeting = (businessName || '').trim() || 'there';
+
+  const content = wrapEmailTemplate(`
+    <h1 style="color:#f8fafc;font-size:26px;font-weight:700;margin:0 0 20px;line-height:1.3;">
+      Your Pay Now button's ready &mdash; put it to work
+    </h1>
+    <p style="color:#cbd5e1;font-size:15px;line-height:1.7;margin:0 0 16px;">
+      Hi ${greeting} &mdash; you've hooked up Square, nice one. But nothing's come through it yet, and a connected account earns you exactly nothing until a customer taps that button.
+    </p>
+    <p style="color:#cbd5e1;font-size:15px;line-height:1.7;margin:0 0 16px;">
+      Next quote or invoice you send, choose <strong style="color:#f8fafc;">&ldquo;Get paid on this quote&rdquo;</strong> and it goes out with a Pay Now button &mdash; your customer pays by card on their phone, and the job's marked paid before you've packed up.
+    </p>
+    <p style="color:#cbd5e1;font-size:15px;line-height:1.7;margin:0;">
+      Deposits up front, balances on the day, no chasing transfers.
+    </p>
+
+    ${ctaButton('Send a quote with a pay link')}
+  `, { unsubscribeUrl, preheader: 'One tap at send and your customer can pay by card on the spot.' });
+
+  return sendEmail({
+    to,
+    subject: "Your Pay Now button's ready — put it to work",
+    htmlContent: content,
+    category: 'marketing',
+    userId,
+    tags: ['square-nudge', 'connected-idle'],
+    unsubscribeUrl,
+  });
+}
+
+/**
+ * Square nudge: trial expired, sent quotes during it, never connected
+ * payments. The post-trial reactivation — connecting Square is also what
+ * lets them send again on the free plan. One send, ever.
+ */
+export function sendSquareNoPaylinkNudgeEmail(
+  to: string,
+  businessName: string,
+  userId: string
+): Promise<boolean> {
+  const unsubscribeUrl = `https://us-central1-hansendev.cloudfunctions.net/unsubscribeEmail?userId=${userId}&category=marketing`;
+  const greeting = (businessName || '').trim() || 'there';
+
+  const content = wrapEmailTemplate(`
+    <h1 style="color:#f8fafc;font-size:26px;font-weight:700;margin:0 0 20px;line-height:1.3;">
+      Your quotes are ready to get paid
+    </h1>
+    <p style="color:#cbd5e1;font-size:15px;line-height:1.7;margin:0 0 16px;">
+      Hi ${greeting} &mdash; you've built proper quotes in QuoteMate, and there's one step left to close the loop: getting paid through them.
+    </p>
+    <p style="color:#cbd5e1;font-size:15px;line-height:1.7;margin:0 0 16px;">
+      Hook up Square &mdash; takes about a minute &mdash; and every quote and invoice you send carries a <strong style="color:#f8fafc;">Pay Now button</strong>. Deposits before you order materials, balances the day the job wraps, no &ldquo;I'll do a transfer tonight&rdquo;.
+    </p>
+    <p style="color:#cbd5e1;font-size:15px;line-height:1.7;margin:0;">
+      It's part of the free plan &mdash; connecting it is also what switches sending back on now your trial's wrapped.
+    </p>
+
+    ${ctaButton('Turn on payments')}
+  `, { unsubscribeUrl, preheader: 'A minute of setup and every quote carries a Pay Now button.' });
+
+  return sendEmail({
+    to,
+    subject: 'Get paid the day the job’s done — your quotes are ready',
+    htmlContent: content,
+    category: 'marketing',
+    userId,
+    tags: ['square-nudge', 'no-paylink'],
+    unsubscribeUrl,
+  });
+}
+
 export function sendOnboardingTipEmail(
   to: string,
   businessName: string,

--- a/functions/src/lifecycleEmails.ts
+++ b/functions/src/lifecycleEmails.ts
@@ -17,6 +17,11 @@
  * stale step. Copy source: website repo marketing/trial-lifecycle-emails.md
  * + the conversion-engine spec (cap-only: no deadlines anywhere).
  *
+ * The same run also dispatches the Path B nudge track (squareNudge.helpers):
+ *   - square_connected_idle: connected ≥5d, never collected
+ *   - square_no_paylink:     trial expired, sent quotes, never connected
+ * evaluated only when no lifecycle step is due, so one email/user/day holds.
+ *
  * SAFETY
  *   - Dry-run unless LIFECYCLE_LIVE=true in functions/.env. Dry runs log the
  *     exact would-send list.
@@ -35,12 +40,18 @@ import * as admin from 'firebase-admin';
 import { listAllAuthUsers } from './authUsers.helpers';
 import { isUnreachableEmail } from './reEngagement.helpers';
 import { lifecycleVerdict, midTrialRecap, SEND_ONCE_FIELD } from './lifecycleEmails.helpers';
+import { squareNudgeVerdict, NUDGE_SEND_ONCE_FIELD } from './squareNudge.helpers';
+import { isActivatingDoc } from './adminFunnel.helpers';
+import { docHasSquarePayment } from './eventFunnel.helpers';
+import { ts } from './subscription.helpers';
 import {
   sendTrialStartValueEmail,
   sendTrialSquarePitchEmail,
   sendTrialMidValueEmail,
   sendTrialEndingEmail,
   sendTrialEndedEmail,
+  sendSquareIdleNudgeEmail,
+  sendSquareNoPaylinkNudgeEmail,
   type FoundingSpots,
 } from './email';
 
@@ -62,6 +73,24 @@ export const trialLifecycleDaily = functions.pubsub
         founding = { spotsLeft: data.spotsLeft, cap: typeof data.cap === 'number' ? data.cap : 100 };
       }
     } catch {}
+
+    // One documents scan for the nudge track's durable signals: who has ever
+    // sent something, and who has ever collected a real Square payment.
+    const activatedUids = new Set<string>();
+    const squarePaidUids = new Set<string>();
+    try {
+      const docsSnap = await db.collectionGroup('documents').get();
+      for (const d of docsSnap.docs) {
+        const uid = d.ref.parent.parent?.id;
+        if (!uid) continue;
+        const data = d.data() as any;
+        if (isActivatingDoc(data)) activatedUids.add(uid);
+        if (docHasSquarePayment(data)) squarePaidUids.add(uid);
+      }
+    } catch (err: any) {
+      // Nudges degrade gracefully; lifecycle steps don't depend on the scan.
+      functions.logger.error('trialLifecycleDaily: documents scan failed', err?.message);
+    }
 
     const authUsers = await listAllAuthUsers(admin.auth());
     let processed = 0;
@@ -87,10 +116,26 @@ export const trialLifecycleDaily = functions.pubsub
         const verdict = lifecycleVerdict(subDoc.data(), stateDoc.data(), now, {
           hasSquareConnection: squareDoc.exists,
         });
-        if (!verdict.send) continue;
+        // Path B nudges only when no lifecycle step is due — one email per
+        // user per morning, lifecycle first.
+        const nudge = verdict.send
+          ? null
+          : squareNudgeVerdict(
+              {
+                sub: subDoc.data(),
+                emailState: stateDoc.data() as any,
+                hasSquareConnection: squareDoc.exists,
+                connectedAtMs: ts(squareDoc.data()?.connectedAt),
+                hasSquarePayment: squarePaidUids.has(userId),
+                hasSentDoc: activatedUids.has(userId),
+              },
+              now
+            );
+        const send = verdict.send ?? nudge;
+        if (!send) continue;
 
         if (!live) {
-          wouldSend.push(`${verdict.send} -> ${email} (${userId})`);
+          wouldSend.push(`${send} -> ${email} (${userId})`);
           continue;
         }
 
@@ -101,7 +146,7 @@ export const trialLifecycleDaily = functions.pubsub
         } catch {}
 
         let ok = false;
-        switch (verdict.send) {
+        switch (send) {
           case 'trial_start_value':
             ok = await sendTrialStartValueEmail(email, businessName, userId);
             break;
@@ -123,11 +168,20 @@ export const trialLifecycleDaily = functions.pubsub
           case 'trial_ended':
             ok = await sendTrialEndedEmail(email, businessName, userId, founding);
             break;
+          case 'square_connected_idle':
+            ok = await sendSquareIdleNudgeEmail(email, businessName, userId);
+            break;
+          case 'square_no_paylink':
+            ok = await sendSquareNoPaylinkNudgeEmail(email, businessName, userId);
+            break;
         }
 
         if (ok) {
+          const field = verdict.send
+            ? SEND_ONCE_FIELD[verdict.send]
+            : NUDGE_SEND_ONCE_FIELD[nudge!];
           await stateRef.set(
-            { [SEND_ONCE_FIELD[verdict.send]]: admin.firestore.FieldValue.serverTimestamp() },
+            { [field]: admin.firestore.FieldValue.serverTimestamp() },
             { merge: true }
           );
           sent++;

--- a/functions/src/squareNudge.helpers.test.ts
+++ b/functions/src/squareNudge.helpers.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+import {
+  IDLE_GRACE_MS,
+  NUDGE_SEND_ONCE_FIELD,
+  SquareNudgeInput,
+  squareNudgeVerdict,
+} from './squareNudge.helpers';
+import { TRIAL_MS } from './subscription.helpers';
+
+const DAY = 24 * 60 * 60 * 1000;
+const NOW = Date.parse('2026-07-16T00:00:00.000Z');
+const iso = (ms: number) => new Date(ms).toISOString();
+
+const trialingSub = { isPro: false, trialStartedAt: iso(NOW - 5 * DAY) };
+const expiredSub = { isPro: false, trialStartedAt: iso(NOW - TRIAL_MS - 2 * DAY) };
+const billedSub = { isPro: true, platform: 'ios', productId: 'quotemate_pro_yearly' };
+
+function input(over: Partial<SquareNudgeInput> = {}): SquareNudgeInput {
+  return {
+    sub: expiredSub,
+    emailState: undefined,
+    hasSquareConnection: false,
+    connectedAtMs: null,
+    hasSquarePayment: false,
+    hasSentDoc: false,
+    ...over,
+  };
+}
+
+describe('monetised users are never nudged to start collecting', () => {
+  const shapes: Array<[string, any]> = [
+    ['billed Pro', billedSub],
+    ['bare isPro flag', { isPro: true }],
+    ['admin_grant comp', { isPro: true, platform: 'admin_grant' }],
+  ];
+  for (const [label, sub] of shapes) {
+    it(`skips a ${label} in every stall state`, () => {
+      expect(
+        squareNudgeVerdict(input({ sub, hasSquareConnection: true, connectedAtMs: NOW - 30 * DAY }), NOW)
+      ).toBeNull();
+      expect(squareNudgeVerdict(input({ sub, hasSentDoc: true }), NOW)).toBeNull();
+    });
+  }
+
+  it('skips anyone who already collected a Square payment', () => {
+    expect(
+      squareNudgeVerdict(
+        input({ hasSquareConnection: true, connectedAtMs: NOW - 30 * DAY, hasSquarePayment: true }),
+        NOW
+      )
+    ).toBeNull();
+  });
+});
+
+describe('square_connected_idle', () => {
+  it('fires once the grace period passes, exactly at the boundary', () => {
+    const base = { hasSquareConnection: true };
+    expect(
+      squareNudgeVerdict(input({ ...base, connectedAtMs: NOW - IDLE_GRACE_MS + 1000 }), NOW)
+    ).toBeNull();
+    expect(
+      squareNudgeVerdict(input({ ...base, connectedAtMs: NOW - IDLE_GRACE_MS }), NOW)
+    ).toBe('square_connected_idle');
+  });
+
+  it('unknown connection age counts as old (pre-stamp docs)', () => {
+    expect(
+      squareNudgeVerdict(input({ hasSquareConnection: true, connectedAtMs: null }), NOW)
+    ).toBe('square_connected_idle');
+  });
+
+  it('applies to trialing users too (the pitch email skips connected users)', () => {
+    expect(
+      squareNudgeVerdict(
+        input({ sub: trialingSub, hasSquareConnection: true, connectedAtMs: NOW - 10 * DAY }),
+        NOW
+      )
+    ).toBe('square_connected_idle');
+  });
+
+  it('send-once', () => {
+    expect(
+      squareNudgeVerdict(
+        input({
+          hasSquareConnection: true,
+          connectedAtMs: NOW - 30 * DAY,
+          emailState: { squareIdleNudgeEmailAt: iso(NOW - DAY) },
+        }),
+        NOW
+      )
+    ).toBeNull();
+  });
+});
+
+describe('square_no_paylink', () => {
+  it('fires only for trial-expired users who sent quotes and never connected', () => {
+    expect(squareNudgeVerdict(input({ hasSentDoc: true }), NOW)).toBe('square_no_paylink');
+  });
+
+  it('never fires for trialing users — trial_square_pitch owns that window', () => {
+    expect(squareNudgeVerdict(input({ sub: trialingSub, hasSentDoc: true }), NOW)).toBeNull();
+  });
+
+  it('never fires for users who never sent anything (activation is a different problem)', () => {
+    expect(squareNudgeVerdict(input({ hasSentDoc: false }), NOW)).toBeNull();
+  });
+
+  it('connected users get the idle nudge path, not this one', () => {
+    expect(
+      squareNudgeVerdict(
+        input({ hasSentDoc: true, hasSquareConnection: true, connectedAtMs: NOW - 30 * DAY }),
+        NOW
+      )
+    ).toBe('square_connected_idle');
+  });
+
+  it('send-once', () => {
+    expect(
+      squareNudgeVerdict(
+        input({ hasSentDoc: true, emailState: { squareNoPaylinkNudgeEmailAt: iso(NOW - DAY) } }),
+        NOW
+      )
+    ).toBeNull();
+  });
+});
+
+describe('NUDGE_SEND_ONCE_FIELD', () => {
+  it('maps each nudge to a distinct emailState field', () => {
+    const fields = Object.values(NUDGE_SEND_ONCE_FIELD);
+    expect(new Set(fields).size).toBe(2);
+  });
+});

--- a/functions/src/squareNudge.helpers.ts
+++ b/functions/src/squareNudge.helpers.ts
@@ -1,0 +1,78 @@
+/**
+ * Pure decision logic for the Path B (Square) nudge track — sibling to
+ * lifecycleEmails.helpers.ts and dispatched by the same trialLifecycleDaily
+ * cron, AFTER the lifecycle verdict (so a user never gets two emails in one
+ * morning; lifecycle steps win).
+ *
+ * Two durable stall states, one send-once email each:
+ *
+ *   square_connected_idle  connected ≥5 days, never collected a payment —
+ *                          "your Pay Now button's ready, put it to work".
+ *   square_no_paylink      trial expired, sent quotes, never connected —
+ *                          the post-trial "turn on payments" reactivation.
+ *                          (Trialing users are NOT nudged here: the
+ *                          lifecycle's trial_square_pitch owns that window.)
+ *
+ * Hard guard: anyone already monetised — billed Pro, bare isPro flag,
+ * admin_grant comp, or ≥1 real Square payment — is never nudged to "start
+ * collecting".
+ */
+import { deriveSubFields } from './subscription.helpers';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+// Give a fresh connection this long to produce a payment naturally before
+// nudging — the opt-in send row and OAuth flow already point the way.
+export const IDLE_GRACE_MS = 5 * DAY_MS;
+
+export type SquareNudgeSend = 'square_connected_idle' | 'square_no_paylink';
+
+export interface SquareNudgeEmailState {
+  squareIdleNudgeEmailAt?: unknown;
+  squareNoPaylinkNudgeEmailAt?: unknown;
+}
+
+export const NUDGE_SEND_ONCE_FIELD: Record<SquareNudgeSend, keyof SquareNudgeEmailState> = {
+  square_connected_idle: 'squareIdleNudgeEmailAt',
+  square_no_paylink: 'squareNoPaylinkNudgeEmailAt',
+};
+
+export interface SquareNudgeInput {
+  /** Raw subscription doc (users/{uid}/profile/subscription), or null. */
+  sub: any;
+  emailState?: SquareNudgeEmailState;
+  hasSquareConnection: boolean;
+  /** ms epoch of the squareConnection doc's connectedAt; null = unknown. */
+  connectedAtMs: number | null;
+  /** ≥1 real (webhook-written) Square payment — already monetised. */
+  hasSquarePayment: boolean;
+  /** ≥1 activating (sent) document — see isActivatingDoc. */
+  hasSentDoc: boolean;
+}
+
+/** Which Square nudge (if any) this user should get right now. */
+export function squareNudgeVerdict(input: SquareNudgeInput, now: number): SquareNudgeSend | null {
+  const f = deriveSubFields(input.sub, now);
+
+  // Already monetised (either path) → never nudged to start collecting.
+  if (f.isPro || input.hasSquarePayment) return null;
+
+  if (input.hasSquareConnection) {
+    if (input.emailState?.squareIdleNudgeEmailAt) return null;
+    // Unknown connection age counts as old — those docs predate the
+    // connectedAt stamp, so the connection is anything but fresh.
+    const connectedAgo = input.connectedAtMs === null ? Infinity : now - input.connectedAtMs;
+    return connectedAgo >= IDLE_GRACE_MS ? 'square_connected_idle' : null;
+  }
+
+  // No connection: only the durable post-trial stall. Trialing users get
+  // trial_square_pitch from the lifecycle campaign instead of this.
+  if (
+    f.tier === 'trial_expired' &&
+    input.hasSentDoc &&
+    !input.emailState?.squareNoPaylinkNudgeEmailAt
+  ) {
+    return 'square_no_paylink';
+  }
+
+  return null;
+}


### PR DESCRIPTION
The two Path B stall-state nudges from the plan, folded into the existing `trialLifecycleDaily` run so the one-email-per-user-per-morning invariant holds (lifecycle steps take priority).

## The nudges (both send-once, email only — push still blocked on Expo tokens)
- **`square_connected_idle`** — connected ≥5 days, never collected: *"Your Pay Now button's ready — put it to work."* Points at the send-sheet "Get paid on this quote" row shipped in Step 4a. The spec's "most tradies who switch it on take their first payment inside a week" was **dropped as fabricated social proof** — we have one collector ever.
- **`square_no_paylink`** — trial expired, sent quotes during it, never connected: *"Your quotes are ready to get paid"*, with the honest kicker that connecting Square is also what re-enables sending on the free plan. Trialing users are excluded — `trial_square_pitch` owns that window, so no double-pitching.

## Guardrails
Any Pro signal (billed / bare `isPro` / `admin_grant`) or an existing Square payment → never nudged to "start collecting" — tested across every shape. Unknown `connectedAt` (pre-stamp docs) counts as old, not fresh.

## Mechanics
The cron gains one `collectionGroup('documents')` scan per run for the durable signals (activated uids + square-paid uids), reusing `isActivatingDoc` / `docHasSquarePayment`. Nudge scan failure degrades gracefully — lifecycle steps don't depend on it.

## Verified against live data
`lifecycleDryRun.ts` (updated to preview nudges): first morning = 13 lifecycle sends + **4 connected-idle + 8 no-paylink** — the one-time backlog drain, then send-once trickle. One email per user, zero Pro leakage.

## Deploy
`firebase deploy --only functions:trialLifecycleDaily` after merge.

## Tests
functions 360 passed (+14) · copy guard green over the new templates · tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)