### PR TITLE
Phase 0 payment criticals + native Google Sign-In (Firefox) fix

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -57,6 +57,17 @@ export default {
       ],
       "expo-apple-authentication",
       [
+        // Native Google Sign-In (Play Services / iOS account picker). Replaces
+        // the browser-based expo-auth-session flow, which Firefox and other
+        // non-Chrome default browsers broke by dropping the OAuth redirect.
+        "@react-native-google-signin/google-signin",
+        {
+          // Reversed iOS OAuth client ID — the URL scheme the SDK returns to on
+          // iOS (see GOOGLE_OAUTH_IOS_CLIENT_ID).
+          iosUrlScheme: "com.googleusercontent.apps.652758863537-isuaotmpo68rj5lirc40otkevmr8annf"
+        }
+      ],
+      [
         "expo-speech-recognition",
         {
           microphonePermission: "Allow QuoteMate to use your microphone for voice-to-text job descriptions.",
@@ -158,7 +169,15 @@ export default {
       eas: {
         projectId: "b164d7f8-b04e-4960-a962-ebc74fe65bce"
       },
-      squareApplicationId: SQUARE_APPLICATION_ID
+      squareApplicationId: SQUARE_APPLICATION_ID,
+      // Public Google OAuth client IDs consumed by nativeGoogleSignIn.native.ts
+      // via Constants.expoConfig.extra. Hardcoded fallbacks (mirroring
+      // src/config/firebase.ts) because non-EXPO_PUBLIC env vars are not in the
+      // EAS build context — so the correct value always bakes into the manifest.
+      googleWebClientId: process.env.GOOGLE_OAUTH_WEB_CLIENT_ID
+        || "652758863537-86a4q9860h9aalo36f4sb9tpt39ut7bs.apps.googleusercontent.com",
+      googleIosClientId: process.env.GOOGLE_OAUTH_IOS_CLIENT_ID
+        || "652758863537-isuaotmpo68rj5lirc40otkevmr8annf.apps.googleusercontent.com"
     }
   }
 };

--- a/firestore.rules
+++ b/firestore.rules
@@ -9,9 +9,64 @@ service cloud.firestore {
       return signedIn() && request.auth.uid == userId;
     }
 
