### PR TITLE
Same-day cross-campaign email suppression (lifecycle ↔ onboarding drip)

### DIFF
--- a/functions/scripts/lifecycleDryRun.ts
+++ b/functions/scripts/lifecycleDryRun.ts
@@ -10,7 +10,7 @@
 import * as admin from 'firebase-admin';
 admin.initializeApp({ projectId: process.env.GOOGLE_CLOUD_PROJECT || 'hansendev' });
 
-import { lifecycleVerdict } from '../src/lifecycleEmails.helpers';
+import { lifecycleVerdict, suppressedByOnboardingDrip } from '../src/lifecycleEmails.helpers';
 import { squareNudgeVerdict } from '../src/squareNudge.helpers';
 import { isActivatingDoc } from '../src/adminFunnel.helpers';
 import { docHasSquarePayment } from '../src/eventFunnel.helpers';
@@ -45,6 +45,7 @@ import { isUnreachableEmail } from '../src/reEngagement.helpers';
       db.doc(`users/${u.uid}/settings/squareConnection`).get(),
     ]);
     if (!subDoc.exists) continue;
+    if (suppressedByOnboardingDrip(stateDoc.data(), now)) continue;
     const v = lifecycleVerdict(subDoc.data(), stateDoc.data() as any, now, {
       hasSquareConnection: squareDoc.exists,
     });

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -43,6 +43,7 @@ export * from './tickets';
 export { adminTrafficStats } from './analyticsTraffic';
 export { weeklyAnalyticsDigest, adminWeeklyDigest } from './analyticsDigest';
 export { trialLifecycleDaily } from './lifecycleEmails';
+import { sentConversionEmailWithin } from './lifecycleEmails.helpers';
 export { subscriptionAuditDaily, adminSubscriptionAudit } from './subscriptionAudit';
 export { dailyTrackingCheck } from './trackingAlarm';
 export { storeFunnelDaily } from './storeFunnel';
@@ -7645,6 +7646,12 @@ export const sendOnboardingDrip = functions.pubsub
           }
         }
 
+        // Same-day cross-campaign suppression: if the trial/nudge cron
+        // (trialLifecycleDaily, 07:30 Brisbane) already emailed this user
+        // this morning, sit today out. The tip isn't consumed — it goes out
+        // on the next eligible day instead.
+        if (sentConversionEmailWithin(data, now.getTime())) continue;
+
         totalEligible++;
 
         let businessName = '';
