### PR TITLE
fix(ios): upgrade expo-speech-recognition 3.1.0→3.1.3 (AVFAudio crash REACT-NATIVE-3)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "expo-notifications": "^0.31.5",
         "expo-print": "~14.1.4",
         "expo-sharing": "~13.1.5",
-        "expo-speech-recognition": "~3.1.0",
+        "expo-speech-recognition": "~3.1.3",
         "expo-status-bar": "~2.2.3",
         "expo-store-review": "~8.1.5",
         "expo-updates": "~0.28.18",
@@ -7271,9 +7271,9 @@
       }
     },
     "node_modules/expo-speech-recognition": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/expo-speech-recognition/-/expo-speech-recognition-3.1.0.tgz",
-      "integrity": "sha512-DgCvY42hbhGDxDKJD0WjgjZboPOXY58JNNQ+zaBQmB+3M2PR2tS8ZTP/yIwslbe30Cnw8yf5JBxrqkZFiLmewQ==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/expo-speech-recognition/-/expo-speech-recognition-3.1.3.tgz",
+      "integrity": "sha512-vluXqggfY2AJcazYITvnV6YSE2rVe5SId5TpdjMC/m6JPUgHCOODrcHJtAQF6OUYl4f2T7oZSceGw6fJCC86Xw==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "expo-notifications": "^0.31.5",
     "expo-print": "~14.1.4",
     "expo-sharing": "~13.1.5",
-    "expo-speech-recognition": "~3.1.0",
+    "expo-speech-recognition": "~3.1.3",
     "expo-status-bar": "~2.2.3",
     "expo-store-review": "~8.1.5",
     "expo-updates": "~0.28.18",


### PR DESCRIPTION
## Sentry issue
**REACT-NATIVE-3** — `com.apple.coreaudio.avfaudio: required condition is false: IsFormatSampleRateAndChannelCountValid(format)` — fatal `SIGABRT` on iOS during voice dictation on `JobDetailsScreen` (release 1.46/76, iOS 26.5.2).

## Root cause
`expo-speech-recognition@3.1.0`'s `restartAudioEngineForRouteChange()` builds a fresh `AVAudioEngine` on an audio route change and calls `connect()`/`installTap`/`start` with `inputNode.outputFormat(forBus:0)` **without** the `audioInputIsBusy` guard that the normal start path has. When the mic input node isn't ready (0 Hz / 0 ch), AVFAudio aborts. iOS 26.5.2's keyboard-driven route reconfiguration exposed the race.

## Fix
In-range patch bump **3.1.0 → 3.1.3**:
- **3.1.1** adds the missing `audioInputIsBusy` guard to the restart path (direct fix)
- **3.1.2** skips the restart when a route change fires while the app is leaving the foreground

Verified both guards are present in the installed native source. Diff is limited to `package.json` + `package-lock.json`; JS/TS API surface is unchanged.

## Shipping
Native-only pod change — ships in a **new native iOS build**, not OTA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)