-    // Users can read/write their own user document and ALL subcollections.
-    match /users/{userId}/{document=**} {
+    // Entitlement fields on users/{uid}/profile/subscription are server-owned
+    // (PAY-02): only the receipt validators, Stripe webhook, and admin tools
+    // may write them (Admin SDK bypasses rules). Client writes to that doc are
+    // allowed only for quota/trial bookkeeping — see the allow-list below,
+    // mirrored in src/utils/subscriptionWritePayload.ts (update both together).
+    // Server-owned keys the client may never add, change, or remove (unchanged
+    // values in a full set() are fine — only affectedKeys count). `isPro` is
+    // NOT here: it has its own rule below (creatable/settable only as false).
+    // `plan` IS here (PAY-02): the server re-derives tier from isPro +
+    // trialStartedAt (resolveServerPlan) and never trusts a client plan string,
+    // so a client plan:'trial'/'pro' — which dodged the free-tier gate + fee —
+    // must be rejected outright.
+    function subEntitlementKeys() {
+      return ['plan', 'platform', 'productId', 'transactionId', 'purchaseToken',
+              'appleValidated', 'googleValidated', 'validatedAt',
+              'subscriptionId', 'customerId', 'priceId', 'cancelAtPeriodEnd',
+              'canceledAt', 'environment', 'restoredFromIncident', 'incidentProUntil',
+              'interval', 'planInterval', 'platformFeeBps'];
+    }
+
+    // Users can read/write their own user document and ALL subcollections —
+    // EXCEPT profile/subscription, which gets the field-guarded match below.
+    // Overlapping matches OR together, so no match here may grant a write to
+    // that doc. In particular a recursive {x=**} matches ZERO or more segments
+    // under rules_version 2, so it must start below the doc, never at it.
+    match /users/{userId} {
       allow read, write: if isOwner(userId);
+    }
+    // Direct subcollection docs (users/{uid}/{collection}/{docId}).
+    match /users/{userId}/{collection}/{docId} {
+      allow read: if isOwner(userId);
+      allow write: if isOwner(userId) && !(collection == 'profile' && docId == 'subscription');
+    }
+    // Anything nested deeper. {rest=**} can only resolve to a document here
+    // when it covers at least one segment, so this never re-grants the doc
+    // above (a zero-segment match lands on a collection path, which rules
+    // never evaluate).
+    match /users/{userId}/{collection}/{docId}/{sub}/{rest=**} {
+      allow read, write: if isOwner(userId);
+    }
+    match /users/{userId}/profile/subscription {
+      allow read: if isOwner(userId);
+      allow delete: if false;
+      // Create: the client trial/quota code seeds this doc (isPro:false, no
+      // entitlement keys — `plan` included, so the seed must omit it).
+      allow create: if isOwner(userId)
+        && !request.resource.data.keys().hasAny(subEntitlementKeys())
+        && request.resource.data.get('isPro', false) == false;
+      // Update: entitlement keys must be untouched (unchanged values in a
+      // full set() are fine — only added/removed/changed keys count). isPro
+      // may be written only as false and never to overwrite a server-granted
+      // true.
+      allow update: if isOwner(userId)
+        && !request.resource.data.diff(resource.data).affectedKeys().hasAny(subEntitlementKeys())
+        && (!request.resource.data.diff(resource.data).affectedKeys().hasAny(['isPro'])
+            || (request.resource.data.isPro == false && resource.data.get('isPro', false) == false));
+      // NOTE: trialStartedAt/trialExpired stay client-writable for the trial
+      // bootstrap — a known, accepted weakness (tracked as follow-up).
     }
 
     // Unified documents collection (phase-1 dual-write mirror of quotes+invoices).
@@ -82,6 +137,13 @@ service cloud.firestore {
 
     // Pending links — no client access (Cloud Functions only)
     match /pendingLinks/{linkId} {
+      allow read, write: if false;
+    }
+
+    // Square OAuth state nonces (PAY-03) — Cloud Functions only. A client
+    // read would leak nothing usable (docs are keyed by SHA-256 of the
+    // nonce), but there is no reason to allow any access.
+    match /squareOAuthStates/{stateHash} {
       allow read, write: if false;
     }
 

--- a/firestore.rules.test.ts
+++ b/firestore.rules.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Firestore security-rules tests (PAY-02 / PAY-03) — run against the
+ * emulator via `npm run test:rules`, NOT part of the default vitest run.
+ *
+ * Proves that a client can no longer write subscription entitlements
+ * (the owner wildcard previously allowed any authenticated user to set
+ * isPro/platformFeeBps/productId on their own profile/subscription doc),
+ * while the legitimate client quota/trial writes keep working.
+ */
+import { readFileSync } from 'node:fs';
+import { beforeAll, afterAll, beforeEach, describe, it } from 'vitest';
+import {
+  assertFails,
+  assertSucceeds,
+  initializeTestEnvironment,
+  type RulesTestEnvironment,
+} from '@firebase/rules-unit-testing';
+import { deleteDoc, doc, getDoc, setDoc, updateDoc } from 'firebase/firestore';
+
+let env: RulesTestEnvironment;
+
+const SUB_PATH = 'users/alice/profile/subscription';
+
+const quotaSeed = {
+  isPro: false,
+  quotesThisMonth: 1,
+  currentPeriodStart: '2026-07-01T00:00:00.000Z',
+  currentPeriodEnd: '2026-07-31T23:59:59.000Z',
+  trialStartedAt: '2026-07-10T00:00:00.000Z',
+  syncedAt: '2026-07-17T00:00:00.000Z',
+};
+
+const serverProDoc = {
+  isPro: true,
+  platform: 'ios',
+  productId: 'quotemate_pro_monthly',
+  transactionId: 'txn-1',
+  appleValidated: true,
+  quotesThisMonth: 2,
+  currentPeriodEnd: '2026-08-01T00:00:00.000Z',
+};
+
+function aliceDb() {
+  return env.authenticatedContext('alice').firestore();
+}
+
+async function seed(path: string, data: Record<string, unknown>) {
+  await env.withSecurityRulesDisabled(async (ctx) => {
+    await setDoc(doc(ctx.firestore(), path), data);
+  });
+}
+
+beforeAll(async () => {
+  env = await initializeTestEnvironment({
+    projectId: 'demo-quotemate-rules',
+    firestore: { rules: readFileSync('firestore.rules', 'utf8') },
+  });
+});
+
+afterAll(async () => {
+  await env.cleanup();
+});
+
+beforeEach(async () => {
+  await env.clearFirestore();
+});
+
+describe('users/{uid}/profile/subscription (PAY-02)', () => {
+  it('denies creating the doc with isPro:true', async () => {
+    await assertFails(setDoc(doc(aliceDb(), SUB_PATH), { ...quotaSeed, isPro: true }));
+  });
+
+  it('denies creating the doc with entitlement keys (productId/platform/platformFeeBps)', async () => {
+    await assertFails(setDoc(doc(aliceDb(), SUB_PATH), { ...quotaSeed, productId: 'quotemate_pro_monthly' }));
+    await assertFails(setDoc(doc(aliceDb(), SUB_PATH), { ...quotaSeed, platform: 'ios' }));
+    await assertFails(setDoc(doc(aliceDb(), SUB_PATH), { ...quotaSeed, platformFeeBps: 100 }));
+  });
+
+  it('denies creating the doc with a client plan string (PAY-02 free-gate bypass)', async () => {
+    await assertFails(setDoc(doc(aliceDb(), SUB_PATH), { ...quotaSeed, plan: 'trial' }));
+    await assertFails(setDoc(doc(aliceDb(), SUB_PATH), { ...quotaSeed, plan: 'pro' }));
+    await assertFails(setDoc(doc(aliceDb(), SUB_PATH), { ...quotaSeed, plan: 'free' }));
+  });
+
+  it('allows the client quota/trial seed (isPro:false + bookkeeping fields)', async () => {
+    await assertSucceeds(setDoc(doc(aliceDb(), SUB_PATH), quotaSeed));
+  });
+
+  it('denies a free user flipping isPro to true — the original PAY-02 exploit', async () => {
+    await seed(SUB_PATH, quotaSeed);
+    await assertFails(updateDoc(doc(aliceDb(), SUB_PATH), { isPro: true }));
+  });
+
+  it('denies a free user granting entitlement fields on update', async () => {
+    await seed(SUB_PATH, quotaSeed);
+    await assertFails(updateDoc(doc(aliceDb(), SUB_PATH), { platformFeeBps: 100 }));
+    await assertFails(updateDoc(doc(aliceDb(), SUB_PATH), { productId: 'quotemate_pro_yearly' }));
+    await assertFails(updateDoc(doc(aliceDb(), SUB_PATH), { plan: 'pro' }));
+  });
+
+  it('denies an expired-trial free user setting plan:trial to dodge the free-tier gate (PAY-02 MAJOR-1)', async () => {
+    // Trial started 30 days ago → server derives 'free'. Writing plan:'trial'
+    // must not be able to flip the server back to the Pro-rate trial tier.
+    await seed(SUB_PATH, { ...quotaSeed, trialStartedAt: '2026-06-17T00:00:00.000Z' });
+    await assertFails(updateDoc(doc(aliceDb(), SUB_PATH), { plan: 'trial' }));
+    await assertFails(updateDoc(doc(aliceDb(), SUB_PATH), { plan: 'free' }));
+  });
+
+  it('denies removing plan from a server-written Pro doc', async () => {
+    await seed(SUB_PATH, { ...serverProDoc, plan: 'pro' });
+    // Full set() that drops the server plan field.
+    await assertFails(setDoc(doc(aliceDb(), SUB_PATH), quotaSeed));
+  });
+
+  it('denies the old-client full setDoc that would clobber server billing fields', async () => {
+    await seed(SUB_PATH, serverProDoc);
+    // Pre-fix saveSubscriptionStatus: non-merge set() of the local mirror —
+    // deletes platform/productId/appleValidated and flips isPro.
+    await assertFails(setDoc(doc(aliceDb(), SUB_PATH), quotaSeed));
+  });
+
+  it('denies clobbering a server-granted isPro:true back to false', async () => {
+    await seed(SUB_PATH, serverProDoc);
+    await assertFails(updateDoc(doc(aliceDb(), SUB_PATH), { isPro: false }));
+  });
+
+  it('allows the client quota transaction shape: full set() that leaves entitlement values unchanged', async () => {
+    await seed(SUB_PATH, serverProDoc);
+    await assertSucceeds(setDoc(doc(aliceDb(), SUB_PATH), {
+      ...serverProDoc,
+      quotesThisMonth: 3,
+      syncedAt: '2026-07-17T01:00:00.000Z',
+    }));
+  });
+
+  it('allows the new whitelisted merge payload on a Pro doc', async () => {
+    await seed(SUB_PATH, serverProDoc);
+    await assertSucceeds(setDoc(doc(aliceDb(), SUB_PATH), {
+      quotesThisMonth: 4,
+      currentPeriodStart: '2026-07-01T00:00:00.000Z',
+      currentPeriodEnd: '2026-07-31T23:59:59.000Z',
+      freeQuotesLimit: 5,
+      trialStartedAt: null,
+      trialExpired: false,
+      dismissedUpgradeBanner: true,
+      syncedAt: '2026-07-17T01:00:00.000Z',
+    }, { merge: true }));
+  });
+
+  it('denies deleting the subscription doc', async () => {
+    await seed(SUB_PATH, quotaSeed);
+    await assertFails(deleteDoc(doc(aliceDb(), SUB_PATH)));
+  });
+
+  it('denies any access by another user', async () => {
+    await seed(SUB_PATH, serverProDoc);
+    const mallory = env.authenticatedContext('mallory').firestore();
+    await assertFails(getDoc(doc(mallory, SUB_PATH)));
+    await assertFails(updateDoc(doc(mallory, SUB_PATH), { quotesThisMonth: 0 }));
+  });
+});
+
+describe('the rest of the user tree keeps working', () => {
+  it('owner can still read/write the user root doc', async () => {
+    await assertSucceeds(setDoc(doc(aliceDb(), 'users/alice'), { name: 'Alice' }));
+    await assertSucceeds(getDoc(doc(aliceDb(), 'users/alice')));
+  });
+
+  it('owner can still write other profile docs and subcollections', async () => {
+    await assertSucceeds(setDoc(doc(aliceDb(), 'users/alice/profile/business'), { businessName: 'Alice Fencing' }));
+    await assertSucceeds(setDoc(doc(aliceDb(), 'users/alice/settings/promptState'), { lastPromptAt: 1 }));
+    await assertSucceeds(setDoc(doc(aliceDb(), 'users/alice/quotes/q1'), { total: 100 }));
+  });
+
+  it('owner can still read the subscription doc', async () => {
+    await seed(SUB_PATH, serverProDoc);
+    await assertSucceeds(getDoc(doc(aliceDb(), SUB_PATH)));
+  });
+
+  it('owner can still write deeply nested docs', async () => {
+    await assertSucceeds(setDoc(doc(aliceDb(), 'users/alice/jobs/j1/notes/n1'), { text: 'g’day' }));
+  });
+
+  it('non-owner still has no access to the user tree', async () => {
+    const mallory = env.authenticatedContext('mallory').firestore();
+    await assertFails(getDoc(doc(mallory, 'users/alice/quotes/q1')));
+    await assertFails(setDoc(doc(mallory, 'users/alice/quotes/q1'), { total: 0 }));
+  });
+});
+
+describe('squareOAuthStates (PAY-03)', () => {
+  it('denies all client access, even authenticated', async () => {
+    await seed('squareOAuthStates/somehash', { uid: 'alice', createdAtMs: 1 });
+    await assertFails(getDoc(doc(aliceDb(), 'squareOAuthStates/somehash')));
+    await assertFails(setDoc(doc(aliceDb(), 'squareOAuthStates/forged'), { uid: 'alice', createdAtMs: 1 }));
+  });
+});

--- a/functions/src/documentHandlers.ts
+++ b/functions/src/documentHandlers.ts
@@ -38,6 +38,7 @@ import {
 } from './shared/document/adapter';
 import { canTransition } from './shared/document/stage';
 import { summarizeMaterialEdits, type SentMaterialLike } from './materialEdits.helpers';
+import { resolveServerPlan } from './subscription.helpers';
 import type {
   DocumentRecord,
   DocumentStage,
@@ -504,25 +505,14 @@ function stripLeadingGreeting(text: string): string {
   return text.replace(greetingLine, '').trimStart();
 }
 
-// Mirror of getUserPlanServerSide in index.ts — duplicated here to keep
-// documentHandlers free of index.ts imports. Used to gate the Payment Methods
-// block in invoice emails (pro/trial only). Resolves to 'trial' on profile
-// miss so we err on the generous side.
+// Used to gate the Payment Methods block in invoice emails (pro/trial only).
+// Resolves to 'trial' on profile miss so we err on the generous side.
+// Delegates to resolveServerPlan so the client-writable `plan` string is never
+// trusted for entitlement (PAY-02) — shared with getUserPlanServerSide.
 async function resolveUserPlan(userId: string): Promise<'trial' | 'free' | 'pro'> {
   try {
     const snap = await db().doc(`users/${userId}/profile/subscription`).get();
-    if (!snap.exists) return 'trial';
-    const data = snap.data() || {};
-    if (data.plan === 'pro' || data.plan === 'free' || data.plan === 'trial') return data.plan;
-    if (data.isPro) return 'pro';
-    if (data.trialStartedAt) {
-      const trialMs = 14 * 24 * 60 * 60 * 1000;
-      const startedAt = data.trialStartedAt.toDate
-        ? data.trialStartedAt.toDate()
-        : new Date(data.trialStartedAt);
-      return Date.now() - startedAt.getTime() < trialMs ? 'trial' : 'free';
-    }
-    return 'trial';
+    return resolveServerPlan(snap.exists ? snap.data() : undefined, Date.now());
   } catch {
     return 'trial';
   }

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -80,6 +80,15 @@ export { adminAssistantCosts, reportAssistantLiveUsage } from './assistantCosts'
 export { reportPriceFetchUsage } from './featureUsage';
 import { recordMaterialsRecommend } from './featureUsage';
 import { randomUUID } from 'crypto';
+import { receiptVerdict } from './receiptValidation.helpers';
+import { resolveServerPlan } from './subscription.helpers';
+import {
+  SQUARE_OAUTH_STATES_COLLECTION,
+  SQUARE_OAUTH_STATE_TTL_MS,
+  hashOAuthState,
+  newOAuthState,
+  oauthStateVerdict,
+} from './squareOAuth.helpers';
 import {
   AccountReclaimRecord,
   reclaimDocIdForEmail,
@@ -1247,16 +1256,20 @@ export const validateAppleReceipt = functions.https.onRequest((req, res) => {
       const receiptData = purchaseToken || transactionId;
       const sharedSecret = process.env.APPLE_SHARED_SECRET || '';
 
-      let appleValidated = false;
+      // 'unavailable' = couldn't reach a verdict (store unreachable / missing
+      // secret) → retryable. 'invalid' = Apple affirmatively rejected → terminal.
+      let appleOutcome: 'valid' | 'invalid' | 'unavailable' = 'unavailable';
       let appleExpiryDate: Date | null = null;
 
       if (sharedSecret && receiptData) {
-        try {
-          // Try production first, then sandbox
-          for (const url of [
-            'https://buy.itunes.apple.com/verifyReceipt',
-            'https://sandbox.itunes.apple.com/verifyReceipt',
-          ]) {
+        // Try production first, then sandbox (21007 = sandbox receipt sent to
+        // production). Only a definitive non-zero, non-21007 status is an
+        // affirmative rejection; a thrown fetch leaves the outcome unavailable.
+        for (const url of [
+          'https://buy.itunes.apple.com/verifyReceipt',
+          'https://sandbox.itunes.apple.com/verifyReceipt',
+        ]) {
+          try {
             const appleRes = await fetch(url, {
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },
@@ -1269,10 +1282,8 @@ export const validateAppleReceipt = functions.https.onRequest((req, res) => {
 
             const appleData = await appleRes.json() as any;
 
-            // Status 0 = valid, 21007 = sandbox receipt sent to production (retry with sandbox)
             if (appleData.status === 0) {
-              appleValidated = true;
-              // Extract expiry from latest receipt info
+              appleOutcome = 'valid';
               const latestInfo = appleData.latest_receipt_info;
               if (latestInfo && latestInfo.length > 0) {
                 const latestExpiry = Math.max(...latestInfo.map((r: any) => parseInt(r.expires_date_ms || '0', 10)));
@@ -1281,22 +1292,44 @@ export const validateAppleReceipt = functions.https.onRequest((req, res) => {
                 }
               }
               break;
-            } else if (appleData.status !== 21007) {
+            } else if (appleData.status === 21007) {
+              continue; // retry against sandbox
+            } else {
+              appleOutcome = 'invalid'; // Apple affirmatively rejected
+              break;
             }
+          } catch (appleError) {
+            console.warn('[receipts] Apple verifyReceipt call failed', { userId, url, error: String(appleError) });
+            // leave outcome 'unavailable'; try the next url
           }
-        } catch (appleError) {
         }
       } else {
+        console.warn('[receipts] Apple validation skipped — missing shared secret or receipt data', { userId });
       }
+
+      // PAY-01: no validation, no entitlement. Never write isPro from an
+      // unverified (or already-expired) receipt.
+      const now = new Date();
+      const verdict = receiptVerdict({ outcome: appleOutcome, storeExpiry: appleExpiryDate, productId, now });
+      if (!verdict.grant) {
+        console.warn('[receipts] Apple receipt not granted', {
+          userId, productId, transactionId, reason: verdict.reason, retryable: verdict.retryable,
+        });
+        // Retryable (store unreachable) → 503 so the client leaves the store
+        // transaction unfinished and re-validates later. Terminal → 402.
+        res.status(verdict.retryable ? 503 : 402).json({
+          success: false,
+          validated: appleOutcome === 'valid',
+          error: verdict.retryable ? 'RECEIPT_VALIDATION_UNAVAILABLE' : 'RECEIPT_VALIDATION_FAILED',
+          reason: verdict.reason,
+        });
+        return;
+      }
+      const appleValidated = true;
+      const expiryDate = verdict.expiryDate;
 
       const firestore = admin.firestore();
       const subscriptionRef = firestore.doc(`users/${userId}/profile/subscription`);
-
-      // Determine subscription period
-      const isYearly = productId.includes('yearly');
-      const periodMs = isYearly ? 365 * 24 * 60 * 60 * 1000 : 30 * 24 * 60 * 60 * 1000;
-      const now = new Date();
-      const expiryDate = appleExpiryDate || new Date(now.getTime() + periodMs);
 
       await subscriptionRef.set({
         isPro: true,
@@ -1368,7 +1401,10 @@ export const validateGoogleReceipt = functions.https.onRequest((req, res) => {
       }
 
 
-      let googleValidated = false;
+      // 'unavailable' = couldn't reach a verdict (API/network error or missing
+      // service account) → retryable. 'invalid' = Google says the purchase is
+      // bad/expired → terminal.
+      let googleOutcome: 'valid' | 'invalid' | 'unavailable' = 'unavailable';
       let googleExpiryDate: Date | null = null;
 
       // Validate with Google Play Developer API if service account is configured
@@ -1399,24 +1435,48 @@ export const validateGoogleReceipt = functions.https.onRequest((req, res) => {
           if (googleRes.data) {
             const expiryTimeMs = parseInt(googleRes.data.expiryTimeMillis || '0', 10);
             if (expiryTimeMs > Date.now()) {
-              googleValidated = true;
+              googleOutcome = 'valid';
               googleExpiryDate = new Date(expiryTimeMs);
             } else {
+              googleOutcome = 'invalid'; // Google confirmed the sub has lapsed
             }
+          } else {
+            googleOutcome = 'invalid'; // API responded with no subscription data
           }
-        } catch (googleError) {
+        } catch (googleError: any) {
+          // A 4xx (invalid/not-found purchase token) is an affirmative
+          // rejection; a 5xx / network error is a transient outage.
+          const httpStatus = googleError?.code ?? googleError?.response?.status;
+          googleOutcome = (typeof httpStatus === 'number' && httpStatus >= 400 && httpStatus < 500)
+            ? 'invalid'
+            : 'unavailable';
+          console.warn('[receipts] Google subscriptions.get failed', { userId, httpStatus, outcome: googleOutcome, error: String(googleError) });
         }
       } else {
+        console.warn('[receipts] Google validation skipped — missing service account or purchase token', { userId });
       }
+
+      // PAY-01: no validation, no entitlement. Never write isPro from an
+      // unverified (or already-expired) receipt.
+      const now = new Date();
+      const verdict = receiptVerdict({ outcome: googleOutcome, storeExpiry: googleExpiryDate, productId, now });
+      if (!verdict.grant) {
+        console.warn('[receipts] Google receipt not granted', {
+          userId, productId, transactionId, reason: verdict.reason, retryable: verdict.retryable,
+        });
+        res.status(verdict.retryable ? 503 : 402).json({
+          success: false,
+          validated: googleOutcome === 'valid',
+          error: verdict.retryable ? 'RECEIPT_VALIDATION_UNAVAILABLE' : 'RECEIPT_VALIDATION_FAILED',
+          reason: verdict.reason,
+        });
+        return;
+      }
+      const googleValidated = true;
+      const expiryDate = verdict.expiryDate;
 
       const firestore = admin.firestore();
       const subscriptionRef = firestore.doc(`users/${userId}/profile/subscription`);
-
-      // Determine subscription period
-      const isYearly = productId.includes('yearly');
-      const periodMs = isYearly ? 365 * 24 * 60 * 60 * 1000 : 30 * 24 * 60 * 60 * 1000;
-      const now = new Date();
-      const expiryDate = googleExpiryDate || new Date(now.getTime() + periodMs);
 
       await subscriptionRef.set({
         isPro: true,
@@ -1874,7 +1934,9 @@ QUALITY TIER DETECTION — read the job description for tier qualifiers and set 
 - Cabinetry/joinery substance descriptors map to tier too: "custom timber cabinetry", "solid timber doors", "marble benchtop", "stone benchtop", "engineered stone", "Caesarstone" all imply premium for those rows even if the job header doesn't say "premium".
 - EVERY section MUST have sectionLaborHours > 0. A section with zero labour hours is invalid output — if the work is materials-only with no labour (rare), put those materials under an existing labour-bearing section instead of creating a zero-hour section.
 - PER-AREA SURFACE-COVERING SECTIONS ONLY (paving installation, tiling, plastering, rendering, screeding): set sectionMultiplier = total surface area in m² and sectionLaborHours = hours PER m² (typical: paving install 0.4–0.6 h/m², tiling 0.5 h/m², plastering 0.3 h/m², screeding 0.2 h/m²). Per-m² IS a per-unit value: one m² is one unit. Material quantities inside these sections are PER m² (e.g. 6.25 pavers per m²) and get multiplied by sectionMultiplier at save time — do NOT pre-multiply.
-- DISCRETE-UNIT SECTIONS (fence bays, gates, post footings, framing, joists, footings, slabs poured per-pour, doors, windows, decks measured per board): sectionMultiplier = COUNT of those repeating units (e.g. 9 bays, 13 post holes, 1 deck), NOT an area. Material quantities are PER UNIT (e.g. 4 bags concrete per post hole × 13 holes). This applies to fencing, framing, and ALL concrete work that goes into individual holes/footings/footings-beams — those are per-hole not per-m².
+- PER-M² IS FOR JOBS WHERE ONE MATERIAL IS SPREAD/LAID CONTINUOUSLY OVER THE AREA AT A REAL DENSITY. It is NOT for roofing, re-roofing, re-cladding, sheet-metal roofing, insulation, or any job whose materials are sheets, lengths, rolls, ridge/flashing, fasteners and consumables — those are a DISCRETE roof/wall (sectionMultiplier = 1), and each material is derived from the roof's AREA and its EDGE/RIDGE LENGTHS via coverage, NOT by multiplying by the area. Roofing sheets ≈ area ÷ sheet-cover-width in lineal m; ridge capping = ridge-line length in lineal m; anticon = area ÷ roll-coverage; sealant = a few tubes per job. NONE of these is "1 per m²".
+- ANTI-LAUNDER RULE for any per-m² section: a material at exactly 1 (or 2, or 3) per m² — the same round placeholder across several materials — means you did NOT derive it and the save-time × area will launder the job size onto every line (e.g. a 165 m² job → 165 of everything). Either give the material its REAL per-m² density (a specific fraction like 0.35 rolls/m², 6.25 pavers/m²), or move it out of the per-m² section and derive it from the job's lengths/counts. If two materials of different physical kinds (a sheet and a tube of sealant) would both come out at the same number, the classification is wrong — recheck it.
+- DISCRETE-UNIT SECTIONS (fence bays, gates, post footings, framing, joists, footings, slabs poured per-pour, doors, windows, decks measured per board, ROOFS, wall-cladding runs): sectionMultiplier = COUNT of those repeating units (e.g. 9 bays, 13 post holes, 1 deck, 1 roof), NOT an area. Material quantities are PER UNIT (e.g. 4 bags concrete per post hole × 13 holes). This applies to fencing, framing, roofing, and ALL concrete work that goes into individual holes/footings/footings-beams — those are per-hole not per-m².
 - DO NOT include concreting/footings under the per-m² surface-covering rule above. A 13-post fence is 13 discrete footings, not a "concreting per m²" job. If you find yourself emitting >50 bags of concrete per post, your multiplier or per-unit quantity is wrong — recalculate.
 
 CRITICAL — emit quantities in the SMALLEST PHYSICAL UNIT, not in guessed packs/bags:
@@ -1919,6 +1981,15 @@ WORKED EXAMPLE — 30 m² (15m × 2m) merbau deck, no handrails — a previously
 - H4 posts 90x90 @ 1.8m: ((15 ÷ 1.8) + 1) ≈ 10 per row × 2 rows ≈ 20. quantity 20, unit "each". WRONG: 70.
 - Decking oil: 30m² × 2 coats ÷ ~8 m²/L = ~8. quantity 8, unit "L". WRONG: "12 tins".
 This deck is ONE discrete unit (sectionMultiplier = 1), NOT a per-m² surface-covering section — do not multiply these per-deck counts by the area.
+
+WORKED EXAMPLE — 165 m² single-storey tile-to-Colorbond re-roof (tiles off, corrugated .48 on) — a previously-broken case that classed a roof as per-m² and laundered "165" onto every line (165 sheets, 165 silicone tubes, 495 screws). This is ONE discrete roof (sectionMultiplier = 1); labour lives in a per-m² labour section if you like, but MATERIALS are derived from area + lengths, NEVER × area:
+- Colorbond corrugated .48 sheets: cover width ≈ 0.762m → lineal metres = 165 ÷ 0.762 × 1.1 waste ≈ 238. quantity 238, unit "m". reasoning: "165m² ÷ 0.762m cover × 1.1 = 238 lm". WRONG: 165 (that is the raw area, not lineal metres).
+- Anticon roofing blanket: 165 ÷ ~18 m² per roll × 1.1 ≈ 10. quantity 10, unit "each". WRONG: 165.
+- Roof battens @ 900 centres: (roof-slope-run ÷ 0.9 + 1) × ridge-length ≈ derive lineal metres (~185 lm typical). quantity ~185, unit "m". WRONG: 165 or 28-off-nothing.
+- Ridge capping: ridge-line length only (a single-storey gable ≈ 8–14 lineal m), unit "m". WRONG: 55 lengths / 165.
+- Roofing screws: ~5–6 per m² tie-down → 165 × 6 ≈ 990. quantity 990, unit "each". WRONG: 495 (that is 165 × 3 laundered).
+- Roof & gutter silicone: a few tubes per job — 6. quantity 6, unit "each". WRONG: 165 tubes.
+If EVERY roofing material comes out at 165 (or a small multiple), you have laundered the area — STOP and derive each from coverage and lengths.
 
 Guidelines:
 - Group materials into REPEATING WORK UNITS where possible. Identify the smallest repeating unit for each section (e.g. one fence bay, one square metre of decking, one staircase riser).
@@ -12733,9 +12804,23 @@ export const getSquareAuthUrl = functions.https.onRequest((req, res) => {
       return;
     }
 
-    const state = Buffer.from(
-      JSON.stringify({ uid: decodedToken.uid, ts: Date.now() }),
-    ).toString('base64url');
+    // PAY-03: `state` is a random single-use nonce. Only its hash is stored,
+    // bound to the uid that authenticated THIS request — the callback resolves
+    // the uid from the stored doc, never from anything the client can craft.
+    const state = newOAuthState();
+    await admin.firestore()
+      .collection(SQUARE_OAUTH_STATES_COLLECTION)
+      .doc(hashOAuthState(state))
+      .set({
+        uid: decodedToken.uid,
+        createdAtMs: Date.now(),
+        env: SQUARE_ENV,
+        // Consumed (deleted) by squareCallback. Abandoned flows never come
+        // back, so this stamp exists for a Firestore TTL policy on the
+        // squareOAuthStates collection to reap them — enable it in the
+        // console; oauthStateVerdict rejects on createdAtMs regardless.
+        expiresAt: admin.firestore.Timestamp.fromMillis(Date.now() + SQUARE_OAUTH_STATE_TTL_MS),
+      });
 
     const params = new URLSearchParams({
       client_id: SQUARE_APP_ID,
@@ -12769,20 +12854,23 @@ export const squareCallback = functions.https.onRequest((req, res) => {
       return;
     }
 
-    let stateData: { uid: string; ts: number };
-    try {
-      stateData = JSON.parse(Buffer.from(state, 'base64url').toString());
-    } catch {
-      res.status(400).json({ error: 'Invalid state parameter' });
+    // PAY-03: resolve the uid from the server-side state doc and consume it
+    // atomically (single use) — a forged or replayed state finds no doc.
+    const stateRef = admin.firestore()
+      .collection(SQUARE_OAUTH_STATES_COLLECTION)
+      .doc(hashOAuthState(state));
+    const stateVerdict = await admin.firestore().runTransaction(async (tx) => {
+      const snap = await tx.get(stateRef);
+      const verdict = oauthStateVerdict(snap.exists ? (snap.data() as any) : undefined, Date.now());
+      if (verdict.ok || snap.exists) tx.delete(stateRef);
+      return verdict;
+    });
+    if (!stateVerdict.ok) {
+      res.status(stateVerdict.status).json({ error: stateVerdict.error });
       return;
     }
 
-    if (Date.now() - stateData.ts > 10 * 60 * 1000) {
-      res.status(400).json({ error: 'Authorization expired. Please try again.' });
-      return;
-    }
-
-    const userId = stateData.uid;
+    const userId = stateVerdict.uid;
 
     try {
       const tokenResponse = await fetch(`${squareOAuthBase()}/oauth2/token`, {
@@ -13040,18 +13128,9 @@ async function flagScopeUpgradeIfNeeded(
 async function getUserPlanServerSide(userId: string): Promise<'trial' | 'free' | 'pro'> {
   try {
     const snap = await admin.firestore().doc(`users/${userId}/profile/subscription`).get();
-    if (!snap.exists) return 'trial';
-    const data = snap.data() || {};
-    if (data.plan === 'pro' || data.plan === 'free' || data.plan === 'trial') return data.plan;
-    if (data.isPro) return 'pro';
-    if (data.trialStartedAt) {
-      const trialMs = 14 * 24 * 60 * 60 * 1000; // 14-day trial — keep in sync with src/utils/trialConfig.ts
-      const startedAt = data.trialStartedAt.toDate
-        ? data.trialStartedAt.toDate()
-        : new Date(data.trialStartedAt);
-      return Date.now() - startedAt.getTime() < trialMs ? 'trial' : 'free';
-    }
-    return 'trial';
+    // resolveServerPlan ignores a client-writable `plan` string (PAY-02) and
+    // keys Pro off the server-owned isPro flag.
+    return resolveServerPlan(snap.exists ? snap.data() : undefined, Date.now());
   } catch (error) {
     console.error('[plan] failed to resolve user plan', { userId, error });
     // Fail closed — assume free so a fee is taken rather than waived.

--- a/functions/src/receiptValidation.helpers.test.ts
+++ b/functions/src/receiptValidation.helpers.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { receiptVerdict } from './receiptValidation.helpers';
+
+const NOW = new Date('2026-07-17T00:00:00Z');
+
+describe('receiptVerdict (PAY-01)', () => {
+  it('rejects an affirmatively-invalid receipt terminally — regression for unconditional isPro grant', () => {
+    const v = receiptVerdict({
+      outcome: 'invalid',
+      storeExpiry: new Date(NOW.getTime() + 86400000),
+      productId: 'quotemate_pro_monthly',
+      now: NOW,
+    });
+    expect(v).toEqual({ grant: false, reason: 'not_validated', retryable: false });
+  });
+
+  it('treats an unreachable store / missing credentials as RETRYABLE, not a rejection (PAY-01 MAJOR-2)', () => {
+    const v = receiptVerdict({ outcome: 'unavailable', storeExpiry: null, productId: 'quotemate_pro_yearly', now: NOW });
+    expect(v).toEqual({ grant: false, reason: 'not_validated', retryable: true });
+  });
+
+  it('rejects a validated receipt whose store expiry has already passed (lapsed sub restore)', () => {
+    const v = receiptVerdict({
+      outcome: 'valid',
+      storeExpiry: new Date(NOW.getTime() - 1000),
+      productId: 'quotemate_pro_monthly',
+      now: NOW,
+    });
+    expect(v).toEqual({ grant: false, reason: 'expired', retryable: false });
+  });
+
+  it('rejects a validated receipt expiring exactly now (boundary is exclusive)', () => {
+    const v = receiptVerdict({ outcome: 'valid', storeExpiry: new Date(NOW), productId: 'quotemate_pro_monthly', now: NOW });
+    expect(v).toEqual({ grant: false, reason: 'expired', retryable: false });
+  });
+
+  it('grants until the store expiry when validated and in the future', () => {
+    const expiry = new Date(NOW.getTime() + 30 * 86400000);
+    const v = receiptVerdict({ outcome: 'valid', storeExpiry: expiry, productId: 'quotemate_pro_monthly', now: NOW });
+    expect(v).toEqual({ grant: true, expiryDate: expiry });
+  });
+
+  it('grants a 30-day fallback for a validated monthly receipt with no store expiry', () => {
+    const v = receiptVerdict({ outcome: 'valid', storeExpiry: null, productId: 'quotemate_pro_monthly', now: NOW });
+    expect(v).toEqual({ grant: true, expiryDate: new Date(NOW.getTime() + 30 * 86400000) });
+  });
+
+  it('grants a 365-day fallback for a validated yearly receipt with no store expiry', () => {
+    const v = receiptVerdict({ outcome: 'valid', storeExpiry: null, productId: 'quotemate_pro_yearly', now: NOW });
+    expect(v).toEqual({ grant: true, expiryDate: new Date(NOW.getTime() + 365 * 86400000) });
+  });
+});

--- a/functions/src/receiptValidation.helpers.ts
+++ b/functions/src/receiptValidation.helpers.ts
@@ -1,0 +1,51 @@
+/**
+ * Pure helpers for validateAppleReceipt / validateGoogleReceipt (PAY-01).
+ *
+ * A store receipt that fails server-side validation must NEVER grant Pro.
+ * Before Jul 2026 both endpoints computed a fallback expiry from the
+ * client-supplied productId and wrote isPro:true unconditionally — a
+ * fabricated transaction id, a store outage, or missing credentials granted
+ * paid access (two such records existed in production). The verdict below is
+ * the single gate: no grant, no subscription write.
+ *
+ * We distinguish an AFFIRMATIVE store rejection ('invalid' — the store told
+ * us the receipt is bad) from an inability to reach a verdict ('unavailable'
+ * — the store was unreachable, timed out, or a server credential is missing).
+ * Only the former is a terminal rejection; 'unavailable' is retryable, so the
+ * caller leaves the store transaction unfinished for later re-validation
+ * instead of burning a real buyer's purchase during a store outage.
+ */
+
+export type ValidationOutcome = 'valid' | 'invalid' | 'unavailable';
+
+export type ReceiptVerdict =
+  | { grant: true; expiryDate: Date }
+  | { grant: false; reason: 'not_validated' | 'expired'; retryable: boolean };
+
+export function receiptVerdict(params: {
+  outcome: ValidationOutcome;
+  storeExpiry: Date | null;
+  productId: string;
+  now: Date;
+}): ReceiptVerdict {
+  const { outcome, storeExpiry, productId, now } = params;
+
+  // Couldn't reach a verdict (store unreachable / missing credentials) — do
+  // not grant, but signal retry so the buyer's transaction isn't consumed.
+  if (outcome === 'unavailable') return { grant: false, reason: 'not_validated', retryable: true };
+  // Store affirmatively rejected the receipt — terminal.
+  if (outcome === 'invalid') return { grant: false, reason: 'not_validated', retryable: false };
+
+  // outcome === 'valid'
+  if (storeExpiry) {
+    // A validated but already-lapsed subscription must not re-grant Pro
+    // (checkQuoteLimit trusts isPro without re-checking currentPeriodEnd).
+    if (storeExpiry.getTime() <= now.getTime()) return { grant: false, reason: 'expired', retryable: false };
+    return { grant: true, expiryDate: storeExpiry };
+  }
+  // Validated with no store expiry (e.g. Apple status 0 without
+  // latest_receipt_info) — grant one period derived from the productId.
+  const isYearly = productId.includes('yearly');
+  const periodMs = (isYearly ? 365 : 30) * 24 * 60 * 60 * 1000;
+  return { grant: true, expiryDate: new Date(now.getTime() + periodMs) };
+}

--- a/functions/src/squareOAuth.helpers.test.ts
+++ b/functions/src/squareOAuth.helpers.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import {
+  SQUARE_OAUTH_STATE_TTL_MS,
+  hashOAuthState,
+  newOAuthState,
+  oauthStateVerdict,
+} from './squareOAuth.helpers';
+
+const NOW_MS = Date.parse('2026-07-17T00:00:00Z');
+
+describe('newOAuthState / hashOAuthState (PAY-03)', () => {
+  it('generates URL-safe nonces with at least 256 bits of entropy encoded', () => {
+    const state = newOAuthState();
+    expect(state).toMatch(/^[A-Za-z0-9_-]{43,}$/);
+  });
+
+  it('generates a different nonce every call', () => {
+    expect(newOAuthState()).not.toEqual(newOAuthState());
+  });
+
+  it('hashes deterministically and differently per state', () => {
+    const a = newOAuthState();
+    const b = newOAuthState();
+    expect(hashOAuthState(a)).toEqual(hashOAuthState(a));
+    expect(hashOAuthState(a)).not.toEqual(hashOAuthState(b));
+    expect(hashOAuthState(a)).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+describe('oauthStateVerdict (PAY-03)', () => {
+  it('rejects a missing doc — an unknown or already-consumed state is invalid', () => {
+    const v = oauthStateVerdict(undefined, NOW_MS);
+    expect(v).toEqual({ ok: false, status: 400, error: 'Invalid state parameter' });
+  });
+
+  it('rejects a doc without a usable uid', () => {
+    expect(oauthStateVerdict({ uid: '', createdAtMs: NOW_MS }, NOW_MS).ok).toBe(false);
+    expect(oauthStateVerdict({ uid: 42 as unknown, createdAtMs: NOW_MS }, NOW_MS).ok).toBe(false);
+  });
+
+  it('rejects a doc without a numeric createdAtMs', () => {
+    const v = oauthStateVerdict({ uid: 'user-1' }, NOW_MS);
+    expect(v).toEqual({ ok: false, status: 400, error: 'Authorization expired. Please try again.' });
+  });
+
+  it('rejects a state older than the 10-minute TTL', () => {
+    const v = oauthStateVerdict(
+      { uid: 'user-1', createdAtMs: NOW_MS - SQUARE_OAUTH_STATE_TTL_MS - 1 },
+      NOW_MS,
+    );
+    expect(v).toEqual({ ok: false, status: 400, error: 'Authorization expired. Please try again.' });
+  });
+
+  it('accepts a fresh state at the TTL boundary and returns the stored uid', () => {
+    const v = oauthStateVerdict(
+      { uid: 'user-1', createdAtMs: NOW_MS - SQUARE_OAUTH_STATE_TTL_MS },
+      NOW_MS,
+    );
+    expect(v).toEqual({ ok: true, uid: 'user-1' });
+  });
+});

--- a/functions/src/squareOAuth.helpers.ts
+++ b/functions/src/squareOAuth.helpers.ts
@@ -1,0 +1,47 @@
+/**
+ * Square OAuth state handling (PAY-03).
+ *
+ * The old flow base64-encoded { uid, ts } as the OAuth `state` and the
+ * unauthenticated callback trusted the decoded uid — anyone could forge a
+ * fresh state for a victim uid and bind their own Square account to that
+ * user. The fix: `state` is a random single-use nonce; only its SHA-256 hash
+ * is stored server-side (squareOAuthStates/{hash}) against the uid that was
+ * authenticated when the flow started, and the callback consumes the doc
+ * transactionally, so a state can neither be forged nor replayed.
+ */
+import * as crypto from 'crypto';
+
+export const SQUARE_OAUTH_STATE_TTL_MS = 10 * 60 * 1000;
+export const SQUARE_OAUTH_STATES_COLLECTION = 'squareOAuthStates';
+
+/** Random, URL-safe, single-use OAuth state nonce. */
+export function newOAuthState(): string {
+  return crypto.randomBytes(32).toString('base64url');
+}
+
+/** Hash stored server-side so a Firestore read leak can't mint valid states. */
+export function hashOAuthState(state: string): string {
+  return crypto.createHash('sha256').update(state).digest('hex');
+}
+
+export type OAuthStateVerdict =
+  | { ok: true; uid: string }
+  | { ok: false; status: number; error: string };
+
+/**
+ * Validate a stored state doc (undefined = not found/already consumed).
+ * Pure so the expiry/shape rules are unit-testable without Firestore.
+ */
+export function oauthStateVerdict(
+  docData: { uid?: unknown; createdAtMs?: unknown } | undefined,
+  nowMs: number,
+): OAuthStateVerdict {
+  if (!docData || typeof docData.uid !== 'string' || !docData.uid) {
+    return { ok: false, status: 400, error: 'Invalid state parameter' };
+  }
+  const createdAtMs = typeof docData.createdAtMs === 'number' ? docData.createdAtMs : NaN;
+  if (!Number.isFinite(createdAtMs) || nowMs - createdAtMs > SQUARE_OAUTH_STATE_TTL_MS) {
+    return { ok: false, status: 400, error: 'Authorization expired. Please try again.' };
+  }
+  return { ok: true, uid: docData.uid };
+}

--- a/functions/src/storeFunnel.ts
+++ b/functions/src/storeFunnel.ts
@@ -170,9 +170,11 @@ export const storeFunnelDaily = functions
     if (!ascConfigured) console.info('storeFunnel: ASC_* not set — skipping Apple side');
     if (!playBucket && !ascConfigured) return null;
 
-    // Both sources lag, so refresh a rolling 4-day window (D-1..D-4) each run.
+    // Both sources lag — Play's monthly overview CSV by up to ~5 days — so a
+    // 4-day window could permanently miss days. Refresh a rolling 10-day
+    // window; merge-writes make re-processing already-written days free.
     const days: { compact: string; dashed: string; month: string }[] = [];
-    for (let back = 1; back <= 4; back++) {
+    for (let back = 1; back <= 10; back++) {
       days.push(brisbaneDateParts(new Date(Date.now() - back * 24 * 60 * 60 * 1000)));
     }
 

--- a/functions/src/subscription.helpers.test.ts
+++ b/functions/src/subscription.helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isBilledSub, subEnvironment, deriveSubFields } from './subscription.helpers';
+import { isBilledSub, subEnvironment, deriveSubFields, resolveServerPlan, TRIAL_MS } from './subscription.helpers';
 
 // Build a StoreKit 2-style JWS: header.payload.signature with base64url segments.
 function jwsWith(payload: Record<string, any>): string {
@@ -91,5 +91,50 @@ describe('deriveSubFields billing rollup', () => {
     expect(f.billed).toBe(true);
     expect(f.interval).toBe('yearly');
     expect(f.monthlyAud).toBeCloseTo(328 / 12, 1);
+  });
+});
+
+describe('resolveServerPlan (PAY-02 MAJOR-1 — client plan string is not trusted)', () => {
+  const NOW = Date.parse('2026-07-19T00:00:00Z');
+  const inTrial = new Date(NOW - 3 * 24 * 60 * 60 * 1000).toISOString();
+  const expiredTrial = new Date(NOW - TRIAL_MS - 1000).toISOString();
+
+  it('returns trial when the subscription doc is missing', () => {
+    expect(resolveServerPlan(undefined, NOW)).toBe('trial');
+    expect(resolveServerPlan(null, NOW)).toBe('trial');
+  });
+
+  it('keys Pro off the server-owned isPro flag', () => {
+    expect(resolveServerPlan({ isPro: true }, NOW)).toBe('pro');
+    expect(resolveServerPlan({ isPro: true, trialStartedAt: expiredTrial }, NOW)).toBe('pro');
+  });
+
+  it('IGNORES a forged client plan:pro on a non-Pro doc — regression for the fee/gate bypass', () => {
+    expect(resolveServerPlan({ isPro: false, plan: 'pro', trialStartedAt: expiredTrial }, NOW)).toBe('free');
+  });
+
+  it('IGNORES a forged client plan:trial on an expired-trial doc — regression for the free-tier gate bypass', () => {
+    expect(resolveServerPlan({ plan: 'trial', trialStartedAt: expiredTrial }, NOW)).toBe('free');
+  });
+
+  it('derives trial vs free from trialStartedAt, not the stored plan', () => {
+    expect(resolveServerPlan({ trialStartedAt: inTrial }, NOW)).toBe('trial');
+    expect(resolveServerPlan({ trialStartedAt: expiredTrial }, NOW)).toBe('free');
+    // stored plan:'free' must not override an in-window trial computation
+    expect(resolveServerPlan({ plan: 'free', trialStartedAt: inTrial }, NOW)).toBe('trial');
+  });
+
+  it('treats the trial boundary as exclusive (>= TRIAL_MS is free)', () => {
+    expect(resolveServerPlan({ trialStartedAt: new Date(NOW - TRIAL_MS).toISOString() }, NOW)).toBe('free');
+    expect(resolveServerPlan({ trialStartedAt: new Date(NOW - TRIAL_MS + 1000).toISOString() }, NOW)).toBe('trial');
+  });
+
+  it('accepts a Firestore Timestamp-like trialStartedAt (toDate)', () => {
+    const ts = { toDate: () => new Date(inTrial) };
+    expect(resolveServerPlan({ trialStartedAt: ts }, NOW)).toBe('trial');
+  });
+
+  it('falls back to trial when trialStartedAt is unparseable', () => {
+    expect(resolveServerPlan({ trialStartedAt: 'not-a-date' }, NOW)).toBe('trial');
   });
 });

--- a/functions/src/subscription.helpers.ts
+++ b/functions/src/subscription.helpers.ts
@@ -17,6 +17,36 @@
 export const TRIAL_DAYS = 14;
 export const TRIAL_MS = TRIAL_DAYS * 24 * 60 * 60 * 1000;
 
+// Resolve a user's effective tier from their profile/subscription doc for
+// server-side gating (free-tier send gate, Square fee tier, invoice payment
+// block). Source of truth on the server so the client cannot claim a tier.
+//
+// SECURITY (PAY-02): a stored `plan` string is NOT trusted — it was
+// historically client-writable, so a free/expired user could set
+// plan:'trial' or plan:'pro' to dodge the free-tier gate and the higher fee.
+// `isPro` is server-owned (firestore.rules denies client true-writes and every
+// server Pro-writer — Stripe, Apple/Google validators, incident restore — sets
+// it), so it is the only trustworthy Pro signal; trial/free is re-derived from
+// trialStartedAt. (trialStartedAt stays client-writable for the first-quote
+// trial bootstrap — a known, separately-tracked weakness; gaming it only
+// extends the trial, it does not grant Pro.)
+export function resolveServerPlan(
+  data: Record<string, any> | undefined | null,
+  nowMs: number,
+): 'trial' | 'free' | 'pro' {
+  if (!data) return 'trial';
+  if (data.isPro === true) return 'pro';
+  const rawStart = data.trialStartedAt;
+  if (rawStart) {
+    const startedAt = rawStart?.toDate ? rawStart.toDate() : new Date(rawStart);
+    const startMs = startedAt.getTime();
+    if (Number.isFinite(startMs)) {
+      return nowMs - startMs < TRIAL_MS ? 'trial' : 'free';
+    }
+  }
+  return 'trial';
+}
+
 // Monthly-equivalent AUD we actually bill per subscription. Source of truth:
 // the live Stripe "Starter" prices ($49/mo, $328/yr); the iOS/Android yearly
 // SKUs are priced to match. Update here if prices change.
@@ -24,9 +54,10 @@ export const SUB_PRICE_AUD = { monthly: 49, yearly: 328 };
 
 // Apple StoreKit 2 purchase tokens are JWS blobs (header.payload.signature)
 // whose payload records the purchase environment ('Sandbox' | 'Production').
-// validateAppleReceipt writes isPro + productId even when Apple validation
-// fails, so a sandbox/TestFlight purchase is otherwise indistinguishable from
-// a paid sub. Reads an explicit `environment` field first so a backfill can
+// Until Jul 2026 validateAppleReceipt wrote isPro + productId even when Apple
+// validation failed (fixed — PAY-01, receiptValidation.helpers.ts), so
+// HISTORICAL sandbox/TestFlight docs are otherwise indistinguishable from
+// paid subs. Reads an explicit `environment` field first so a backfill can
 // override without re-decoding.
 export function subEnvironment(sub: any): string | null {
   if (typeof sub?.environment === 'string') return sub.environment;

--- a/package-lock.json
+++ b/package-lock.json
@@ -84,6 +84,7 @@
       },
       "devDependencies": {
         "@babel/core": "^7.23.5",
+        "@firebase/rules-unit-testing": "^5.0.1",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/react": "^16.3.2",
         "@types/papaparse": "^5.5.2",
@@ -2920,6 +2921,19 @@
       "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.5.0.tgz",
       "integrity": "sha512-vI3bqLoF14L/GchtgayMiFpZJF+Ao3uR8WCde0XpYNkSokDpAKca2DxvcfeZv7lZUqkUwQPL2wD83d3vQ4vvrg==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/rules-unit-testing": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@firebase/rules-unit-testing/-/rules-unit-testing-5.0.1.tgz",
+      "integrity": "sha512-EvbxUvgoY2cG7vgtdhKc7gjalKzeO3AWr2NiUuyEEmcXaSaOJanV3hXLj3Viigs+Y/jFYQmtVPpSoiwUs/ZlPg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "firebase": "^12.0.0"
+      }
     },
     "node_modules/@firebase/storage": {
       "version": "0.14.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@expo/vector-icons": "^14.1.0",
         "@lottiefiles/dotlottie-react": "^0.18.1",
         "@react-native-async-storage/async-storage": "^2.1.2",
+        "@react-native-google-signin/google-signin": "^16.1.2",
         "@react-navigation/bottom-tabs": "^7.2.0",
         "@react-navigation/native": "^7.0.14",
         "@react-navigation/stack": "^7.0.0",
@@ -3488,6 +3489,25 @@
       },
       "peerDependencies": {
         "react-native": "^0.0.0-0 || >=0.65 <1.0"
+      }
+    },
+    "node_modules/@react-native-google-signin/google-signin": {
+      "version": "16.1.2",
+      "resolved": "https://registry.npmjs.org/@react-native-google-signin/google-signin/-/google-signin-16.1.2.tgz",
+      "integrity": "sha512-1hf4pRmpnS5t0dHtqU72Q1FmWzsCZR2Sm3uVQbbfMKeNPl5TKjpAsP6F8QTZ9L+Q6Cnn9tL9BXpDCb1nyutdCQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://universal-sign-in.com"
+      },
+      "peerDependencies": {
+        "expo": ">=52.0.40",
+        "react": "*",
+        "react-native": "*"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        }
       }
     },
     "node_modules/@react-native/assets-registry": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@expo/vector-icons": "^14.1.0",
     "@lottiefiles/dotlottie-react": "^0.18.1",
     "@react-native-async-storage/async-storage": "^2.1.2",
+    "@react-native-google-signin/google-signin": "^16.1.2",
     "@react-navigation/bottom-tabs": "^7.2.0",
     "@react-navigation/native": "^7.0.14",
     "@react-navigation/stack": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "export:staging": "expo export --platform web --output-dir dist-staging",
     "deploy:staging": "npm run export:staging && firebase deploy --only hosting --config firebase.staging.json --project hansendev",
     "test": "vitest run",
+    "test:rules": "export PATH=\"/opt/homebrew/opt/openjdk/bin:$PATH\" && firebase emulators:exec --only firestore --project demo-quotemate-rules \"vitest run --config vitest.rules.config.ts\"",
     "test:watch": "vitest",
     "postinstall": "patch-package"
   },
@@ -92,6 +93,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.23.5",
+    "@firebase/rules-unit-testing": "^5.0.1",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.2",
     "@types/papaparse": "^5.5.2",

--- a/src/screens/AuthScreen.tsx
+++ b/src/screens/AuthScreen.tsx
@@ -8,9 +8,7 @@ import { View, StyleSheet, Platform, KeyboardAvoidingView, ScrollView, Image, An
 import { Text, TextInput, Button, Surface, Title, ActivityIndicator } from 'react-native-paper';
 import { signInWithEmailAndPassword, createUserWithEmailAndPassword, GoogleAuthProvider, signInWithPopup, signInWithRedirect, getRedirectResult, signInWithCredential, OAuthProvider, sendEmailVerification, getAdditionalUserInfo, UserCredential } from 'firebase/auth';
 import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
-import * as Google from 'expo-auth-session/providers/google';
 import * as AppleAuthentication from 'expo-apple-authentication';
-import * as WebBrowser from 'expo-web-browser';
 import * as Crypto from 'expo-crypto';
 import { doc, setDoc, serverTimestamp } from 'firebase/firestore';
 import { auth, db } from '../config/firebase';
@@ -18,9 +16,12 @@ import { colors } from '../theme';
 import { WebContainer } from '../components/WebContainer';
 import { lightTap, errorTap } from '../utils/haptics';
 import { trackWebEvent } from '../utils/webAnalytics';
-
-// Needed for expo-auth-session to work properly
-WebBrowser.maybeCompleteAuthSession();
+import { signInGetIdToken, statusCodes } from '../services/nativeGoogleSignIn';
+import {
+  firebaseSignInWithGoogleIdToken,
+  mapGoogleSignInError,
+  messageForGoogleSignInError,
+} from '../services/googleSignInCore';
 
 // Detect in-app browsers (Facebook Messenger, Instagram, etc.) that block popups
 function isInAppBrowser(): boolean {
@@ -105,25 +106,6 @@ export function AuthScreen() {
   // Input refs for keyboard Return key chaining
   const passwordRef = useRef<RNTextInput>(null);
   const confirmPasswordRef = useRef<RNTextInput>(null);
-
-  // Configure Google Sign-In for mobile (iOS/Android)
-  // On web, we use Firebase popup instead of expo-auth-session
-  // Use debug client ID in development, production client ID in production
-  const androidClientId = __DEV__ && process.env.GOOGLE_OAUTH_ANDROID_CLIENT_ID_DEBUG
-    ? process.env.GOOGLE_OAUTH_ANDROID_CLIENT_ID_DEBUG
-    : process.env.GOOGLE_OAUTH_ANDROID_CLIENT_ID;
-
-  const [request, response, promptAsync] = Google.useAuthRequest({
-    iosClientId: process.env.GOOGLE_OAUTH_IOS_CLIENT_ID || undefined,
-    androidClientId: androidClientId || undefined,
-    // Public web OAuth client ID (exposed in the browser anyway). Hardcoded as
-    // a fallback because non-EXPO_PUBLIC env vars are not inlined into the web
-    // bundle — without this, Google.useAuthRequest throws on web ("webClientId
-    // must be defined"), crashing the whole app to a white screen. Mirrors the
-    // hardcoded-fallback pattern in src/config/firebase.ts.
-    webClientId: process.env.GOOGLE_OAUTH_WEB_CLIENT_ID
-      || '652758863537-86a4q9860h9aalo36f4sb9tpt39ut7bs.apps.googleusercontent.com',
-  });
 
   // Handle Google redirect result (for in-app browsers that can't use popups)
   useEffect(() => {
@@ -222,24 +204,6 @@ export function AuthScreen() {
     checkAppleAuth();
   }, []);
 
-  // Handle Google Sign-In response (mobile)
-  useEffect(() => {
-    if (response?.type === 'success') {
-      setIsProcessingOAuth(true);
-      const { id_token } = response.params;
-      const credential = GoogleAuthProvider.credential(id_token);
-      signInWithCredential(auth, credential)
-        .then((result) => {
-          saveRegistrationPlatform(result, 'google');
-          // Keep loading state - App.tsx will handle navigation
-        })
-        .catch((error) => {
-          setError('Failed to sign in with Google');
-          setIsProcessingOAuth(false);
-        });
-    }
-  }, [response]);
-
   const handleSignIn = async () => {
     if (!email || !password) {
       setError('Please enter email and password');
@@ -328,17 +292,29 @@ export function AuthScreen() {
         await saveRegistrationPlatform(result, 'google');
         // Keep loading state - App.tsx will handle navigation
       } else {
-        // Mobile: Use expo-auth-session
-        await promptAsync();
-        // OAuth state will be handled by response useEffect
+        // Mobile: native Google Sign-In (no browser, no OAuth redirect — works
+        // regardless of the device's default browser, including Firefox).
+        const idToken = await signInGetIdToken();
+        if (!idToken) return; // user cancelled the native picker — no error
+        setIsProcessingOAuth(true);
+        const result = await firebaseSignInWithGoogleIdToken(auth, idToken);
+        await saveRegistrationPlatform(result, 'google');
+        // Keep loading state - App.tsx will handle navigation
       }
     } catch (err: any) {
-      if (err.code === 'auth/popup-closed-by-user') {
-        setError('Sign-in cancelled');
-      } else if (err.code === 'auth/popup-blocked') {
-        setError('Pop-up blocked. Please allow pop-ups for this site.');
+      if (Platform.OS === 'web') {
+        if (err.code === 'auth/popup-closed-by-user') {
+          setError('Sign-in cancelled');
+        } else if (err.code === 'auth/popup-blocked') {
+          setError('Pop-up blocked. Please allow pop-ups for this site.');
+        } else {
+          setError('Failed to sign in with Google. Please try again.');
+        }
       } else {
-        setError('Failed to sign in with Google. Please try again.');
+        // Native SDK errors: no Play Services → email fallback; misconfig
+        // (DEVELOPER_ERROR) → generic; user cancel/in-progress → silent.
+        const message = messageForGoogleSignInError(mapGoogleSignInError(err, statusCodes));
+        if (message) setError(message);
       }
       setIsProcessingOAuth(false);
       setLoading(false);
@@ -544,7 +520,7 @@ export function AuthScreen() {
                   style={styles.googleButton}
                   contentStyle={styles.socialButtonContent}
                   labelStyle={styles.socialButtonLabel}
-                  disabled={loading || (Platform.OS !== 'web' && !request)}
+                  disabled={loading}
                   icon={() => <MaterialCommunityIcons name="google" size={22} color="#fff" />}
                   buttonColor="#4285F4"
                   textColor="#fff"

--- a/src/screens/PaywallScreen.tsx
+++ b/src/screens/PaywallScreen.tsx
@@ -34,6 +34,7 @@ import {
 } from '../config/pricingConfig';
 import { trackEvent } from '../services/analyticsService';
 import { resolvePurchaseAnalytics } from '../services/paywallAnalytics.helpers';
+import { classifyReceiptResponse, ReceiptOutcome } from '../utils/purchaseValidation';
 
 const PRO_NUDGES = [
   "Your quotes deserve the VIP treatment",
@@ -233,7 +234,10 @@ export function PaywallScreen() {
             const hasValidPurchase = purchase.purchaseToken || purchase.transactionReceipt || purchase.id;
             if (hasValidPurchase) {
               trackEvent('purchase_completed', resolvePurchaseAnalytics(purchase, Platform.OS));
-              // Send receipt to server for validation
+              // PAY-01: premium is granted only when the server verifies the
+              // receipt — no local fallback. On transient failures the store
+              // transaction stays unfinished so validation retries later.
+              let outcome: ReceiptOutcome = 'retry';
               const currentUser = auth.currentUser;
               if (currentUser) {
                 const API_BASE_URL = process.env.API_BASE_URL || 'https://us-central1-hansendev.cloudfunctions.net';
@@ -249,28 +253,44 @@ export function PaywallScreen() {
                       purchaseToken: purchase.purchaseToken || null,
                     }),
                   });
-                  const data = await response.json();
-                  if (data.success) {
-                    // Reload subscription from Firestore
-                    await loadSubscription();
-                  } else {
-                  }
+                  const data = await response.json().catch(() => null);
+                  outcome = classifyReceiptResponse(response.status, data);
                 } catch (serverError) {
+                  outcome = 'retry';
                 }
               }
 
-              // Always set local premium as fallback
-              await setPremium(
-                true,
-                purchase.productId,
-                new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toISOString()
-              );
-              await billingService.finishTransaction(purchase);
-              Alert.alert(
-                'Success!',
-                'Welcome to QuoteMate Pro! You now have unlimited quotes.',
-                [{ text: 'OK', onPress: () => navigation.goBack() }]
-              );
+              if (outcome === 'granted') {
+                // Reload subscription from Firestore (server wrote it)
+                await loadSubscription();
+                await setPremium(
+                  true,
+                  purchase.productId,
+                  new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toISOString()
+                );
+                await billingService.finishTransaction(purchase);
+                Alert.alert(
+                  'Success!',
+                  'Welcome to QuoteMate Pro! You now have unlimited quotes.',
+                  [{ text: 'OK', onPress: () => navigation.goBack() }]
+                );
+              } else if (outcome === 'rejected') {
+                trackEvent('purchase_failed', { platform: Platform.OS, code: 'validation_rejected' });
+                await billingService.finishTransaction(purchase);
+                Alert.alert(
+                  "Couldn't verify your purchase",
+                  "The app store couldn't confirm this purchase, so Pro hasn't been switched on. If you were charged, use Restore Purchases or contact support and we'll sort it out.",
+                  [{ text: 'OK' }]
+                );
+              } else {
+                // Transient failure: leave the transaction unfinished so the
+                // store re-delivers it and validation retries.
+                Alert.alert(
+                  'Almost there',
+                  "Your purchase went through but we couldn't confirm it just now. It'll finish automatically next time you open the app.",
+                  [{ text: 'OK' }]
+                );
+              }
             }
           } catch (error) {
             Alert.alert('Error', 'Failed to process purchase. Please contact support.');
@@ -363,7 +383,9 @@ export function PaywallScreen() {
 
       if (activeSubscriptions.length > 0) {
         const purchase = activeSubscriptions[0];
-        // Validate with server
+        // PAY-01: restore only completes when the server verifies the
+        // receipt — no local-premium fallback.
+        let outcome: ReceiptOutcome = 'retry';
         const currentUser = auth.currentUser;
         if (currentUser) {
           const API_BASE_URL = process.env.API_BASE_URL || 'https://us-central1-hansendev.cloudfunctions.net';
@@ -379,22 +401,34 @@ export function PaywallScreen() {
                 purchaseToken: purchase.purchaseToken || null,
               }),
             });
-            const data = await response.json();
-            if (data.success) {
-              await loadSubscription();
-            }
+            const data = await response.json().catch(() => null);
+            outcome = classifyReceiptResponse(response.status, data);
           } catch (serverError) {
+            outcome = 'retry';
           }
         }
 
-        await setPremium(
-          true,
-          purchase.productId,
-          new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toISOString()
-        );
-        Alert.alert('Restored', 'Your Pro subscription has been restored successfully!', [
-          { text: 'OK', onPress: () => navigation.goBack() },
-        ]);
+        if (outcome === 'granted') {
+          await loadSubscription();
+          await setPremium(
+            true,
+            purchase.productId,
+            new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toISOString()
+          );
+          Alert.alert('Restored', 'Your Pro subscription has been restored successfully!', [
+            { text: 'OK', onPress: () => navigation.goBack() },
+          ]);
+        } else if (outcome === 'rejected') {
+          Alert.alert(
+            "Couldn't verify your subscription",
+            "The app store couldn't confirm an active subscription for this account. If you believe that's wrong, contact support and we'll sort it out."
+          );
+        } else {
+          Alert.alert(
+            'Try again shortly',
+            "We found your subscription but couldn't confirm it just now. Please try Restore Purchases again in a few minutes."
+          );
+        }
       } else {
         Alert.alert('No Purchases Found', 'No previous subscriptions were found for this account.');
       }

--- a/src/services/firestoreService.ts
+++ b/src/services/firestoreService.ts
@@ -23,6 +23,7 @@ import { auth, db } from '../config/firebase';
 import { Quote, BusinessSettings, SubscriptionStatus, Invoice, ReferralInfo, Contact } from '../types';
 import { Conversation } from '../types/assistant';
 import { TRIAL_DAYS, TRIAL_MS } from '../utils/trialConfig';
+import { clientSubscriptionWritePayload } from '../utils/subscriptionWritePayload';
 
 /**
  * Master switch for Mate conversation logging. While this is on, every chat is
@@ -379,19 +380,11 @@ class FirestoreService {
 
     try {
       const subscriptionRef = doc(db, 'users', userId, 'profile', 'subscription');
-      await setDoc(subscriptionRef, {
-        isPro: subscriptionStatus.isPro,
-        plan: subscriptionStatus.plan ?? null,
-        quotesThisMonth: subscriptionStatus.quotesThisMonth,
-        currentPeriodStart: subscriptionStatus.currentPeriodStart.toISOString(),
-        currentPeriodEnd: subscriptionStatus.currentPeriodEnd.toISOString(),
-        freeQuotesLimit: subscriptionStatus.freeQuotesLimit,
-        trialStartedAt: subscriptionStatus.trialStartedAt ? new Date(subscriptionStatus.trialStartedAt).toISOString() : null,
-        trialExpired: subscriptionStatus.trialExpired || false,
-        dismissedUpgradeBanner: subscriptionStatus.dismissedUpgradeBanner || false,
-        platformFeeBps: subscriptionStatus.platformFeeBps ?? null,
-        syncedAt: new Date().toISOString(),
-      });
+      // PAY-02: merge a whitelisted payload only. Entitlement fields (isPro,
+      // plan, platformFeeBps, …) are server-owned — firestore.rules denies
+      // client writes that touch them, and the old non-merge setDoc here was
+      // clobbering server-written billing fields for real Pro users.
+      await setDoc(subscriptionRef, clientSubscriptionWritePayload(subscriptionStatus), { merge: true });
     } catch (error) {
       throw error;
     }

--- a/src/services/googleSignInCore.test.ts
+++ b/src/services/googleSignInCore.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Tests for the native Google Sign-In core logic.
+ *
+ * Regression context: the browser (`expo-auth-session`) Google flow silently
+ * failed when the default browser was Firefox — the OAuth redirect never made
+ * it back to the app. We moved native sign-in to the native SDK; these tests
+ * lock in the result-interpretation and error-mapping that the platform adapter
+ * relies on, including the v16 behaviour where cancellation is a *returned*
+ * `{ type: 'cancelled' }` rather than a thrown error.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const authSdk = vi.hoisted(() => ({
+  credential: vi.fn((idToken: string) => ({ providerId: 'google.com', idToken })),
+  signInWithCredential: vi.fn(async (_auth: unknown, cred: unknown) => ({ user: { uid: 'u1' }, _cred: cred })),
+}));
+
+vi.mock('firebase/auth', () => ({
+  GoogleAuthProvider: { credential: authSdk.credential },
+  signInWithCredential: authSdk.signInWithCredential,
+}));
+
+import {
+  interpretSignInResponse,
+  mapGoogleSignInError,
+  messageForGoogleSignInError,
+  firebaseSignInWithGoogleIdToken,
+  type GoogleStatusCodes,
+} from './googleSignInCore';
+
+const CODES: GoogleStatusCodes = {
+  SIGN_IN_CANCELLED: 'SIGN_IN_CANCELLED',
+  IN_PROGRESS: 'IN_PROGRESS',
+  PLAY_SERVICES_NOT_AVAILABLE: 'PLAY_SERVICES_NOT_AVAILABLE',
+  SIGN_IN_REQUIRED: 'SIGN_IN_REQUIRED',
+};
+
+beforeEach(() => {
+  authSdk.credential.mockClear();
+  authSdk.signInWithCredential.mockClear();
+  authSdk.signInWithCredential.mockResolvedValue({ user: { uid: 'u1' } } as never);
+});
+
+describe('interpretSignInResponse (v16 signIn() shape)', () => {
+  it('returns success + idToken for a successful response', () => {
+    const res = { type: 'success', data: { idToken: 'tok-123', user: { id: 'x' } } };
+    expect(interpretSignInResponse(res)).toEqual({ status: 'success', idToken: 'tok-123' });
+  });
+
+  it('treats a cancelled response as cancelled, not an error — regression for v16 return-based cancel', () => {
+    expect(interpretSignInResponse({ type: 'cancelled', data: null })).toEqual({ status: 'cancelled' });
+  });
+
+  it('flags a success response whose idToken is null as no-token (never hands null to Firebase)', () => {
+    expect(interpretSignInResponse({ type: 'success', data: { idToken: null } })).toEqual({ status: 'no-token' });
+  });
+
+  it('flags an empty-string idToken as no-token', () => {
+    expect(interpretSignInResponse({ type: 'success', data: { idToken: '' } })).toEqual({ status: 'no-token' });
+  });
+
+  it('is defensive against malformed / undefined responses', () => {
+    expect(interpretSignInResponse(undefined)).toEqual({ status: 'no-token' });
+    expect(interpretSignInResponse(null)).toEqual({ status: 'no-token' });
+    expect(interpretSignInResponse({})).toEqual({ status: 'no-token' });
+    expect(interpretSignInResponse({ data: {} })).toEqual({ status: 'no-token' });
+  });
+});
+
+describe('mapGoogleSignInError (thrown SDK errors)', () => {
+  it('maps PLAY_SERVICES_NOT_AVAILABLE → no-play-services', () => {
+    expect(mapGoogleSignInError({ code: CODES.PLAY_SERVICES_NOT_AVAILABLE }, CODES)).toBe('no-play-services');
+  });
+
+  it('maps a defensively-thrown SIGN_IN_CANCELLED → cancelled', () => {
+    expect(mapGoogleSignInError({ code: CODES.SIGN_IN_CANCELLED }, CODES)).toBe('cancelled');
+  });
+
+  it('maps IN_PROGRESS → in-progress', () => {
+    expect(mapGoogleSignInError({ code: CODES.IN_PROGRESS }, CODES)).toBe('in-progress');
+  });
+
+  it('maps an unknown code (Android DEVELOPER_ERROR / SHA-1 misconfig) → failed', () => {
+    expect(mapGoogleSignInError({ code: 'DEVELOPER_ERROR' }, CODES)).toBe('failed');
+    expect(mapGoogleSignInError(new Error('boom'), CODES)).toBe('failed');
+    expect(mapGoogleSignInError(undefined, CODES)).toBe('failed');
+  });
+});
+
+describe('messageForGoogleSignInError', () => {
+  it('points the user at email sign-in when Play Services is missing', () => {
+    expect(messageForGoogleSignInError('no-play-services')).toMatch(/email/i);
+  });
+
+  it('stays silent on user cancel and in-progress (no scary error)', () => {
+    expect(messageForGoogleSignInError('cancelled')).toBeNull();
+    expect(messageForGoogleSignInError('in-progress')).toBeNull();
+  });
+
+  it('shows a generic retry message on failure', () => {
+    expect(messageForGoogleSignInError('failed')).toMatch(/try again/i);
+  });
+});
+
+describe('firebaseSignInWithGoogleIdToken', () => {
+  it('builds a Google credential from the idToken and signs into Firebase', async () => {
+    const auth = { name: 'auth' } as never;
+    const result = await firebaseSignInWithGoogleIdToken(auth, 'tok-abc');
+
+    expect(authSdk.credential).toHaveBeenCalledWith('tok-abc');
+    expect(authSdk.signInWithCredential).toHaveBeenCalledTimes(1);
+    const [passedAuth, passedCred] = authSdk.signInWithCredential.mock.calls[0];
+    expect(passedAuth).toBe(auth);
+    expect(passedCred).toEqual({ providerId: 'google.com', idToken: 'tok-abc' });
+    expect(result).toMatchObject({ user: { uid: 'u1' } });
+  });
+
+  it('propagates Firebase errors (e.g. account-exists-with-different-credential)', async () => {
+    authSdk.signInWithCredential.mockRejectedValueOnce(
+      Object.assign(new Error('exists'), { code: 'auth/account-exists-with-different-credential' }),
+    );
+    await expect(firebaseSignInWithGoogleIdToken({} as never, 'tok')).rejects.toMatchObject({
+      code: 'auth/account-exists-with-different-credential',
+    });
+  });
+});

--- a/src/services/googleSignInCore.ts
+++ b/src/services/googleSignInCore.ts
@@ -1,0 +1,95 @@
+/**
+ * Pure, native-free logic for the native Google Sign-In flow.
+ *
+ * Kept deliberately free of `@react-native-google-signin/google-signin` and any
+ * Expo/React Native imports so it runs under vitest (node) with only
+ * `firebase/auth` mocked. The platform adapter (`nativeGoogleSignIn.native.ts`)
+ * feeds the SDK's return values and thrown errors through these helpers.
+ *
+ * Why this exists: the browser-based `expo-auth-session` Google flow depended on
+ * the device's default browser handing an OAuth redirect back to the app, which
+ * Firefox (and other non-Chrome Custom Tabs providers) drop — so sign-in
+ * silently failed. The native SDK has no browser/redirect, and this module is
+ * where its results become a Firebase session.
+ */
+import { GoogleAuthProvider, signInWithCredential } from 'firebase/auth';
+import type { Auth, UserCredential } from 'firebase/auth';
+
+/**
+ * The subset of the SDK's `statusCodes` we branch on. Passed in (rather than
+ * imported) so this module stays free of the native dependency.
+ */
+export interface GoogleStatusCodes {
+  SIGN_IN_CANCELLED: string;
+  IN_PROGRESS: string;
+  PLAY_SERVICES_NOT_AVAILABLE: string;
+  SIGN_IN_REQUIRED: string;
+}
+
+export type GoogleSignInOutcome =
+  | { status: 'success'; idToken: string }
+  | { status: 'cancelled' }
+  | { status: 'no-token' };
+
+/**
+ * Interpret the *return value* of `GoogleSignin.signIn()`.
+ *
+ * v13+ (incl. the installed v16) returns `{ type: 'cancelled', data: null }`
+ * when the user backs out — a normal, non-error outcome — and
+ * `{ type: 'success', data: { idToken, ... } }` on success. `idToken` can be
+ * `null` on success in edge cases, which we surface as `no-token` so the caller
+ * doesn't hand `null` to Firebase.
+ */
+export function interpretSignInResponse(res: unknown): GoogleSignInOutcome {
+  const r = res as { type?: string; data?: { idToken?: string | null } } | null | undefined;
+  if (r?.type === 'cancelled') return { status: 'cancelled' };
+  const idToken = r?.data?.idToken ?? null;
+  if (typeof idToken === 'string' && idToken.length > 0) {
+    return { status: 'success', idToken };
+  }
+  return { status: 'no-token' };
+}
+
+export type GoogleSignInErrorKind = 'cancelled' | 'in-progress' | 'no-play-services' | 'failed';
+
+/**
+ * Classify a *thrown* SDK error (e.g. from `hasPlayServices()` or a native
+ * module rejection). Cancellation normally arrives as a return value now, but a
+ * thrown `SIGN_IN_CANCELLED` is still handled defensively. Unknown codes —
+ * including Android's `DEVELOPER_ERROR` (a SHA-1 / OAuth-client misconfig) —
+ * fall through to `failed`.
+ */
+export function mapGoogleSignInError(err: unknown, codes: GoogleStatusCodes): GoogleSignInErrorKind {
+  const code = (err as { code?: string } | null | undefined)?.code;
+  if (code === codes.SIGN_IN_CANCELLED) return 'cancelled';
+  if (code === codes.IN_PROGRESS) return 'in-progress';
+  if (code === codes.PLAY_SERVICES_NOT_AVAILABLE) return 'no-play-services';
+  return 'failed';
+}
+
+/**
+ * User-facing message for an error kind. `null` means show nothing (the user
+ * cancelled, or a sign-in is already running — neither warrants an error).
+ */
+export function messageForGoogleSignInError(kind: GoogleSignInErrorKind): string | null {
+  switch (kind) {
+    case 'cancelled':
+    case 'in-progress':
+      return null;
+    case 'no-play-services':
+      return 'Google sign-in needs Google Play Services. Please sign in with email instead.';
+    case 'failed':
+    default:
+      return 'Failed to sign in with Google. Please try again.';
+  }
+}
+
+/**
+ * Exchange a Google `idToken` for a Firebase session. The idToken's audience is
+ * the web/server OAuth client, which is exactly what Firebase's Google provider
+ * expects — so this is the same credential path the old browser flow used.
+ */
+export async function firebaseSignInWithGoogleIdToken(auth: Auth, idToken: string): Promise<UserCredential> {
+  const credential = GoogleAuthProvider.credential(idToken);
+  return signInWithCredential(auth, credential);
+}

--- a/src/services/nativeGoogleSignIn.d.ts
+++ b/src/services/nativeGoogleSignIn.d.ts
@@ -1,0 +1,20 @@
+/**
+ * Type surface for the platform-resolved `nativeGoogleSignIn` module
+ * (`nativeGoogleSignIn.native.ts` / `nativeGoogleSignIn.web.ts`).
+ *
+ * tsconfig uses `moduleResolution: "bundler"` with no platform `moduleSuffixes`,
+ * so `tsc` can't resolve a bare `import '.../nativeGoogleSignIn'` to the
+ * platform files. This declaration provides the shared type; Metro still picks
+ * the correct `.native`/`.web` implementation at bundle time. Keep it in sync
+ * with both implementations.
+ */
+export function ensureConfigured(): void;
+
+export function signInGetIdToken(): Promise<string | null>;
+
+export const statusCodes: {
+  SIGN_IN_CANCELLED: string;
+  IN_PROGRESS: string;
+  PLAY_SERVICES_NOT_AVAILABLE: string;
+  SIGN_IN_REQUIRED: string;
+};

--- a/src/services/nativeGoogleSignIn.native.ts
+++ b/src/services/nativeGoogleSignIn.native.ts
@@ -1,0 +1,51 @@
+/**
+ * Native (iOS/Android) Google Sign-In adapter.
+ *
+ * Uses the native Google Play Services / iOS account picker via
+ * `@react-native-google-signin/google-signin` — there is NO browser or OAuth
+ * redirect, so sign-in works regardless of the device's default browser. This
+ * replaces the old `expo-auth-session` Custom Tab flow, which Firefox and other
+ * non-Chrome browsers broke by dropping the `com.quotemate.app:/oauthredirect`
+ * hand-off back to the app.
+ *
+ * Metro resolves this file on native; `nativeGoogleSignIn.web.ts` is used on
+ * web (where Google sign-in goes through Firebase `signInWithPopup` instead).
+ * All branching logic lives in `googleSignInCore.ts` so it stays unit-testable.
+ */
+import { GoogleSignin, statusCodes } from '@react-native-google-signin/google-signin';
+import Constants from 'expo-constants';
+import { interpretSignInResponse } from './googleSignInCore';
+
+let configured = false;
+
+export function ensureConfigured(): void {
+  if (configured) return;
+  GoogleSignin.configure({
+    // webClientId is the *server*/web OAuth client. The idToken it yields is
+    // minted for this audience, which is exactly what Firebase's Google
+    // provider verifies — so no extra Firebase wiring is needed.
+    webClientId: Constants.expoConfig?.extra?.googleWebClientId,
+    iosClientId: Constants.expoConfig?.extra?.googleIosClientId,
+    offlineAccess: false,
+  });
+  configured = true;
+}
+
+/**
+ * Present the native account picker and return a Google `idToken`, or `null` if
+ * the user cancelled (a normal outcome the caller should treat as a no-op).
+ * Throws for real failures — no Play Services, or a SHA-1 / OAuth-client
+ * misconfiguration (`DEVELOPER_ERROR`) — which the caller maps via
+ * `mapGoogleSignInError`.
+ */
+export async function signInGetIdToken(): Promise<string | null> {
+  ensureConfigured();
+  await GoogleSignin.hasPlayServices({ showPlayServicesUpdateDialog: true });
+  const res = await GoogleSignin.signIn();
+  const outcome = interpretSignInResponse(res);
+  if (outcome.status === 'cancelled') return null;
+  if (outcome.status === 'no-token') throw new Error('no-id-token');
+  return outcome.idToken;
+}
+
+export { statusCodes };

--- a/src/services/nativeGoogleSignIn.web.ts
+++ b/src/services/nativeGoogleSignIn.web.ts
@@ -1,0 +1,24 @@
+/**
+ * Web stub for the native Google Sign-In adapter.
+ *
+ * Google sign-in on web goes through Firebase `signInWithPopup` directly in
+ * `AuthScreen`; this native-only module must never be invoked there. It exists
+ * so the web bundle never resolves `@react-native-google-signin/google-signin`
+ * (a native module). Metro picks this file for the web platform.
+ */
+
+export function ensureConfigured(): void {
+  // no-op on web
+}
+
+export async function signInGetIdToken(): Promise<string | null> {
+  throw new Error('nativeGoogleSignIn is unavailable on web');
+}
+
+/** Mirrors the SDK's statusCodes so `AuthScreen`'s error mapping type-checks. */
+export const statusCodes = {
+  SIGN_IN_CANCELLED: 'SIGN_IN_CANCELLED',
+  IN_PROGRESS: 'IN_PROGRESS',
+  PLAY_SERVICES_NOT_AVAILABLE: 'PLAY_SERVICES_NOT_AVAILABLE',
+  SIGN_IN_REQUIRED: 'SIGN_IN_REQUIRED',
+} as const;

--- a/src/utils/purchaseValidation.test.ts
+++ b/src/utils/purchaseValidation.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { classifyReceiptResponse } from './purchaseValidation';
+
+describe('classifyReceiptResponse (PAY-01)', () => {
+  it('grants only when the server explicitly confirms success', () => {
+    expect(classifyReceiptResponse(200, { success: true, validated: true })).toBe('granted');
+  });
+
+  it('rejects a 402 RECEIPT_VALIDATION_FAILED — regression for the old "always set local premium" fallback', () => {
+    expect(
+      classifyReceiptResponse(402, { success: false, error: 'RECEIPT_VALIDATION_FAILED', reason: 'not_validated' }),
+    ).toBe('rejected');
+  });
+
+  it('rejects a 400 bad-request response', () => {
+    expect(classifyReceiptResponse(400, { error: 'Missing required parameters' })).toBe('rejected');
+  });
+
+  it('does not grant on success:false even with HTTP 200', () => {
+    expect(classifyReceiptResponse(200, { success: false })).toBe('rejected');
+  });
+
+  it('does not grant on a malformed body', () => {
+    expect(classifyReceiptResponse(200, null)).toBe('rejected');
+    expect(classifyReceiptResponse(200, 'ok')).toBe('rejected');
+    expect(classifyReceiptResponse(200, { success: 'true' })).toBe('rejected');
+  });
+
+  it('retries on server errors so the store re-delivers the transaction', () => {
+    expect(classifyReceiptResponse(500, null)).toBe('retry');
+    expect(classifyReceiptResponse(503, { error: 'unavailable' })).toBe('retry');
+  });
+});

--- a/src/utils/purchaseValidation.ts
+++ b/src/utils/purchaseValidation.ts
@@ -1,0 +1,25 @@
+/**
+ * Client-side handling of validateAppleReceipt / validateGoogleReceipt
+ * responses (PAY-01).
+ *
+ * The server now rejects receipts it can't verify (402 RECEIPT_VALIDATION_
+ * FAILED) instead of granting Pro. The client must mirror that: local
+ * premium is only set when the server confirmed the entitlement — never as
+ * a fallback.
+ */
+
+export type ReceiptOutcome =
+  /** Server verified the receipt and wrote the entitlement. */
+  | 'granted'
+  /** Server reached a decision: the receipt does not earn Pro. */
+  | 'rejected'
+  /** Transient failure (5xx / no response) — leave the store transaction
+   *  unfinished so it is re-delivered and validation retries later. */
+  | 'retry';
+
+export function classifyReceiptResponse(status: number, body: unknown): ReceiptOutcome {
+  const data = body as { success?: unknown } | null | undefined;
+  if (data && data.success === true) return 'granted';
+  if (status >= 500) return 'retry';
+  return 'rejected';
+}

--- a/src/utils/subscriptionWritePayload.test.ts
+++ b/src/utils/subscriptionWritePayload.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { SubscriptionStatus } from '../types';
+import {
+  CLIENT_SUBSCRIPTION_WRITABLE_KEYS,
+  clientSubscriptionWritePayload,
+} from './subscriptionWritePayload';
+
+const proStatus: SubscriptionStatus = {
+  isPro: true,
+  plan: 'pro',
+  quotesThisMonth: 3,
+  currentPeriodStart: new Date('2026-07-01T00:00:00Z'),
+  currentPeriodEnd: new Date('2026-07-31T23:59:59Z'),
+  freeQuotesLimit: 5,
+  trialStartedAt: new Date('2026-06-20T00:00:00Z'),
+  trialExpired: false,
+  dismissedUpgradeBanner: true,
+  platformFeeBps: 100,
+};
+
+describe('clientSubscriptionWritePayload (PAY-02)', () => {
+  it('never contains entitlement fields, even for a Pro status — regression for the client isPro upload', () => {
+    const payload = clientSubscriptionWritePayload(proStatus);
+    for (const key of ['isPro', 'plan', 'platformFeeBps', 'platform', 'productId', 'transactionId', 'purchaseToken', 'appleValidated', 'googleValidated', 'subscriptionId', 'cancelAtPeriodEnd']) {
+      expect(payload, `payload must not contain ${key}`).not.toHaveProperty(key);
+    }
+  });
+
+  it('contains exactly the rules-allow-listed keys', () => {
+    const payload = clientSubscriptionWritePayload(proStatus);
+    expect(Object.keys(payload).sort()).toEqual([...CLIENT_SUBSCRIPTION_WRITABLE_KEYS].sort());
+  });
+
+  it('serialises dates as ISO strings and preserves quota/trial values', () => {
+    const payload = clientSubscriptionWritePayload(proStatus);
+    expect(payload.quotesThisMonth).toBe(3);
+    expect(payload.currentPeriodStart).toBe('2026-07-01T00:00:00.000Z');
+    expect(payload.currentPeriodEnd).toBe('2026-07-31T23:59:59.000Z');
+    expect(payload.trialStartedAt).toBe('2026-06-20T00:00:00.000Z');
+    expect(payload.dismissedUpgradeBanner).toBe(true);
+    expect(typeof payload.syncedAt).toBe('string');
+  });
+
+  it('writes trialStartedAt as null (not undefined) when the trial has not started', () => {
+    const payload = clientSubscriptionWritePayload({ ...proStatus, trialStartedAt: undefined });
+    expect(payload.trialStartedAt).toBeNull();
+  });
+
+  it('tolerates ISO-string dates from AsyncStorage round-trips', () => {
+    const stored = {
+      ...proStatus,
+      currentPeriodStart: '2026-07-01T00:00:00.000Z',
+      currentPeriodEnd: '2026-07-31T23:59:59.000Z',
+    } as unknown as SubscriptionStatus;
+    const payload = clientSubscriptionWritePayload(stored);
+    expect(payload.currentPeriodStart).toBe('2026-07-01T00:00:00.000Z');
+  });
+});

--- a/src/utils/subscriptionWritePayload.ts
+++ b/src/utils/subscriptionWritePayload.ts
@@ -1,0 +1,40 @@
+/**
+ * The ONLY payload the client may write to users/{uid}/profile/subscription
+ * (PAY-02).
+ *
+ * Entitlement fields (isPro, plan, platformFeeBps, platform, productId,
+ * appleValidated, …) are server-owned: they are written exclusively by the
+ * receipt/Stripe/admin backends, and firestore.rules denies any client write
+ * that touches them. Before Jul 2026 the client mirrored its whole local
+ * SubscriptionStatus with a non-merge setDoc — which both let a client grant
+ * itself Pro and, for real Pro users, clobbered the server's billing fields
+ * (the source of the "bare isPro" records in the live pull).
+ *
+ * Mirror of the allow-list in firestore.rules (users/{uid}/profile/
+ * subscription match) — update both together.
+ */
+import { SubscriptionStatus } from '../types';
+
+export const CLIENT_SUBSCRIPTION_WRITABLE_KEYS = [
+  'quotesThisMonth',
+  'currentPeriodStart',
+  'currentPeriodEnd',
+  'freeQuotesLimit',
+  'trialStartedAt',
+  'trialExpired',
+  'dismissedUpgradeBanner',
+  'syncedAt',
+] as const;
+
+export function clientSubscriptionWritePayload(status: SubscriptionStatus): Record<string, unknown> {
+  return {
+    quotesThisMonth: status.quotesThisMonth,
+    currentPeriodStart: new Date(status.currentPeriodStart).toISOString(),
+    currentPeriodEnd: new Date(status.currentPeriodEnd).toISOString(),
+    freeQuotesLimit: status.freeQuotesLimit,
+    trialStartedAt: status.trialStartedAt ? new Date(status.trialStartedAt).toISOString() : null,
+    trialExpired: status.trialExpired || false,
+    dismissedUpgradeBanner: status.dismissedUpgradeBanner || false,
+    syncedAt: new Date().toISOString(),
+  };
+}

--- a/vitest.rules.config.ts
+++ b/vitest.rules.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vitest/config';
+
+// Security-rules tests need the Firestore emulator, so they run via
+// `npm run test:rules` (firebase emulators:exec) instead of the default
+// vitest config — which deliberately does not include this file.
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['firestore.rules.test.ts'],
+    // The emulator serialises rule evaluation; keep a single worker.
+    fileParallelism: false,
+    testTimeout: 20000,
+    hookTimeout: 30000,
+  },
+});


### PR DESCRIPTION
Three fixes on top of `main` (`44d67f6`): two Phase 0 payment/growth criticals, plus a fix for Android Google sign-in on non-Chrome default browsers.

---

## `568ddde` — fix(auth): native Google Sign-In on iOS/Android (Firefox fix)

Android Google sign-in **silently failed when the default browser was Firefox** (also Samsung Internet, DuckDuckGo). The old `expo-auth-session` Custom Tab flow relied on the browser handing the `com.quotemate.app:/oauthredirect` redirect back to the app — Firefox drops it, so `response.type` never became `success` and the user was bounced back to the login screen with no error. Chrome worked, which was the tell.

Migrated native (iOS/Android) sign-in to `@react-native-google-signin` v16 — the native Play Services / iOS account picker, **no browser and no OAuth redirect**, so the default browser is irrelevant. Web is unchanged (Firebase `signInWithPopup`).

- `src/services/googleSignInCore.ts` — pure, native-free result-interpretation + error-mapping + Firebase credential exchange. **14 vitest cases.** Handles the v16 change where cancellation is a returned `{type:'cancelled'}` (not a thrown error).
- `src/services/nativeGoogleSignIn.native.ts` / `.web.ts` (+ `.d.ts`) — platform-split adapter; the web bundle never pulls the native module (verified via web export).
- `src/screens/AuthScreen.tsx` — removed `useAuthRequest` / `[response]` effect / `expo-auth-session` + `WebBrowser`; native branch now `signInGetIdToken → firebaseSignInWithGoogleIdToken`.
- `app.config.js` — google-signin config plugin (`iosUrlScheme`) + public client IDs in `extra` with hardcoded fallbacks (mirrors `config/firebase.ts`).

> ⚠️ **Before this works in production:** register the **Google Play App Signing SHA-1** on the `com.quotemate.app` Android OAuth client (else `DEVELOPER_ERROR`), and it needs a **native dev-client/EAS build** to verify autolinking — **not OTA-able**. Acceptance test = sign in on a real Android phone with **Firefox set as default**. Google **Calendar** connect still uses the browser flow → separate ticket.

---

## `c1e1bf3` — fix(payments): close PAY-01/02/03 entitlement holes

Phase 0 criticals — no store/rules path grants Pro without a verified purchase, and the free-tier gate can't be bypassed client-side. *(Authored separately; summarised from the commit.)*

- **PAY-01** — failed receipt validation no longer grants Pro. `receiptVerdict()` gates Apple/Google validation: store rejection is terminal (402), an unreachable store/missing credential is retryable (503) so a real buyer isn't burned during an outage, lapsed receipts refused. Client sets premium **only** on server-confirmed success (local-premium fallback removed).
- **PAY-02** — clients can no longer write subscription entitlements. `firestore.rules` replaces the owner wildcard with a field-guarded match (entitlement keys server-only; `isPro` creatable only as `false`); client writes go through a whitelisted merge payload. Server re-derives plan from `isPro` + `trialStartedAt` instead of trusting a client plan string.
- **PAY-03** — Square OAuth state forgery closed via a single-use SHA-256 nonce bound to the authenticated uid, consumed transactionally in the callback.

> ⚠️ **Rules/functions NOT deployed** — needs sign-off (per the commit).

---

## `466d3db` — fix(storeFunnel): widen refresh window 4→10 days

Play's installs CSV lags up to ~5 days, so the 4-day rolling window could permanently miss days (0 writes despite working access). Merge-writes make the wider window free.

---

## Tests
- App suite: **908 pass** (incl. 14 new auth cases); `tsc` clean; web export clean — verified this session for the auth work.
- Per the payments commit: functions **390** + emulator-backed firestore rules **20** green (`npm run test:rules`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
