### PR TITLE
feat(conversion): behavioural-state next-best-action model (Intervention 0 core)

### DIFF
--- a/CONVERSION_BUILD_PROMPT.md
+++ b/CONVERSION_BUILD_PROMPT.md
@@ -1,5 +1,7 @@
 # BUILD: QuoteMate trial→monetised conversion engine
 
+> ⚠️ **SUPERSEDED — do not execute.** Steps 1–4 shipped 2026-07-16 as PRs #43–#48 (cap-only founding model; the 72h grace window below was dropped). Parts of the copy now violate the current plan: no "Pro pays for itself" claims, no push-dependent sends (all tokens are Expo; FCM delivery is broken), and the day-7 email leads with payments collected, not face value. Current work: `CONVERSION_UX_BUILD_PROMPT.md` + `../QuoteMateAppWebsite/marketing/high-intent-conversion-plan.md` (v2). Kept for historical reference only.
+
 You are implementing a conversion system for QuoteMate (React Native/Expo app +
 Firebase Functions backend + Next.js admin site at ../QuoteMateAppWebsite).
 The full technical spec — exact files, line numbers, helpers to reuse, and per-file

--- a/CONVERSION_UX_BUILD_PROMPT.md
+++ b/CONVERSION_UX_BUILD_PROMPT.md
@@ -6,7 +6,7 @@ You are working in the QuoteMate app repo (Expo/React Native app + Firebase func
 
 ## Context you should not rediscover
 
-- North star: **20% of trials monetised** (billed Pro OR ≥1 real Square payment; `payments[].method==='square'` webhook-written, manual cash never counts). Live baseline 2026-07-16: 146 trials, 2.05% monetised. 5% gates marketing spend.
+- North star: **20% of trials monetised** (billed Pro OR ≥1 real Square payment; a payment counts when `payments[].method==='square'` or it carries a `squarePaymentId` — i.e. webhook-written, matching `docHasSquarePayment` in `functions/src/eventFunnel.helpers.ts`; manual cash never counts). Live baseline 2026-07-16: 146 trials, 2.05% monetised. 5% gates marketing spend.
 - Already shipped 2026-07-16 (PRs #43–#48) — **do not rebuild, extend**: event funnel (`src/services/analyticsService.ts` → `users/{uid}/events`; `functions/src/eventFunnel.helpers.ts` with `furthestStage`; `aggregateEventFunnel` cron), founding cap (`functions/src/foundingOffer.ts`, `config/foundingOffer`, cap-only, fail-closed display), 5-step lifecycle emails (`functions/src/lifecycleEmails.ts` + helpers, LIVE, dry-run via `functions/scripts/lifecycleDryRun.ts`), Square trial opt-in (`src/utils/quoteDeliveryGuard.ts`, `src/components/SendDocumentDialog.tsx`), Square nudges (`functions/src/squareNudge.helpers.ts`), cross-campaign email suppression (20h window).
 - Key surfaces: `src/screens/PaywallScreen.tsx`, `src/components/TrialBanner.tsx` (dashboard shows it only in the final 3 days — deliberate), `src/screens/DashboardScreen.tsx`, `src/components/SendGateModal.tsx`, `src/components/TakePaymentSheet.tsx`, `src/components/CancellationReasonModal.tsx`.
 - Trial: 14 days, starts on first quote (`trialStartedAt`), expiry recomputed live from `trialStartedAt + TRIAL_MS`; enforcement is the send gate only; creation stays unlimited on Free.
@@ -34,6 +34,10 @@ The plan forbids new conversion pressure while these are open. **Check current s
 - PAY-07 Stripe checkout accepts arbitrary price IDs
 - PAY-08 duplicate Stripe customers / incomplete subscriptions
 - EMAIL-01 documents marked sent before Brevo accepts; EMAIL-05 suppressed recipients retried; Brevo free-plan credits nearly exhausted
+
+## Phase 0.5 — founding-offer definition work (Intervention 6)
+
+The plan sequences this second — right after the blockers — because it protects live paywall/website copy. Follow Intervention 6 in the plan: the shipped model stays cap-only (no per-user deadline); enforcement is a manual price rise when the 100th billed subscriber lands; audit every founding claim currently rendered (paywall, website) against `config/foundingOffer` and the plan's copy rules, and fix any that overpromise.
 
 ## Phase 1 — behavioural-state selector + pressure budget + exposure events (Intervention 0 + 8)
 
@@ -69,7 +73,7 @@ The orchestration layer everything else hangs off. One PR.
 ## Phase 6 — Square-first moments + cancellation save (Interventions 7 + 5)
 
 - Accepted-quote in-app view: "Take a deposit" primary (reuse `TakePaymentSheet`/`StickyJobActionBar`; the hosted acceptance page already mints deposit links).
-- Implementation-intention prompts wiring existing settings: "When they accept, request a 20% deposit?" (`requireDeposit`/`depositPercentage`); "Use this payment setting on future invoices?" after first payment.
+- Implementation-intention prompts wiring existing settings: "When they accept, request a 20% deposit?" — the settings-level fields are `requireDepositByDefault`/`defaultDepositPercentage` (`src/types/index.ts`); `requireDeposit`/`depositPercentage` are the per-quote fields. "Use this payment setting on future invoices?" after first payment.
 - Cancellation (web/Stripe only): reason-routed save treatments per the plan; cancellation always completes in the same flow.
 
 ## Working style

--- a/functions/src/crossPackage.guard.test.ts
+++ b/functions/src/crossPackage.guard.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { SUB_PRICE_AUD, TRIAL_DAYS, TRIAL_MS } from './subscription.helpers';
+import { ENDING_THRESHOLD_DAYS } from './lifecycleEmails.helpers';
 
 /**
  * Cross-package mirror guards. TRIAL_DAYS and the charged prices are
@@ -21,5 +22,11 @@ describe('trial length mirror (src/utils/trialConfig.ts TRIAL_DAYS)', () => {
 describe('price mirror (app ACTUAL_PRICE_AUD + live store/Stripe products)', () => {
   it('charged prices are $49/mo, $328/yr AUD', () => {
     expect(SUB_PRICE_AUD).toEqual({ monthly: 49, yearly: 328 });
+  });
+});
+
+describe('trial-ending threshold mirror (app src/utils/nextBestAction.ts NBA_ENDING_THRESHOLD_DAYS)', () => {
+  it('is 3 days — the in-app continuity_choice state mirrors when trial_ending fires', () => {
+    expect(ENDING_THRESHOLD_DAYS).toBe(3);
   });
 });

--- a/src/config/crossPackageMirrors.guard.test.ts
+++ b/src/config/crossPackageMirrors.guard.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { TRIAL_DAYS, TRIAL_MS } from '../utils/trialConfig';
+import { NBA_ENDING_THRESHOLD_DAYS } from '../utils/nextBestAction';
 import { ACTUAL_PRICE_AUD, REGULAR_PRICE_AUD } from './pricingConfig';
 
 /**
@@ -15,6 +16,12 @@ describe('trial length mirror (functions/src/subscription.helpers.ts TRIAL_DAYS)
   it('is 14 days', () => {
     expect(TRIAL_DAYS).toBe(14);
     expect(TRIAL_MS).toBe(14 * 24 * 60 * 60 * 1000);
+  });
+});
+
+describe('trial-ending threshold mirror (functions/src/lifecycleEmails.helpers.ts ENDING_THRESHOLD_DAYS)', () => {
+  it('is 3 days, so the in-app continuity_choice state flips the same day the trial_ending email fires', () => {
+    expect(NBA_ENDING_THRESHOLD_DAYS).toBe(3);
   });
 });
 

--- a/src/utils/nextBestAction.test.ts
+++ b/src/utils/nextBestAction.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it } from 'vitest';
+import {
+  nextBestAction,
+  docHasRealSquarePayment,
+  NBA_ENDING_THRESHOLD_DAYS,
+  REPEAT_PRO_USE_MIN,
+  type NextBestActionInput,
+  type NextBestActionDoc,
+} from './nextBestAction';
+import { TRIAL_MS } from './trialConfig';
+
+const NOW = 1_800_000_000_000; // fixed, injected — the model never reads the clock
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const doc = (stage: NextBestActionDoc['stage'], payments?: NextBestActionDoc['payments']): NextBestActionDoc => ({
+  stage,
+  payments,
+});
+
+const base = (over: Partial<NextBestActionInput> = {}): NextBestActionInput => ({
+  plan: 'trial',
+  trialStartedAt: NOW - 2 * DAY_MS, // day 2 — mid-trial by default
+  docs: [],
+  hasSquareConnection: false,
+  proFeatureUses: 0,
+  happyOnFree: false,
+  now: NOW,
+  ...over,
+});
+
+describe('state table (high-intent-conversion-plan.md Intervention 0)', () => {
+  it('no documents → create_first_quote, and never with pricing', () => {
+    const r = nextBestAction(base());
+    expect(r.key).toBe('create_first_quote');
+    expect(r.sellingAllowed).toBe(false);
+  });
+
+  it('draft exists, nothing ever sent → send_first_quote, no pricing', () => {
+    const r = nextBestAction(base({ docs: [doc('draft')] }));
+    expect(r.key).toBe('send_first_quote');
+    expect(r.sellingAllowed).toBe(false);
+  });
+
+  it('sent quote awaiting a response → follow_up, not a generic upgrade', () => {
+    const r = nextBestAction(base({ docs: [doc('quote_sent')] }));
+    expect(r.key).toBe('follow_up');
+    expect(r.sellingAllowed).toBe(false);
+  });
+
+  it('accepted quote with no real payment → take_deposit', () => {
+    const r = nextBestAction(base({ docs: [doc('quote_accepted')] }));
+    expect(r.key).toBe('take_deposit');
+    expect(r.sellingAllowed).toBe(false);
+    expect(r.needsSquareConnect).toBe(true);
+  });
+
+  it('take_deposit does not ask for a Square connect that already exists', () => {
+    const r = nextBestAction(base({ docs: [doc('invoice_sent')], hasSquareConnection: true }));
+    expect(r.key).toBe('take_deposit');
+    expect(r.needsSquareConnect).toBe(false);
+  });
+
+  it('trial ending (≤3 days) → continuity_choice with pricing allowed', () => {
+    const r = nextBestAction(
+      base({
+        trialStartedAt: NOW - (TRIAL_MS - NBA_ENDING_THRESHOLD_DAYS * DAY_MS),
+        docs: [doc('paid', [{ method: 'square', amount: 500, paidAt: NOW - DAY_MS }])],
+      })
+    );
+    expect(r.key).toBe('continuity_choice');
+    expect(r.sellingAllowed).toBe(true);
+    expect(r.trialDaysRemaining).toBe(NBA_ENDING_THRESHOLD_DAYS);
+  });
+
+  it('repeated Pro-feature use mid-trial → keep_pro_tools', () => {
+    const r = nextBestAction(
+      base({
+        proFeatureUses: REPEAT_PRO_USE_MIN,
+        docs: [doc('quote_rejected')], // sent-tier, nothing collectable or awaiting response
+      })
+    );
+    expect(r.key).toBe('keep_pro_tools');
+    expect(r.sellingAllowed).toBe(true);
+  });
+
+  it('free user with meaningful Square volume → fee_comparison on real fees', () => {
+    // $1,000 collected in-window → $7/mo saving, above the $5 claim threshold.
+    const r = nextBestAction(
+      base({
+        plan: 'free',
+        trialStartedAt: NOW - TRIAL_MS - 5 * DAY_MS,
+        hasSquareConnection: true,
+        docs: [doc('paid', [{ method: 'square', amount: 1000, paidAt: NOW - DAY_MS }])],
+      })
+    );
+    expect(r.key).toBe('fee_comparison');
+    expect(r.sellingAllowed).toBe(true);
+  });
+
+  it('free user with thin volume gets complete_via_square, never a thin fee claim', () => {
+    const r = nextBestAction(
+      base({
+        plan: 'free',
+        trialStartedAt: NOW - TRIAL_MS - 5 * DAY_MS,
+        hasSquareConnection: true,
+        docs: [doc('paid', [{ method: 'square', amount: 100, paidAt: NOW - DAY_MS }])],
+      })
+    );
+    expect(r.key).toBe('complete_via_square');
+    expect(r.sellingAllowed).toBe(false);
+  });
+});
+
+describe('precedence: money and activation beat every subscription ask', () => {
+  it('take_deposit outranks continuity_choice even on the last trial day', () => {
+    const r = nextBestAction(
+      base({
+        trialStartedAt: NOW - (TRIAL_MS - 1 * DAY_MS),
+        docs: [doc('quote_accepted')],
+      })
+    );
+    expect(r.key).toBe('take_deposit');
+  });
+
+  it('manual cash on an accepted quote does NOT settle the money moment', () => {
+    const r = nextBestAction(
+      base({ docs: [doc('quote_accepted', [{ method: 'cash', amount: 500, paidAt: NOW }])] })
+    );
+    expect(r.key).toBe('take_deposit');
+  });
+
+  it('a real Square payment settles it — accepted+paid doc stops demanding a deposit', () => {
+    const r = nextBestAction(
+      base({ docs: [doc('partially_paid', [{ method: 'square', amount: 500, paidAt: NOW - DAY_MS }])] })
+    );
+    expect(r.key).not.toBe('take_deposit');
+  });
+
+  it('activation outranks keep_pro_tools: heavy Pro use with only drafts still says send it', () => {
+    const r = nextBestAction(base({ proFeatureUses: 5, docs: [doc('draft')] }));
+    expect(r.key).toBe('send_first_quote');
+  });
+});
+
+describe('suppression: Pro users and happy-on-Free never get generic asks', () => {
+  it('Pro user with settled jobs → none', () => {
+    const r = nextBestAction(
+      base({
+        plan: 'pro',
+        proFeatureUses: 10,
+        docs: [doc('paid', [{ method: 'square', amount: 900, paidAt: NOW - DAY_MS }])],
+      })
+    );
+    expect(r.key).toBe('none');
+    expect(r.sellingAllowed).toBe(false);
+  });
+
+  it('Pro user still gets the money moment', () => {
+    const r = nextBestAction(base({ plan: 'pro', docs: [doc('invoice_sent')] }));
+    expect(r.key).toBe('take_deposit');
+  });
+
+  it('happy on Free suppresses fee_comparison and routes to the job', () => {
+    const r = nextBestAction(
+      base({
+        plan: 'free',
+        happyOnFree: true,
+        hasSquareConnection: true,
+        trialStartedAt: NOW - TRIAL_MS - 5 * DAY_MS,
+        docs: [doc('paid', [{ method: 'square', amount: 5000, paidAt: NOW - DAY_MS }])],
+      })
+    );
+    expect(r.key).toBe('complete_via_square');
+    expect(r.sellingAllowed).toBe(false);
+  });
+
+  it('happy on Free during a live trial still gets follow_up, never continuity', () => {
+    const r = nextBestAction(
+      base({
+        happyOnFree: true,
+        trialStartedAt: NOW - (TRIAL_MS - 1 * DAY_MS),
+        docs: [doc('quote_sent')],
+      })
+    );
+    expect(r.key).toBe('follow_up');
+  });
+});
+
+describe('trialDaysRemaining', () => {
+  it('is null when not trialing and 0-floored at expiry boundary', () => {
+    expect(nextBestAction(base({ plan: 'free', trialStartedAt: null })).trialDaysRemaining).toBeNull();
+    const r = nextBestAction(base({ trialStartedAt: NOW - TRIAL_MS }));
+    expect(r.trialDaysRemaining).toBe(0);
+  });
+
+  it('uses ceil like deriveSubFields: 2.5 days left reports 3', () => {
+    const r = nextBestAction(base({ trialStartedAt: NOW - (TRIAL_MS - 2.5 * DAY_MS) }));
+    expect(r.trialDaysRemaining).toBe(3);
+  });
+});
+
+describe('docHasRealSquarePayment mirror (functions/src/eventFunnel.helpers.ts docHasSquarePayment)', () => {
+  it('matches the server rule: method square OR squarePaymentId; cash/empty never', () => {
+    expect(docHasRealSquarePayment(doc('paid', [{ method: 'square' }]))).toBe(true);
+    expect(docHasRealSquarePayment(doc('paid', [{ squarePaymentId: 'sq_123' }]))).toBe(true);
+    expect(docHasRealSquarePayment(doc('paid', [{ method: 'cash' }]))).toBe(false);
+    expect(docHasRealSquarePayment(doc('paid', []))).toBe(false);
+    expect(docHasRealSquarePayment(doc('paid'))).toBe(false);
+    expect(docHasRealSquarePayment(null)).toBe(false);
+  });
+});

--- a/src/utils/nextBestAction.ts
+++ b/src/utils/nextBestAction.ts
@@ -1,0 +1,175 @@
+/**
+ * The behavioural-state conversion model: ONE primary commercial action per
+ * user, selected from durable job state — never from trial day alone.
+ *
+ * Spec: QuoteMateAppWebsite/marketing/high-intent-conversion-plan.md
+ * (Intervention 0). Core rules encoded here:
+ *   - One primary commercial action at a time; Square (Path B) and Pro
+ *     (Path A) never compete as primary CTAs.
+ *   - A money moment (deposit/payment waiting to be collected) always beats
+ *     a subscription ask — a free tradie collecting via Square IS revenue.
+ *   - No subscription pricing before the user reaches a meaningful outcome
+ *     (`sellingAllowed` is false on activation states); the exception —
+ *     user-initiated opens of Pro features — is the caller's context, not
+ *     this model's.
+ *   - "Happy on Free" suppresses every generic Pro ask; job actions remain.
+ *
+ * Mirrors the server's furthestStage classifier semantics
+ * (functions/src/eventFunnel.helpers.ts): durable document/payment state
+ * always wins over anything lossy. Pure and `now`-injectable like
+ * followUpNudge.ts — no store, no Firestore, no Date.now().
+ */
+import type { DocumentStage } from '../types/document';
+import { TRIAL_MS } from './trialConfig';
+import { monthlyFeeSaving, FEE_SAVING_CLAIM_THRESHOLD_AUD, squareCollectedLast30d } from '../config/pricingConfig';
+
+export type EffectivePlan = 'trial' | 'free' | 'pro';
+
+export type NextBestActionKey =
+  /** Accepted quote / sent invoice with no real Square money yet — collect it. */
+  | 'take_deposit'
+  /** No documents at all — get the first quote drafted. */
+  | 'create_first_quote'
+  /** Draft(s) exist but nothing has ever gone to a customer — send it. */
+  | 'send_first_quote'
+  /** Trial in its final days — informed keep-Pro / go-Free choice. */
+  | 'continuity_choice'
+  /** Free user with real Square volume — Pro pitched on their actual fees. */
+  | 'fee_comparison'
+  /** Trial user repeatedly using Pro-only tools — keep them with Pro. */
+  | 'keep_pro_tools'
+  /** Sent quote(s) awaiting a customer response — follow up. */
+  | 'follow_up'
+  /** Settled on Free — help them run jobs and get paid through Square. */
+  | 'complete_via_square'
+  /** Nothing to ask (e.g. Pro user, all jobs settled). */
+  | 'none';
+
+/**
+ * Mirror of ENDING_THRESHOLD_DAYS in functions/src/lifecycleEmails.helpers.ts
+ * so the in-app "trial ending" state flips the same day the trial_ending
+ * email fires. Pinned by crossPackageMirrors.guard.test.ts — update both
+ * sides together.
+ */
+export const NBA_ENDING_THRESHOLD_DAYS = 3;
+
+/** Pro-only feature uses in the trial before "keep these tools" outranks generic states. */
+export const REPEAT_PRO_USE_MIN = 2;
+
+/** Stages where the customer owes money and no further sending is needed first. */
+const AWAITING_PAYMENT_STAGES: ReadonlyArray<DocumentStage> = [
+  'quote_accepted',
+  'invoice_sent',
+  'partially_paid',
+];
+
+/** Stages proving a document reached a customer at some point. */
+const SENT_TIER_STAGES: ReadonlyArray<DocumentStage> = [
+  'quote_sent',
+  'quote_rejected',
+  'quote_accepted',
+  'invoice_sent',
+  'partially_paid',
+  'paid',
+];
+
+export interface NextBestActionDoc {
+  stage: DocumentStage;
+  payments?: Array<{ amount?: number; paidAt?: number; method?: string; squarePaymentId?: string }>;
+}
+
+/**
+ * Mirror of docHasSquarePayment in functions/src/eventFunnel.helpers.ts:
+ * only webhook-written Square money counts as collected — manual cash/bank
+ * records never monetise QuoteMate and never settle a "take_deposit" state.
+ */
+export function docHasRealSquarePayment(doc: NextBestActionDoc | null | undefined): boolean {
+  const payments = doc?.payments;
+  if (!Array.isArray(payments)) return false;
+  return payments.some((p) => p && (p.method === 'square' || typeof p.squarePaymentId === 'string'));
+}
+
+export interface NextBestActionInput {
+  /** From useStore.getEffectivePlan() — expiry already resolved to 'free'. */
+  plan: EffectivePlan;
+  /** trialStartedAt in ms epoch, or null if the trial never started. */
+  trialStartedAt: number | null;
+  /** Minimal projection of the user's documents (durable truth). */
+  docs: NextBestActionDoc[];
+  /** users/{uid}/settings/squareConnection exists. */
+  hasSquareConnection: boolean;
+  /** Pro-only feature opens this trial (premium template, logo, …). */
+  proFeatureUses: number;
+  /** User chose "happy on Free" within the suppression window (promptState). */
+  happyOnFree: boolean;
+  /** Injected clock — never Date.now() inside the model. */
+  now: number;
+}
+
+export interface NextBestAction {
+  key: NextBestActionKey;
+  /**
+   * Whether subscription pricing may accompany this action. False on
+   * activation and money-moment states: no selling before a real outcome,
+   * and never against a pending payment.
+   */
+  sellingAllowed: boolean;
+  /** Whole days of trial left (ceil, matches deriveSubFields), null if not trialing. */
+  trialDaysRemaining: number | null;
+  /** True when the primary action needs Square connected first (same CTA, extra step). */
+  needsSquareConnect: boolean;
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export function nextBestAction(input: NextBestActionInput): NextBestAction {
+  const trialing = input.plan === 'trial' && input.trialStartedAt !== null;
+  const trialDaysRemaining = trialing
+    ? Math.max(0, Math.ceil((input.trialStartedAt! + TRIAL_MS - input.now) / DAY_MS))
+    : null;
+
+  const base = { trialDaysRemaining, needsSquareConnect: false };
+  const needsConnect = !input.hasSquareConnection;
+
+  const awaitingPayment = input.docs.some(
+    (d) => AWAITING_PAYMENT_STAGES.includes(d.stage) && !docHasRealSquarePayment(d)
+  );
+  const hasAnyDoc = input.docs.length > 0;
+  const hasSentDoc = input.docs.some((d) => SENT_TIER_STAGES.includes(d.stage));
+  const awaitingResponse = input.docs.some((d) => d.stage === 'quote_sent');
+
+  // 1. Money moment: a collectable job always beats any subscription ask.
+  if (awaitingPayment) {
+    return { key: 'take_deposit', sellingAllowed: false, ...base, needsSquareConnect: needsConnect };
+  }
+
+  // 2–3. Activation: no pricing before the first real outcome.
+  if (!hasAnyDoc) return { key: 'create_first_quote', sellingAllowed: false, ...base };
+  if (!hasSentDoc) return { key: 'send_first_quote', sellingAllowed: false, ...base };
+
+  // 4–6. Commercial states — never for Pro, and suppressed by "happy on Free".
+  if (input.plan !== 'pro' && !input.happyOnFree) {
+    if (trialing && trialDaysRemaining !== null && trialDaysRemaining <= NBA_ENDING_THRESHOLD_DAYS) {
+      return { key: 'continuity_choice', sellingAllowed: true, ...base };
+    }
+    if (
+      input.plan === 'free' &&
+      monthlyFeeSaving(squareCollectedLast30d(input.docs, input.now)) >= FEE_SAVING_CLAIM_THRESHOLD_AUD
+    ) {
+      return { key: 'fee_comparison', sellingAllowed: true, ...base };
+    }
+    if (trialing && input.proFeatureUses >= REPEAT_PRO_USE_MIN) {
+      return { key: 'keep_pro_tools', sellingAllowed: true, ...base };
+    }
+  }
+
+  // 7. Job momentum: sent quotes waiting on a customer.
+  if (awaitingResponse) return { key: 'follow_up', sellingAllowed: false, ...base };
+
+  // 8. Settled on Free: the business model is Square collection, not nagging.
+  if (input.plan === 'free') {
+    return { key: 'complete_via_square', sellingAllowed: false, ...base, needsSquareConnect: needsConnect };
+  }
+
+  return { key: 'none', sellingAllowed: false, ...base };
+}


### PR DESCRIPTION
## What

The core of Intervention 0 from `QuoteMateAppWebsite/marketing/high-intent-conversion-plan.md` (v2): a pure, `now`-injectable `nextBestAction(state)` selector that picks **one primary commercial action** per user from durable job state — never from trial day alone.

- **State table encoded:** create_first_quote → send_first_quote → take_deposit → continuity_choice → fee_comparison → keep_pro_tools → follow_up → complete_via_square → none.
- **Precedence rules:** a collectable money moment always beats any subscription ask; activation states never show pricing (`sellingAllowed: false`); Square and Pro never compete as primary CTAs.
- **Suppression:** Pro users and happy-on-Free users get job actions only, never generic upgrade asks.
- **Mirrors, both guard-pinned:** `docHasRealSquarePayment` mirrors `functions/src/eventFunnel.helpers.ts` `docHasSquarePayment` (manual cash never counts); `NBA_ENDING_THRESHOLD_DAYS` mirrors lifecycle `ENDING_THRESHOLD_DAYS` so the in-app trial-ending state flips the same day the trial_ending email fires. Pins added to `crossPackageMirrors.guard.test.ts` (app) and `crossPackage.guard.test.ts` (functions).
- Reuses `monthlyFeeSaving`/`squareCollectedLast30d`/`FEE_SAVING_CLAIM_THRESHOLD_AUD` from `pricingConfig.ts` for the fee_comparison state — real volume only, thin data claims nothing.

## What this deliberately does NOT include

No UI consumers yet — the dashboard job-progress card, pressure budget (`promptState`), and exposure events are the rest of Phase 1 in `CONVERSION_UX_BUILD_PROMPT.md` and build on this selector.

## Tests

- 24 new tests in `nextBestAction.test.ts`: every state in the plan's table, precedence (deposit beats last-day continuity; cash never settles a money moment), suppression (Pro / happy-on-Free), ceil day-math boundary, and the Square-payment mirror fixtures.
- Full app suite: 876/876 passing; functions guard: passing; tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)