@@ -7655,7 +7662,15 @@ export const sendOnboardingDrip = functions.pubsub
 
         const sent = await sendOnboardingTipEmail(email, businessName, tipToSend, userId);
         if (sent) {
-          await emailStateDoc.ref.set({ lastOnboardingTip: tipToSend }, { merge: true });
+          await emailStateDoc.ref.set(
+            {
+              lastOnboardingTip: tipToSend,
+              // Timestamp lets trialLifecycleDaily suppress in the other
+              // direction — the tip number alone carries no send time.
+              lastOnboardingTipAt: admin.firestore.FieldValue.serverTimestamp(),
+            },
+            { merge: true }
+          );
           totalSent++;
         }
       } catch (error: any) {

--- a/functions/src/lifecycleEmails.helpers.test.ts
+++ b/functions/src/lifecycleEmails.helpers.test.ts
@@ -7,6 +7,10 @@ import {
   SEND_ONCE_FIELD,
   RECAP_MIN_QUOTES,
   RECAP_MIN_DOLLARS,
+  CROSS_CAMPAIGN_WINDOW_MS,
+  lastConversionSendMs,
+  sentConversionEmailWithin,
+  suppressedByOnboardingDrip,
 } from './lifecycleEmails.helpers';
 import { TRIAL_MS } from './subscription.helpers';
 
@@ -127,6 +131,48 @@ describe('trial_ended (T+0..3d)', () => {
   it('never backfills trials that expired before the window', () => {
     const daysAgo = (TRIAL_MS + ENDED_WINDOW_MS) / DAY + 1;
     expect(lifecycleVerdict(trialSub(daysAgo), undefined, NOW).send).toBeNull();
+  });
+});
+
+describe('same-day cross-campaign suppression', () => {
+  const HOUR = 60 * 60 * 1000;
+
+  it('window is 20h: catches the same-morning pair (1.5h), never the next-day one (22.5h)', () => {
+    expect(CROSS_CAMPAIGN_WINDOW_MS).toBe(20 * HOUR);
+    expect(CROSS_CAMPAIGN_WINDOW_MS).toBeGreaterThan(1.5 * HOUR);
+    expect(CROSS_CAMPAIGN_WINDOW_MS).toBeLessThan(22.5 * HOUR);
+  });
+
+  it('suppressedByOnboardingDrip: true within the window, false at/after it or when absent', () => {
+    expect(suppressedByOnboardingDrip({ lastOnboardingTipAt: NOW - 1.5 * HOUR }, NOW)).toBe(true);
+    expect(suppressedByOnboardingDrip({ lastOnboardingTipAt: NOW - CROSS_CAMPAIGN_WINDOW_MS }, NOW)).toBe(false);
+    expect(suppressedByOnboardingDrip({}, NOW)).toBe(false);
+    expect(suppressedByOnboardingDrip(undefined, NOW)).toBe(false);
+  });
+
+  it('handles every timestamp shape emailState can carry', () => {
+    const t = NOW - HOUR;
+    expect(suppressedByOnboardingDrip({ lastOnboardingTipAt: iso(t) }, NOW)).toBe(true);
+    expect(suppressedByOnboardingDrip({ lastOnboardingTipAt: { _seconds: t / 1000 } }, NOW)).toBe(true);
+    expect(suppressedByOnboardingDrip({ lastOnboardingTipAt: { toMillis: () => t } }, NOW)).toBe(true);
+  });
+
+  it('lastConversionSendMs takes the max across lifecycle AND nudge flags, ignoring drip fields', () => {
+    expect(lastConversionSendMs(undefined)).toBeNull();
+    expect(lastConversionSendMs({ lastOnboardingTipAt: NOW })).toBeNull();
+    expect(
+      lastConversionSendMs({
+        trialEndingEmailAt: NOW - 5 * HOUR,
+        squareIdleNudgeEmailAt: NOW - 2 * HOUR,
+        lastOnboardingTipAt: NOW, // other campaign — never counted
+      })
+    ).toBe(NOW - 2 * HOUR);
+  });
+
+  it('sentConversionEmailWithin drives the drip-side skip on any of the seven flags', () => {
+    expect(sentConversionEmailWithin({ squareNoPaylinkNudgeEmailAt: iso(NOW - HOUR) }, NOW)).toBe(true);
+    expect(sentConversionEmailWithin({ trialStartValueEmailAt: NOW - 21 * HOUR }, NOW)).toBe(false);
+    expect(sentConversionEmailWithin({}, NOW)).toBe(false);
   });
 });
 

--- a/functions/src/lifecycleEmails.helpers.ts
+++ b/functions/src/lifecycleEmails.helpers.ts
@@ -19,8 +19,9 @@
  * tip 5 (Tom's first-quote note, day 14 post-signup) owns it — anyone with a
  * trial has already built a quote, so the two campaigns can't overlap.
  */
-import { deriveSubFields, TRIAL_MS } from './subscription.helpers';
+import { deriveSubFields, TRIAL_MS, ts } from './subscription.helpers';
 import { isActivatingDoc } from './adminFunnel.helpers';
+import { NUDGE_SEND_ONCE_FIELD } from './squareNudge.helpers';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 // How long after trial expiry the trial_ended email may still go out. Going
@@ -53,6 +54,49 @@ export const SEND_ONCE_FIELD: Record<LifecycleSend, keyof LifecycleEmailState> =
   trial_ending: 'trialEndingEmailAt',
   trial_ended: 'trialEndedEmailAt',
 };
+
+/**
+ * Same-day cross-campaign suppression window. The two marketing campaigns —
+ * this trial/nudge cron (07:30 Brisbane) and the signup-anchored onboarding
+ * drip (09:00 Sydney) — must never both email one user on the same morning.
+ * 20h suppresses the same-day pair (1.5h apart) but never the next-day one
+ * (22.5h apart). Steps deferred by suppression follow their normal window
+ * rules — if the window passes meanwhile, the step is skipped, not sent
+ * stale; fewer emails beats more.
+ */
+export const CROSS_CAMPAIGN_WINDOW_MS = 20 * 60 * 60 * 1000;
+
+/** ms epoch of the most recent conversion-campaign send, or null. */
+export function lastConversionSendMs(emailState: Record<string, unknown> | undefined): number | null {
+  if (!emailState) return null;
+  const fields = [...Object.values(SEND_ONCE_FIELD), ...Object.values(NUDGE_SEND_ONCE_FIELD)];
+  let latest: number | null = null;
+  for (const field of fields) {
+    const at = ts(emailState[field]);
+    if (at !== null && (latest === null || at > latest)) latest = at;
+  }
+  return latest;
+}
+
+/** Drip-side check: did the conversion campaign email this user today? */
+export function sentConversionEmailWithin(
+  emailState: Record<string, unknown> | undefined,
+  now: number,
+  windowMs: number = CROSS_CAMPAIGN_WINDOW_MS
+): boolean {
+  const last = lastConversionSendMs(emailState);
+  return last !== null && now - last < windowMs;
+}
+
+/** Conversion-side check: did the onboarding drip email this user today? */
+export function suppressedByOnboardingDrip(
+  emailState: { lastOnboardingTipAt?: unknown } | undefined,
+  now: number,
+  windowMs: number = CROSS_CAMPAIGN_WINDOW_MS
+): boolean {
+  const at = ts(emailState?.lastOnboardingTipAt);
+  return at !== null && now - at < windowMs;
+}
 
 export interface LifecycleDecision {
   send: LifecycleSend | null;

--- a/functions/src/lifecycleEmails.ts
+++ b/functions/src/lifecycleEmails.ts
@@ -39,7 +39,12 @@ import * as functions from 'firebase-functions';
 import * as admin from 'firebase-admin';
 import { listAllAuthUsers } from './authUsers.helpers';
 import { isUnreachableEmail } from './reEngagement.helpers';
-import { lifecycleVerdict, midTrialRecap, SEND_ONCE_FIELD } from './lifecycleEmails.helpers';
+import {
+  lifecycleVerdict,
+  midTrialRecap,
+  SEND_ONCE_FIELD,
+  suppressedByOnboardingDrip,
+} from './lifecycleEmails.helpers';
 import { squareNudgeVerdict, NUDGE_SEND_ONCE_FIELD } from './squareNudge.helpers';
 import { isActivatingDoc } from './adminFunnel.helpers';
 import { docHasSquarePayment } from './eventFunnel.helpers';
@@ -113,7 +118,14 @@ export const trialLifecycleDaily = functions.pubsub
         if (!subDoc.exists) continue;
         processed++;
 
-        const verdict = lifecycleVerdict(subDoc.data(), stateDoc.data(), now, {
+        const emailState = stateDoc.data();
+
+        // Same-day cross-campaign suppression: if the onboarding drip
+        // emailed this user within the window, sit today out. Steps whose
+        // window survives fire tomorrow; ones that don't are skipped.
+        if (suppressedByOnboardingDrip(emailState, now)) continue;
+
+        const verdict = lifecycleVerdict(subDoc.data(), emailState, now, {
           hasSquareConnection: squareDoc.exists,
         });
         // Path B nudges only when no lifecycle step is due — one email per
@@ -123,7 +135,7 @@ export const trialLifecycleDaily = functions.pubsub
           : squareNudgeVerdict(
               {
                 sub: subDoc.data(),
-                emailState: stateDoc.data() as any,
+                emailState: emailState as any,
                 hasSquareConnection: squareDoc.exists,
                 connectedAtMs: ts(squareDoc.data()?.connectedAt),
                 hasSquarePayment: squarePaidUids.has(userId),


### PR DESCRIPTION
Closes the one known volume gap from the Step 4b review: the trial/nudge cron (07:30 Brisbane) and the signup-anchored onboarding drip (09:00 Sydney) could both email the same user on the same morning.

## How it works
One shared window, `CROSS_CAMPAIGN_WINDOW_MS = 20h` — wide enough to catch the same-morning pair (1.5h apart), narrow enough to never block the next-day run (22.5h apart). Guard-tested against both gaps.

- **Drip side**: skips a user when any of the seven conversion-campaign timestamps (5 lifecycle + 2 Square nudge flags) is fresher than the window. The tip is **not consumed** — it sends on the next eligible day.
- **Lifecycle/nudge side**: skips when `lastOnboardingTipAt` is fresh. Deferred steps keep their normal window rules — if a window passes during deferral the step is skipped, not sent stale (fewer emails beats more).
- The drip previously stored only the tip *number*; it now also stamps `lastOnboardingTipAt` on successful sends. That direction of suppression takes effect from the first tip sent after deploy; the other direction works immediately (lifecycle flags were already timestamps).
- `lifecycleDryRun.ts` applies the suppression, so morning previews stay faithful.

Deliberately out of scope: the transactional welcome email and event-triggered sends (quote follow-up, draft/ready nudges) — this covers the two *scheduled marketing* campaigns, which are the same-morning repeat offenders.

## Verified
functions 365 passed (+5) · tsc clean · live dry-run unchanged (correct — no drip stamp exists yet, and today's lifecycle list had no drip collisions).

## Deploy
`firebase deploy --only functions:trialLifecycleDaily,functions:sendOnboardingDrip`

🤖 Generated with [Claude Code](https://claude.com/claude-code)