### PR TITLE
feat(reports): service reports — integrated onto main (with sign-in fix + payments)

### DIFF
--- a/functions/src/composeServiceReport.helpers.test.ts
+++ b/functions/src/composeServiceReport.helpers.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildComposePrompt,
+  sanitizeComposed,
+  ComposeNotes,
+} from './composeServiceReport.helpers';
+
+describe('buildComposePrompt — factual, Aussie, no forbidden term', () => {
+  const notes: ComposeNotes = {
+    natureOfProblem: 'no hot water, tripped rcd',
+    workCarriedOut: 'replaced split flex on hws iso',
+    recommendedWork: 'suggest rcd upgrade next visit',
+  };
+
+  it('instructs the model not to invent facts', () => {
+    const prompt = buildComposePrompt(notes).toLowerCase();
+    expect(prompt).toContain('factual');
+    // Names the categories of invention that are forbidden.
+    expect(prompt).toContain('measurements');
+    expect(prompt).toContain('equipment');
+    expect(prompt).toMatch(/never add|do not add|only what is in the note|not already present/);
+  });
+
+  it('demands Australian English and gender-neutral tone', () => {
+    const prompt = buildComposePrompt(notes).toLowerCase();
+    expect(prompt).toContain('australian english');
+    expect(prompt).toContain('gender-neutral');
+  });
+
+  it('forbids a greeting', () => {
+    const prompt = buildComposePrompt(notes).toLowerCase();
+    expect(prompt).toMatch(/greeting|salutation/);
+  });
+
+  it('never contains the two-letter machine-intelligence term', () => {
+    const prompt = buildComposePrompt(notes);
+    // Word-boundary match so "maintain"/"claims" etc. don't trip it.
+    expect(prompt).not.toMatch(/\bAI\b/);
+    expect(prompt).not.toMatch(/\bai\b/i);
+  });
+
+  it('only asks for the fields that were supplied', () => {
+    const prompt = buildComposePrompt({ workCarriedOut: 'swapped the tap washer' });
+    expect(prompt).toContain('"workCarriedOut"');
+    expect(prompt).not.toContain('"natureOfProblem"');
+    expect(prompt).not.toContain('"recommendedWork"');
+  });
+});
+
+describe('sanitizeComposed — cleans model output', () => {
+  it('strips a leading greeting the model added', () => {
+    const raw = JSON.stringify({
+      natureOfProblem: 'Hi there, the customer reported no hot water and a tripped safety switch.',
+      workCarriedOut: 'Replaced the damaged flexible connection on the hot water isolation valve.',
+      recommendedWork: 'Upgrade the safety switch on a future visit.',
+    });
+    const out = sanitizeComposed(raw, {
+      natureOfProblem: 'no hot water, tripped rcd',
+      workCarriedOut: 'replaced split flex on hws iso',
+      recommendedWork: 'suggest rcd upgrade next visit',
+    });
+    expect(out.natureOfProblem).toBe(
+      'the customer reported no hot water and a tripped safety switch.',
+    );
+    expect(out.natureOfProblem).not.toMatch(/^hi/i);
+    // Non-greeting fields pass through untouched.
+    expect(out.workCarriedOut).toContain('Replaced the damaged flexible connection');
+  });
+
+  it('blanks a field whose source note was empty, even if the model returned prose', () => {
+    const raw = JSON.stringify({
+      natureOfProblem: 'Leaking mixer tap in the kitchen.',
+      recommendedWork: 'You should really re-plumb the whole kitchen and add three new taps.',
+    });
+    const out = sanitizeComposed(raw, {
+      natureOfProblem: 'leaking kitchen mixer',
+      // workCarriedOut and recommendedWork were never entered by the tradie.
+    });
+    expect(out.natureOfProblem).toBe('Leaking mixer tap in the kitchen.');
+    expect(out.workCarriedOut).toBe('');
+    expect(out.recommendedWork).toBe('');
+  });
+
+  it('keeps the tradie note when the model drops a supplied field', () => {
+    const raw = JSON.stringify({ natureOfProblem: 'Reported a blocked drain.' });
+    const out = sanitizeComposed(raw, {
+      natureOfProblem: 'blocked drain',
+      workCarriedOut: 'cleared the blockage with the eel',
+    });
+    expect(out.natureOfProblem).toBe('Reported a blocked drain.');
+    // Model omitted workCarriedOut — the tradie's own note is preserved.
+    expect(out.workCarriedOut).toBe('cleared the blockage with the eel');
+  });
+
+  it('tolerates a code-fenced JSON reply', () => {
+    const raw = '```json\n{"natureOfProblem":"Faulty powerpoint in the garage."}\n```';
+    const out = sanitizeComposed(raw, { natureOfProblem: 'dead powerpoint garage' });
+    expect(out.natureOfProblem).toBe('Faulty powerpoint in the garage.');
+  });
+
+  it('returns all-blank when source notes are empty and the reply is unusable', () => {
+    const out = sanitizeComposed('not json at all', {});
+    expect(out).toEqual({ natureOfProblem: '', workCarriedOut: '', recommendedWork: '' });
+  });
+});

--- a/functions/src/composeServiceReport.helpers.ts
+++ b/functions/src/composeServiceReport.helpers.ts
@@ -1,0 +1,183 @@
+/**
+ * Pure, network-free logic for the Service Report write-up compose step.
+ *
+ * A tradie types rough notes at the end of a service visit — "found split
+ * flex on the hot water iso, replaced it, recommend rcd upgrade next visit".
+ * The compose callable rewrites those into clean, professional service-report
+ * prose for a customer-facing document. These helpers hold the two pieces
+ * that must stay unit-testable without touching Gemini or Firestore:
+ *
+ *   buildComposePrompt — assembles the model instruction, and
+ *   sanitizeComposed   — cleans the model output back into the three fields.
+ *
+ * The discipline mirrors src/utils/sanitizeJobDescription.ts: the rewrite is
+ * STRICTLY FACTUAL. The model may tidy grammar and tone but must never invent
+ * equipment, measurements, part numbers, or claims that aren't in the note.
+ * An empty source note always yields an empty output field — the model is
+ * never allowed to fill a blank.
+ */
+
+export interface ComposeNotes {
+  natureOfProblem?: string;
+  workCarriedOut?: string;
+  recommendedWork?: string;
+}
+
+export interface ComposeContext {
+  businessName?: string;
+  tradeCategory?: string;
+}
+
+export interface ComposedReport {
+  natureOfProblem: string;
+  workCarriedOut: string;
+  recommendedWork: string;
+}
+
+/** The three note fields, in output order, with their customer-facing labels. */
+const FIELDS: { key: keyof ComposeNotes; label: string; hint: string }[] = [
+  {
+    key: 'natureOfProblem',
+    label: 'Nature of the problem',
+    hint: 'what the customer reported or what was found on arrival',
+  },
+  {
+    key: 'workCarriedOut',
+    label: 'Work carried out',
+    hint: 'what was actually done during this visit',
+  },
+  {
+    key: 'recommendedWork',
+    label: 'Recommended work',
+    hint: 'work suggested for a future visit, if any',
+  },
+];
+
+function clean(v: string | undefined | null): string {
+  return (v || '').trim();
+}
+
+/**
+ * Build the single prompt string sent to the text model. Only the fields the
+ * tradie actually filled in are included, so the model is never handed a blank
+ * to complete. The instruction forbids invention, demands Australian English
+ * and gender-neutral wording, bans any greeting, and requires a JSON reply
+ * keyed by the field names so sanitizeComposed can parse it deterministically.
+ *
+ * Note: the strings below never use the two-letter term for machine
+ * intelligence — this prose can surface in review and must not seed it into a
+ * customer document.
+ */
+export function buildComposePrompt(notes: ComposeNotes, context?: ComposeContext): string {
+  const present = FIELDS.filter((f) => clean(notes[f.key]).length > 0);
+
+  const trade = clean(context?.tradeCategory);
+  const business = clean(context?.businessName);
+
+  const who = [
+    business ? `You are writing on behalf of ${business}.` : '',
+    trade ? `The trade is ${trade}.` : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  const rules = [
+    'You are cleaning up a tradesperson\'s rough notes into the write-up section of a service report that their customer will read.',
+    who,
+    'Rewrite ONLY the notes provided below into clear, professional prose.',
+    'Use Australian English spelling.',
+    'Write in a plain, factual, gender-neutral tone. Do not use "he", "she", "guys", "blokes" or similar.',
+    'STRICTLY FACTUAL: rewrite only what is in the note. Never add equipment, materials, measurements, part numbers, brands, times, prices, or any claim that is not already present. If a detail is not in the note, leave it out.',
+    'Do not add a greeting, sign-off, salutation, or any address to the reader (no "Hi", "Hello", "Dear", "G\'day"). Return the write-up text only.',
+    'Do not mention that this text was generated or assisted by any tool.',
+    'Keep each field to a sentence or two. Do not invent headings.',
+    'Reply with ONLY a JSON object, no code fences, with a string value for each of these keys: '
+      + present.map((f) => `"${f.key}"`).join(', ')
+      + '. Do not include keys that were not supplied.',
+  ]
+    .filter(Boolean)
+    .join('\n');
+
+  const sourceBlock = present
+    .map((f) => `${f.label} (${f.hint}):\n${clean(notes[f.key])}`)
+    .join('\n\n');
+
+  return `${rules}\n\nNOTES TO REWRITE:\n${sourceBlock}`;
+}
+
+// A leading greeting/salutation the model may prepend despite instructions.
+// Matched only at the very start of a field and removed, keeping the factual
+// body that follows.
+const LEADING_GREETING =
+  /^\s*(?:hi|hello|hey|g'?day|dear|good\s+(?:morning|afternoon|evening|day))\b[^,.!?:\n—-]*[,.!?:\n—-]+\s*/i;
+
+function stripLeadingGreeting(text: string): string {
+  let out = text;
+  // Apply once — a single leading salutation is the observed failure; looping
+  // could eat a legitimate sentence that merely starts with one of these words
+  // after the greeting is gone.
+  const m = LEADING_GREETING.exec(out);
+  if (m && m[0].trim().length > 0) out = out.slice(m[0].length);
+  return out.trim();
+}
+
+/** Pull a JSON object out of a raw model reply, tolerating code fences / prose. */
+function extractJson(raw: string): Record<string, unknown> | null {
+  const text = (raw || '').trim();
+  if (!text) return null;
+  // Strip a ```json … ``` (or bare ```) fence if the model added one.
+  const fenced = text.replace(/^```(?:json)?\s*/i, '').replace(/```\s*$/, '').trim();
+  const candidates = [fenced, text];
+  for (const c of candidates) {
+    try {
+      const parsed = JSON.parse(c);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+    } catch {
+      /* fall through to brace-slice */
+    }
+  }
+  // Last resort: slice from the first { to the last }.
+  const start = text.indexOf('{');
+  const end = text.lastIndexOf('}');
+  if (start !== -1 && end > start) {
+    try {
+      const parsed = JSON.parse(text.slice(start, end + 1));
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+    } catch {
+      /* give up */
+    }
+  }
+  return null;
+}
+
+/**
+ * Turn a raw model reply into the three write-up fields.
+ *
+ * Rules:
+ *  - A field whose SOURCE note was empty is always blank, whatever the model
+ *    returned — the model is never allowed to fill a gap.
+ *  - A leading greeting the model added is stripped.
+ *  - If the model dropped a field that had a source note, the tradie's own
+ *    (trimmed) note is kept rather than losing their factual content.
+ */
+export function sanitizeComposed(raw: string, notes: ComposeNotes): ComposedReport {
+  const parsed = extractJson(raw) || {};
+  const out = {} as ComposedReport;
+
+  for (const f of FIELDS) {
+    const source = clean(notes[f.key]);
+    if (!source) {
+      out[f.key] = '';
+      continue;
+    }
+    const modelValue = typeof parsed[f.key] === 'string' ? (parsed[f.key] as string) : '';
+    const chosen = clean(modelValue) || source;
+    out[f.key] = stripLeadingGreeting(chosen);
+  }
+
+  return out;
+}

--- a/functions/src/composeServiceReport.ts
+++ b/functions/src/composeServiceReport.ts
@@ -1,0 +1,103 @@
+// Service Report write-up compose — authenticated proxy to the Gemini text
+// model, mirroring assistantChat.ts (cors + verifyAuth + GEMINI_API_KEY guard
+// + generateContent fetch). The client posts the tradie's rough notes; we
+// build a strictly-factual rewrite prompt, forward it with the master key kept
+// off the device, and return the three cleaned write-up fields.
+//
+// Kept as its own onRequest (not folded into assistantChat) because it is a
+// one-shot rewrite with no tool loop and no per-turn quota: a service report
+// is a separate document type from a Mate chat turn.
+//
+// NOT registered in index.ts here — the Wiring phase exports it.
+
+import * as functions from 'firebase-functions';
+import fetch from 'node-fetch';
+import cors from 'cors';
+import { verifyAuth, checkRateLimit, RateLimitConfig } from './assistantToken';
+import {
+  buildComposePrompt,
+  sanitizeComposed,
+  ComposeNotes,
+  ComposeContext,
+} from './composeServiceReport.helpers';
+
+const corsHandler = cors({ origin: true });
+
+// Same text-capable flash model the Mate text chat uses.
+const CHAT_MODEL = 'gemini-3-flash-preview';
+
+// One-shot rewrite — a modest ceiling is plenty and bounds abuse.
+const COMPOSE_RATE: RateLimitConfig = { maxRequests: 20, windowMs: 60_000 };
+
+function hasAnyNote(notes: ComposeNotes | undefined | null): notes is ComposeNotes {
+  if (!notes || typeof notes !== 'object') return false;
+  return (
+    !!(notes.natureOfProblem && String(notes.natureOfProblem).trim()) ||
+    !!(notes.workCarriedOut && String(notes.workCarriedOut).trim()) ||
+    !!(notes.recommendedWork && String(notes.recommendedWork).trim())
+  );
+}
+
+export const composeServiceReport = functions
+  .runWith({ timeoutSeconds: 60, memory: '256MB' })
+  .https.onRequest((req, res) => {
+    corsHandler(req, res, async () => {
+      if (req.method !== 'POST') { res.status(405).send('Method Not Allowed'); return; }
+
+      const decoded = await verifyAuth(req, res);
+      if (!decoded) return;
+      const ok = await checkRateLimit(`report-compose:${decoded.uid}`, COMPOSE_RATE, res);
+      if (!ok) return;
+
+      const apiKey = process.env.GEMINI_API_KEY;
+      if (!apiKey) { res.status(500).json({ error: 'Mate is offline (no API key).' }); return; }
+
+      const notes = (req.body?.notes || {}) as ComposeNotes;
+      const context = (req.body?.context || undefined) as ComposeContext | undefined;
+      if (!hasAnyNote(notes)) {
+        res.status(400).json({ error: 'notes required.' });
+        return;
+      }
+
+      const prompt = buildComposePrompt(notes, context);
+      const body = {
+        contents: [{ role: 'user', parts: [{ text: prompt }] }],
+      };
+
+      const url = `https://generativelanguage.googleapis.com/v1beta/models/${CHAT_MODEL}:generateContent?key=${apiKey}`;
+      let geminiRes: Awaited<ReturnType<typeof fetch>>;
+      try {
+        geminiRes = await fetch(url, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        });
+      } catch (err: any) {
+        res.status(502).json({ error: 'Mate is offline — try again in a moment.', detail: err?.message });
+        return;
+      }
+
+      const text = await geminiRes.text();
+      if (!geminiRes.ok) {
+        // eslint-disable-next-line no-console
+        console.warn('[composeServiceReport] gemini error', geminiRes.status, text.slice(0, 300));
+        res.status(502).json({ error: 'Mate hit a snag — try again in a moment.' });
+        return;
+      }
+
+      let parsed: any;
+      try { parsed = JSON.parse(text); } catch {
+        res.status(502).json({ error: 'Mate returned an unreadable reply.' });
+        return;
+      }
+
+      const parts = parsed?.candidates?.[0]?.content?.parts || [];
+      const rawText = parts
+        .map((p: any) => (typeof p?.text === 'string' ? p.text : ''))
+        .join('')
+        .trim();
+
+      const composed = sanitizeComposed(rawText, notes);
+      res.status(200).json(composed);
+    });
+  });

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -75,6 +75,8 @@ export {
 export { onQuoteWritten, onInvoiceWritten, mirrorAllDocuments } from './documentMirror';
 export { assistantToken } from './assistantToken';
 export { assistantChat } from './assistantChat';
+export { composeServiceReport } from './composeServiceReport';
+export { sendServiceReport } from './serviceReportEmail';
 export { generatePresenterClip } from './generatePresenterClip';
 export { adminAssistantCosts, reportAssistantLiveUsage } from './assistantCosts';
 export { reportPriceFetchUsage } from './featureUsage';

--- a/functions/src/serviceReportEmail.helpers.test.ts
+++ b/functions/src/serviceReportEmail.helpers.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from 'vitest';
+import {
+  sanitizeReportFilename,
+  reportAttachmentFilename,
+  fmtAuDate,
+  buildReportEmailHtml,
+  buildReportPdfData,
+} from './serviceReportEmail';
+import type { ServiceReport } from './shared/report/types';
+
+const baseReport: ServiceReport = {
+  id: 'r1',
+  jobId: 'j1',
+  userId: 'u1',
+  number: 'RP-001',
+  visitDate: Date.UTC(2026, 6, 22, 3, 0, 0), // 22 July 2026 (AU)
+  serviceType: 'Annual pump service',
+  riskAssessment: 'Isolate power before work',
+  equipment: ['Multimeter', 'Torque wrench'],
+  itemsChecked: [
+    { id: 'a', text: 'Pressure tested', checked: true },
+    { id: 'b', text: 'Seals replaced', checked: false },
+  ],
+  natureOfProblem: 'Pump losing prime',
+  workCarriedOut: 'Replaced impeller seal',
+  recommendedWork: 'Replace pressure switch next visit',
+  photos: [
+    { id: 'p1', storageUrl: 'https://cdn.example/p1.jpg' },
+    { id: 'p2', storageUrl: 'https://cdn.example/p2.jpg' },
+  ],
+  customerSignature: { svgPath: 'M0 0 L1 1', name: 'Jane Client', signedAt: 1 },
+  technicianSignature: { svgPath: 'M2 2 L3 3', name: 'Bob Tradie', signedAt: 2 },
+  status: 'draft',
+  createdAt: 1,
+  updatedAt: 1,
+};
+
+const job = {
+  customerName: "O'Brien & Sons",
+  customerEmail: 'jane@example.com',
+  customerPhone: '0400 000 000',
+  jobAddress: '12 Smith St, Bendigo VIC',
+};
+
+describe('sanitizeReportFilename', () => {
+  it('strips punctuation and collapses whitespace', () => {
+    expect(sanitizeReportFilename("O'Brien & Sons")).toBe('OBrien_Sons');
+  });
+  it('caps length at 30 chars', () => {
+    expect(sanitizeReportFilename('x'.repeat(50)).length).toBe(30);
+  });
+});
+
+describe('reportAttachmentFilename', () => {
+  it('builds a Service_Report_<num>_<who>.pdf name', () => {
+    expect(reportAttachmentFilename('RP-001', 'John Smith')).toBe('Service_Report_RP001_John_Smith.pdf');
+  });
+  it('falls back to Report/Client when tokens sanitise to empty', () => {
+    expect(reportAttachmentFilename('###', '!!!')).toBe('Service_Report_Report_Client.pdf');
+  });
+});
+
+describe('fmtAuDate', () => {
+  it('formats an epoch as an AU long date', () => {
+    expect(fmtAuDate(Date.UTC(2026, 6, 22, 3, 0, 0))).toBe('22 July 2026');
+  });
+});
+
+describe('buildReportEmailHtml', () => {
+  const html = buildReportEmailHtml({
+    businessName: 'Acme Plumbing',
+    customerName: 'Jane Client',
+    reportNumber: 'RP-001',
+    serviceType: 'Annual pump service',
+    visitDate: '22 July 2026',
+    emailBody: 'Thanks for having us out today.',
+  });
+
+  it('shows the business name', () => {
+    expect(html).toContain('Acme Plumbing');
+  });
+  it('never mentions QuoteMate (customer-facing artifact)', () => {
+    expect(html).not.toContain('QuoteMate');
+    expect(html.toLowerCase()).not.toContain('quotemate');
+  });
+  it('never uses the word "AI"', () => {
+    // Match a standalone "AI" token, case-insensitive — must not appear.
+    expect(/\bAI\b/i.test(html)).toBe(false);
+  });
+  it('escapes the tradie note and includes report metadata', () => {
+    expect(html).toContain('Thanks for having us out today.');
+    expect(html).toContain('RP-001');
+    expect(html).toContain('22 July 2026');
+  });
+  it('escapes HTML in the business/customer names', () => {
+    const evil = buildReportEmailHtml({
+      businessName: '<script>x</script>',
+      customerName: 'a & b',
+      reportNumber: 'RP-002',
+      serviceType: 'Test',
+      visitDate: '1 January 2026',
+      emailBody: '',
+    });
+    expect(evil).not.toContain('<script>x</script>');
+    expect(evil).toContain('&lt;script&gt;');
+    expect(evil).toContain('a &amp; b');
+  });
+});
+
+describe('buildReportPdfData', () => {
+  const data = buildReportPdfData(baseReport, job);
+
+  it('maps customer identity from the parent job', () => {
+    expect(data.customerName).toBe("O'Brien & Sons");
+    expect(data.customerEmail).toBe('jane@example.com');
+    expect(data.customerPhone).toBe('0400 000 000');
+    expect(data.jobAddress).toBe('12 Smith St, Bendigo VIC');
+  });
+
+  it('preformats the visit date and carries the report body fields', () => {
+    expect(data.visitDate).toBe('22 July 2026');
+    expect(data.serviceType).toBe('Annual pump service');
+    expect(data.equipment).toEqual(['Multimeter', 'Torque wrench']);
+    expect(data.itemsChecked).toEqual([
+      { text: 'Pressure tested', checked: true },
+      { text: 'Seals replaced', checked: false },
+    ]);
+    expect(data.natureOfProblem).toBe('Pump losing prime');
+    expect(data.workCarriedOut).toBe('Replaced impeller seal');
+    expect(data.recommendedWork).toBe('Replace pressure switch next visit');
+  });
+
+  it('maps photo storageUrl to the PDF url field', () => {
+    expect(data.photos).toEqual([
+      { url: 'https://cdn.example/p1.jpg' },
+      { url: 'https://cdn.example/p2.jpg' },
+    ]);
+  });
+
+  it('passes signatures through as {svgPath, name}', () => {
+    expect(data.customerSignature).toEqual({ svgPath: 'M0 0 L1 1', name: 'Jane Client' });
+    expect(data.technicianSignature).toEqual({ svgPath: 'M2 2 L3 3', name: 'Bob Tradie' });
+  });
+
+  it('omits photos when includePhotos is false', () => {
+    expect(buildReportPdfData(baseReport, job, false).photos).toBeUndefined();
+  });
+
+  it('carries NO money, terms, or Square/payment fields (report ≠ invoice)', () => {
+    const keys = Object.keys(data);
+    for (const forbidden of [
+      'total', 'subtotal', 'gst', 'materials', 'terms', 'termsSnapshot',
+      'squarePaymentLinkUrl', 'payNowUrl', 'depositAmount', 'stage',
+    ]) {
+      expect(keys).not.toContain(forbidden);
+    }
+  });
+
+  it('falls back to Client when no job is linked', () => {
+    const orphan = buildReportPdfData(baseReport, null);
+    expect(orphan.customerName).toBe('Client');
+    expect(orphan.customerEmail).toBeUndefined();
+  });
+});

--- a/functions/src/serviceReportEmail.ts
+++ b/functions/src/serviceReportEmail.ts
@@ -1,0 +1,329 @@
+// Phase-2 Service Report email sender.
+//
+// A Service Report is a customer-facing leave-behind a tradie produces after a
+// service visit (users/{uid}/reports/{reportId}). It is NOT a Document: it
+// carries no money, no stage, no line items — so this sender is deliberately a
+// stripped-down sibling of documentHandlers.sendDocumentEmail:
+//   - NO Square payment link is minted or rendered.
+//   - NO Terms & Conditions are snapshotted or attached.
+//   - Every customer-facing string shows ONLY the tradie's business name —
+//     never "QuoteMate", never "via QuoteMate", and never the word "AI".
+//
+// Registration in index.ts is intentionally deferred (Phase-2 wiring) — this
+// module only exports the core sender and the onRequest handler.
+
+import * as admin from 'firebase-admin';
+import * as functions from 'firebase-functions';
+import cors from 'cors';
+import { verifyAuth } from './assistantToken';
+import { sendEmail, getUserEmail } from './email';
+import { generateQuotePdfBuffer } from './pdfGenerator';
+import { buildReportPdfHtml } from './shared/pdf';
+import type { ReportPdfData, BusinessPdfData } from './shared/pdf';
+import type { ServiceReport } from './shared/report/types';
+
+type AnyData = Record<string, any>;
+
+const db = () => admin.firestore();
+const corsHandler = cors({ origin: true });
+
+interface BusinessSettings {
+  businessName?: string;
+  email?: string;
+  phone?: string;
+  address?: string;
+  abn?: string;
+  website?: string;
+  logoStorageUrl?: string;
+  logoUri?: string;
+  brandColor?: string;
+  pdfTemplate?: any;
+  [key: string]: any;
+}
+
+export interface SendServiceReportEmailInput {
+  userId: string;
+  recipientEmail: string;
+  /** Optional tradie-authored cover note. Falls back to a neutral default. */
+  emailBody?: string;
+  /** Optional subject override. Falls back to "Service report … - …". */
+  subject?: string;
+  /** Attach the report photos as inline images in the PDF/email when true. */
+  includePhotos?: boolean;
+}
+
+export interface SendServiceReportEmailResult {
+  success: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers (unit-tested in serviceReportEmail.helpers.test.ts)
+// ---------------------------------------------------------------------------
+
+/** Reduce a display string to a filesystem-safe token. Mirrors the
+ * sanitizeFilename used by documentHandlers so attachment names stay tidy. */
+export function sanitizeReportFilename(s: string): string {
+  return (s || '').replace(/[^a-zA-Z0-9\s]/g, '').replace(/\s+/g, '_').substring(0, 30);
+}
+
+/** Build the PDF attachment filename, e.g. "Service_Report_RP-001_John_Smith.pdf". */
+export function reportAttachmentFilename(reportNumber: string, customerName: string): string {
+  const num = sanitizeReportFilename(reportNumber) || 'Report';
+  const who = sanitizeReportFilename(customerName) || 'Client';
+  return `Service_Report_${num}_${who}.pdf`;
+}
+
+/** Australian long-date, e.g. "22 July 2026". Pure — deterministic for a given ms. */
+export function fmtAuDate(value: number | undefined): string {
+  return new Date(value || Date.now()).toLocaleDateString('en-AU', {
+    day: '2-digit', month: 'long', year: 'numeric',
+  });
+}
+
+function esc(s: string): string {
+  return String(s ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+export interface ReportEmailHtmlArgs {
+  businessName: string;
+  customerName: string;
+  reportNumber: string;
+  serviceType: string;
+  visitDate: string; // preformatted
+  emailBody: string;
+}
+
+/**
+ * Build the report email body. Customer-facing, so it shows ONLY the tradie's
+ * business name — never "QuoteMate" — and never the word "AI". Pure/offline.
+ */
+export function buildReportEmailHtml(args: ReportEmailHtmlArgs): string {
+  const { businessName, customerName, reportNumber, serviceType, visitDate, emailBody } = args;
+  const name = esc(businessName || 'Your Tradie');
+  const bodyHtml = esc(emailBody || '').replace(/\n/g, '<br/>');
+  return `<!DOCTYPE html>
+<html lang="en"><head><meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0"></head>
+<body style="margin:0;padding:0;background:#f1f5f9;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;color:#0f172a;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#f1f5f9;">
+    <tr><td align="center" style="padding:32px 16px;">
+      <table role="presentation" width="600" cellpadding="0" cellspacing="0" style="max-width:600px;width:100%;background:#ffffff;border-radius:12px;border:1px solid #e2e8f0;">
+        <tr><td style="padding:36px 32px;">
+          <p style="color:#64748b;font-size:13px;font-weight:700;text-transform:uppercase;letter-spacing:0.6px;margin:0 0 8px;">${name}</p>
+          <h1 style="color:#0f172a;font-size:22px;font-weight:700;margin:0 0 18px;line-height:1.3;">Your service report</h1>
+          <p style="color:#334155;font-size:15px;line-height:1.6;margin:0 0 16px;">Hi ${esc(customerName || 'there')},</p>
+          <p style="color:#334155;font-size:15px;line-height:1.6;margin:0 0 20px;">${bodyHtml || 'Please find your service report attached.'}</p>
+          <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#f8fafc;border-radius:10px;border:1px solid #e2e8f0;margin:0 0 20px;">
+            <tr><td style="padding:16px 20px;">
+              <p style="margin:0 0 6px;color:#64748b;font-size:13px;">Report number</p>
+              <p style="margin:0 0 14px;color:#0f172a;font-size:15px;font-weight:600;">${esc(reportNumber)}</p>
+              <p style="margin:0 0 6px;color:#64748b;font-size:13px;">Service</p>
+              <p style="margin:0 0 14px;color:#0f172a;font-size:15px;font-weight:600;">${esc(serviceType || 'Service visit')}</p>
+              <p style="margin:0 0 6px;color:#64748b;font-size:13px;">Visit date</p>
+              <p style="margin:0;color:#0f172a;font-size:15px;font-weight:600;">${esc(visitDate)}</p>
+            </td></tr>
+          </table>
+          <p style="color:#334155;font-size:15px;line-height:1.6;margin:0 0 24px;">The full report is attached as a PDF. If you have any questions, just reply to this email.</p>
+          <p style="color:#0f172a;font-size:15px;line-height:1.6;margin:0;">Cheers,<br/><strong>${name}</strong></p>
+        </td></tr>
+      </table>
+      <p style="color:#94a3b8;font-size:12px;margin:20px 0 0;text-align:center;">${name}</p>
+    </td></tr>
+  </table>
+</body></html>`;
+}
+
+/**
+ * Map a ServiceReport (plus its parent Job for customer identity) into the
+ * ReportPdfData shape. Pure. Deliberately carries NO money, NO terms, and NO
+ * Square/payment fields — a report is a leave-behind, not an invoice.
+ */
+export function buildReportPdfData(report: ServiceReport, job: AnyData | null, includePhotos = true): ReportPdfData {
+  const j = job || {};
+  const data: ReportPdfData = {
+    reportNumber: report.number,
+    customerName: j.customerName || 'Client',
+    customerEmail: j.customerEmail || undefined,
+    customerPhone: j.customerPhone || undefined,
+    jobAddress: j.jobAddress || undefined,
+    visitDate: fmtAuDate(report.visitDate),
+    serviceType: report.serviceType || '',
+    riskAssessment: report.riskAssessment || undefined,
+    equipment: Array.isArray(report.equipment) ? report.equipment : [],
+    itemsChecked: (report.itemsChecked || []).map((it) => ({ text: it.text, checked: !!it.checked })),
+    natureOfProblem: report.natureOfProblem || undefined,
+    workCarriedOut: report.workCarriedOut || undefined,
+    recommendedWork: report.recommendedWork || undefined,
+    photos: includePhotos && Array.isArray(report.photos)
+      ? report.photos.map((p) => ({ url: p.storageUrl })).filter((p) => !!p.url)
+      : undefined,
+    customerSignature: report.customerSignature
+      ? { svgPath: report.customerSignature.svgPath, name: report.customerSignature.name }
+      : undefined,
+    technicianSignature: report.technicianSignature
+      ? { svgPath: report.technicianSignature.svgPath, name: report.technicianSignature.name }
+      : undefined,
+  };
+  return data;
+}
+
+// Loose RFC 5321 sanity check — mirrors documentHandlers.isLikelyValidEmail.
+function isLikelyValidEmail(s: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/.test((s || '').trim());
+}
+
+// ---------------------------------------------------------------------------
+// Core sender
+// ---------------------------------------------------------------------------
+
+/**
+ * Load the report's business settings + parent job, render the report PDF,
+ * attach it, and send the customer email — then stamp the report as sent.
+ *
+ * CRITICAL: no Square link is minted, no T&Cs are snapshotted/attached, and
+ * every customer-facing string shows only the business name.
+ */
+export async function sendServiceReportEmail(
+  report: ServiceReport,
+  input: SendServiceReportEmailInput,
+): Promise<SendServiceReportEmailResult> {
+  const firestore = db();
+  const { userId, recipientEmail, subject } = input;
+  const includePhotos = input.includePhotos !== false;
+
+  const settingsSnap = await firestore.doc(`users/${userId}/settings/business`).get();
+  const business: BusinessSettings = settingsSnap.exists ? (settingsSnap.data() as BusinessSettings) : {};
+
+  const jobSnap = report.jobId
+    ? await firestore.doc(`users/${userId}/jobs/${report.jobId}`).get()
+    : null;
+  const job: AnyData | null = jobSnap && jobSnap.exists ? (jobSnap.data() as AnyData) : null;
+
+  const pdfData = buildReportPdfData(report, job, includePhotos);
+
+  const logoUrl = business.logoStorageUrl || business.logoUri || '';
+  const businessData: BusinessPdfData = {
+    businessName: business.businessName || 'Business',
+    email: business.email,
+    phone: business.phone,
+    website: business.website,
+    abn: business.abn,
+    address: business.address,
+    logoHtml: logoUrl ? `<img src="${logoUrl}" alt="${business.businessName || 'Business'}" class="logo" />` : '',
+    brandColor: business.brandColor,
+    pdfTemplate: business.pdfTemplate,
+  };
+
+  const pdfHtml = buildReportPdfHtml(pdfData, businessData);
+  const pdfBuffer = await generateQuotePdfBuffer(pdfHtml);
+  const pdfBase64 = pdfBuffer.toString('base64');
+  const pdfFilename = reportAttachmentFilename(report.number, pdfData.customerName);
+
+  const emailBody = (input.emailBody || '').trim();
+  const htmlContent = buildReportEmailHtml({
+    businessName: business.businessName || '',
+    customerName: pdfData.customerName,
+    reportNumber: report.number,
+    serviceType: report.serviceType || '',
+    visitDate: pdfData.visitDate,
+    emailBody,
+  });
+
+  // Reply-To: prefer the saved business email so customer replies land in the
+  // tradie's inbox; fall back to the auth email. Display name is the business.
+  const businessEmail = (business.email || '').trim();
+  let replyEmail: string | null = businessEmail && isLikelyValidEmail(businessEmail) ? businessEmail : null;
+  if (!replyEmail) {
+    const authEmail = await getUserEmail(userId);
+    replyEmail = authEmail && isLikelyValidEmail(authEmail) ? authEmail : null;
+  }
+  const tradieDisplayName = business.businessName || undefined;
+
+  const trimmedSubject = (subject || '').trim();
+  const baseSubject = trimmedSubject
+    || `Service report from ${business.businessName || 'Your Tradie'} - ${report.serviceType || 'Service visit'}`;
+
+  const sent = await sendEmail({
+    to: recipientEmail,
+    subject: baseSubject,
+    htmlContent,
+    category: 'transactional',
+    userId,
+    tags: ['service-report-to-client'],
+    attachment: [{ name: pdfFilename, content: pdfBase64 }],
+    senderName: tradieDisplayName,
+    replyTo: replyEmail ? { email: replyEmail, name: tradieDisplayName } : undefined,
+  });
+
+  if (!sent) return { success: false };
+
+  // Stamp the report as sent. All fields are defined, so no undefined can reach
+  // Firestore; keep the merge minimal.
+  await firestore.doc(`users/${userId}/reports/${report.id}`).set({
+    status: 'sent',
+    sentAt: Date.now(),
+    sendMethod: 'email',
+    updatedAt: Date.now(),
+  }, { merge: true });
+
+  return { success: true };
+}
+
+// ---------------------------------------------------------------------------
+// HTTP handler (NOT registered in index.ts yet — Phase-2 wiring is deferred)
+// ---------------------------------------------------------------------------
+
+/**
+ * POST { reportId, recipientEmail, emailBody?, subject?, includePhotos? }
+ * Loads users/{uid}/reports/{reportId} for the authed user and sends it.
+ */
+export const sendServiceReport = functions
+  .runWith({ timeoutSeconds: 120, memory: '1GB' })
+  .https.onRequest((req, res) => {
+    corsHandler(req, res, async () => {
+      if (req.method !== 'POST') { res.status(405).send('Method Not Allowed'); return; }
+
+      const decoded = await verifyAuth(req, res);
+      if (!decoded) return;
+      const userId = decoded.uid;
+
+      const { reportId, recipientEmail, emailBody, subject, includePhotos } = req.body || {};
+      if (!reportId || typeof reportId !== 'string') {
+        res.status(400).json({ error: 'reportId required.' });
+        return;
+      }
+      if (!recipientEmail || typeof recipientEmail !== 'string') {
+        res.status(400).json({ error: 'recipientEmail required.' });
+        return;
+      }
+
+      const snap = await db().doc(`users/${userId}/reports/${reportId}`).get();
+      if (!snap.exists) {
+        res.status(404).json({ error: 'Report not found.' });
+        return;
+      }
+      const report = { id: snap.id, ...(snap.data() as AnyData) } as ServiceReport;
+
+      try {
+        const result = await sendServiceReportEmail(report, {
+          userId,
+          recipientEmail,
+          emailBody: typeof emailBody === 'string' ? emailBody : undefined,
+          subject: typeof subject === 'string' ? subject : undefined,
+          includePhotos: includePhotos !== false,
+        });
+        if (!result.success) {
+          res.status(502).json({ error: 'Report email could not be sent.' });
+          return;
+        }
+        res.status(200).json({ success: true });
+      } catch (err: any) {
+        // eslint-disable-next-line no-console
+        console.error('[sendServiceReport] failed', { userId, reportId, message: err?.message });
+        res.status(500).json({ error: 'Report email failed.' });
+      }
+    });
+  });

--- a/shared/pdf/htmlBuilders.ts
+++ b/shared/pdf/htmlBuilders.ts
@@ -3,7 +3,7 @@
  * Used by both client (Expo Print) and server (Puppeteer) renderers
  */
 
-import { PdfMaterial, QuotePdfData, InvoicePdfData, BusinessPdfData, PdfTemplateId } from './types';
+import { PdfMaterial, QuotePdfData, InvoicePdfData, BusinessPdfData, PdfTemplateId, ReportPdfData } from './types';
 import { formatCurrency } from './formatCurrency';
 import { printMediaCSS, getTemplateCSS } from './templates';
 import { PASSTHROUGH_SURCHARGE_PCT } from './squareFees';
@@ -596,6 +596,188 @@ export function buildQuotePdfHtml(
 
       <div class="pdf-footer">
         <p>QuoteMate</p>
+      </div>
+    </body>
+    </html>
+    `;
+}
+
+/**
+ * Render a single narrative block (nature of problem / work carried out /
+ * recommended work). Returns '' when the text is empty so the block is
+ * omitted entirely rather than left as an empty heading.
+ */
+function buildReportNarrativeHTML(heading: string, text: string | undefined): string {
+  if (!text || !text.trim()) return '';
+  return `
+      <div class="info-section" style="page-break-inside: avoid;">
+        <h3>${escapeHtml(heading)}</h3>
+        <p>${formatMultiline(text.trim())}</p>
+      </div>`;
+}
+
+/**
+ * Render one signature block: the printed name with the captured SVG path
+ * drawn inline underneath it. The viewBox matches the signature pad's
+ * coordinate space so the stroke scales to fit.
+ */
+function buildReportSignatureHTML(
+  label: string,
+  sig: { svgPath: string; name: string; width?: number; height?: number } | undefined,
+): string {
+  // No signature → no block. A heading over blank space on a customer
+  // document reads as "forgot to fill this in", not "optional".
+  if (!sig?.svgPath) return '';
+  const name = sig.name ? escapeHtml(sig.name) : '';
+  // viewBox must match the capture-space of the pad the ink was drawn on;
+  // a fixed guess clips signatures from pads with other proportions. The
+  // 300×150 fallback only covers legacy captures without dimensions.
+  const vbWidth = sig.width && sig.width > 0 ? sig.width : 300;
+  const vbHeight = sig.height && sig.height > 0 ? sig.height : 150;
+  const svg = `<svg class="report-signature-svg" viewBox="0 0 ${vbWidth} ${vbHeight}" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg"><path d="${sig.svgPath}" fill="none" stroke="#111827" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" /></svg>`;
+  return `
+      <div class="report-signature">
+        <div class="report-signature-label">${escapeHtml(label)}</div>
+        <div class="report-signature-name">${name}</div>
+        ${svg}
+      </div>`;
+}
+
+/**
+ * Build the full service-report PDF HTML document. A service report is a
+ * customer-facing leave-behind: what was found, what was done, what's
+ * recommended next — no money, no line items. Reuses the same header / logo
+ * / footer chrome as the quote and invoice builders. The footer shows only
+ * the tradie's business name (never "QuoteMate") because this is a
+ * customer-facing artifact.
+ */
+export function buildReportPdfHtml(data: ReportPdfData, business: BusinessPdfData): string {
+  const templateId: PdfTemplateId = business.pdfTemplate || 'professional';
+
+  const equipmentHtml = data.equipment.length > 0
+    ? `
+      <div class="section-wrapper" style="page-break-inside: avoid;">
+        <h3>Equipment</h3>
+        <ul class="report-list">
+          ${data.equipment.map((e) => `<li>${escapeHtml(e)}</li>`).join('')}
+        </ul>
+      </div>`
+    : '';
+
+  const checklistHtml = data.itemsChecked.length > 0
+    ? `
+      <div class="section-wrapper" style="page-break-inside: avoid;">
+        <h3>Items checked</h3>
+        <ul class="report-checklist">
+          ${data.itemsChecked.map((it) => `<li><span class="report-check-box">${it.checked ? '&#10003;' : '&#9744;'}</span><span class="report-check-text">${escapeHtml(it.text)}</span></li>`).join('')}
+        </ul>
+      </div>`
+    : '';
+
+  const photosHtml = (data.photos && data.photos.length > 0)
+    ? (() => {
+        const imgs = data.photos!
+          .map((p) => p.dataUri || p.url)
+          .filter((src): src is string => !!src)
+          .map((src) => `<div class="report-photo"><img src="${src}" alt="Service photo" /></div>`)
+          .join('');
+        return imgs
+          ? `
+      <div class="section-wrapper" style="page-break-inside: avoid;">
+        <h3>Photos</h3>
+        <div class="report-photo-grid">${imgs}</div>
+      </div>`
+          : '';
+      })()
+    : '';
+
+  const hasSignature = !!(data.customerSignature || data.technicianSignature);
+  const signaturesHtml = hasSignature
+    ? `
+      <div class="section-wrapper report-signatures" style="page-break-inside: avoid;">
+        <p class="report-signature-statement">I am satisfied the above work has been carried out as stated.</p>
+        <div class="report-signature-grid">
+          ${buildReportSignatureHTML('Customer', data.customerSignature)}
+          ${buildReportSignatureHTML('Technician', data.technicianSignature)}
+        </div>
+      </div>`
+    : '';
+
+  return `
+    <!DOCTYPE html>
+    <html>
+    <head>
+      <meta charset="UTF-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no" />
+      <style>
+        ${printMediaCSS}
+        ${getTemplateCSS(templateId, business.brandColor)}
+        .report-list { margin: 8px 0; padding-left: 20px; }
+        .report-list li { margin: 2px 0; }
+        .report-checklist { list-style: none; margin: 8px 0; padding: 0; }
+        .report-checklist li { display: flex; align-items: flex-start; margin: 4px 0; }
+        .report-check-box { display: inline-block; width: 20px; font-size: 15px; line-height: 1.4; }
+        .report-check-text { flex: 1; }
+        .report-photo-grid { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 8px; }
+        .report-photo { width: 48%; box-sizing: border-box; }
+        .report-photo img { width: 100%; height: auto; border-radius: 6px; }
+        .report-signature-statement { font-size: 12px; color: #4b5563; margin: 0 0 12px 0; }
+        .report-signature-grid { display: flex; gap: 24px; }
+        .report-signature { flex: 1; }
+        .report-signature-label { font-size: 11px; text-transform: uppercase; letter-spacing: 1px; color: #6b7280; }
+        .report-signature-name { font-weight: 700; margin: 4px 0; min-height: 18px; }
+        .report-signature-svg { width: 100%; max-width: 260px; height: 90px; border-bottom: 1px solid #9ca3af; }
+      </style>
+    </head>
+    <body>
+      <div class="content-wrapper">
+      <div class="header">
+        <div class="header-business">
+          <div class="header-content">
+            ${business.logoHtml || ''}
+            <div class="header-text">
+              <h1>${business.businessName}</h1>
+              <p>
+                ${business.abn ? `<strong>ABN:</strong> ${business.abn}<br>` : ''}
+                ${business.address ? `<strong>Address:</strong> ${business.address.replace(/\n/g, '<br>')}<br>` : ''}
+                ${business.email ? `<strong>Email:</strong> ${business.email}<br>` : ''}
+                ${business.phone ? `<strong>Phone:</strong> ${business.phone}${business.website ? '<br>' : ''}` : ''}
+                ${business.website ? `<strong>Web:</strong> ${business.website}` : ''}
+              </p>
+            </div>
+          </div>
+        </div>
+        <div class="header-meta">
+          <h2>SERVICE REPORT</h2>
+          ${data.reportNumber ? `<p><strong>Report #:</strong> ${escapeHtml(data.reportNumber)}</p>` : ''}
+          <p><strong>Visit Date:</strong> ${escapeHtml(data.visitDate)}</p>
+          <p><strong>Service Type:</strong> ${escapeHtml(data.serviceType)}</p>
+          <p><strong>Customer:</strong> ${escapeHtml(data.customerName)}</p>
+          ${data.customerEmail ? `<p><strong>Email:</strong> ${escapeHtml(data.customerEmail)}</p>` : ''}
+          ${data.customerPhone ? `<p><strong>Phone:</strong> ${escapeHtml(data.customerPhone)}</p>` : ''}
+          ${data.jobAddress ? `<p><strong>Job Address:</strong> ${escapeHtml(data.jobAddress)}</p>` : ''}
+        </div>
+      </div>
+
+      ${buildReportNarrativeHTML('Risk Assessment', data.riskAssessment)}
+
+      ${equipmentHtml}
+
+      ${checklistHtml}
+
+      ${buildReportNarrativeHTML('Nature of Problem', data.natureOfProblem)}
+
+      ${buildReportNarrativeHTML('Work Carried Out', data.workCarriedOut)}
+
+      ${buildReportNarrativeHTML('Recommended Work', data.recommendedWork)}
+
+      ${photosHtml}
+
+      ${signaturesHtml}
+      </div>
+
+      <div class="pdf-footer">
+        <p>${escapeHtml(business.businessName)}</p>
       </div>
     </body>
     </html>

--- a/shared/pdf/index.ts
+++ b/shared/pdf/index.ts
@@ -1,5 +1,5 @@
 export { formatCurrency } from './formatCurrency';
 export { printMediaCSS, getTemplateCSS, getTemplateAccentColor, PDF_TEMPLATES } from './templates';
-export { generateMaterialsHTML, generatePaymentMethodsHTML, buildQuotePdfHtml, buildInvoicePdfHtml, buildTermsHTML } from './htmlBuilders';
+export { generateMaterialsHTML, generatePaymentMethodsHTML, buildQuotePdfHtml, buildInvoicePdfHtml, buildReportPdfHtml, buildTermsHTML } from './htmlBuilders';
 export { PASSTHROUGH_SURCHARGE_PCT, QM_APP_FEE_PCT_ONLINE, QM_APP_FEE_PCT_ONLINE_FREE, QM_APP_FEE_PCT_IN_PERSON, QM_APP_FEE_PCT_IN_PERSON_FREE } from './squareFees';
-export type { PdfTemplateId, PdfTemplateInfo, PdfMaterial, LaborSection, QuotePdfData, InvoicePdfData, BusinessPdfData } from './types';
+export type { PdfTemplateId, PdfTemplateInfo, PdfMaterial, LaborSection, QuotePdfData, InvoicePdfData, ReportPdfData, BusinessPdfData } from './types';

--- a/shared/pdf/reportHtml.test.ts
+++ b/shared/pdf/reportHtml.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'vitest';
+import { buildReportPdfHtml } from './htmlBuilders';
+import type { ReportPdfData, BusinessPdfData } from './types';
+
+const business: BusinessPdfData = {
+  businessName: 'Aussie Plumbing Co',
+  email: 'jobs@aussieplumbing.com.au',
+  phone: '0400 111 222',
+  abn: '12 345 678 901',
+  logoHtml: '',
+};
+
+function reportData(over: Partial<ReportPdfData> = {}): ReportPdfData {
+  return {
+    reportNumber: 'RP-001',
+    customerName: 'Craig Customer',
+    visitDate: '22 July 2026',
+    serviceType: 'Hot water service',
+    equipment: ['Ladder', 'Pipe wrench'],
+    itemsChecked: [
+      { text: 'Isolation valve operating', checked: true },
+      { text: 'Pressure relief valve tested', checked: false },
+    ],
+    natureOfProblem: 'No hot water at the kitchen tap.',
+    workCarriedOut: 'Replaced the faulty thermostat.',
+    recommendedWork: '',
+    ...over,
+  };
+}
+
+describe('buildReportPdfHtml', () => {
+  it('renders checked and unchecked items differently', () => {
+    const html = buildReportPdfHtml(reportData(), business);
+    // Checked uses a tick glyph, unchecked an empty box — they must differ.
+    expect(html).toContain('&#10003;'); // tick for the checked item
+    expect(html).toContain('&#9744;'); // empty box for the unchecked item
+    expect(html).toContain('Isolation valve operating');
+    expect(html).toContain('Pressure relief valve tested');
+  });
+
+  it('omits a narrative block entirely when its text is empty', () => {
+    const html = buildReportPdfHtml(reportData({ recommendedWork: '' }), business);
+    expect(html).not.toContain('Recommended Work');
+    // A populated block is still present.
+    expect(html).toContain('Nature of Problem');
+    expect(html).toContain('No hot water at the kitchen tap.');
+  });
+
+  it('omits a narrative block for whitespace-only text', () => {
+    const html = buildReportPdfHtml(reportData({ workCarriedOut: '   \n  ' }), business);
+    expect(html).not.toContain('Work Carried Out');
+  });
+
+  it('shows the business name in the footer and never "QuoteMate"', () => {
+    const html = buildReportPdfHtml(reportData(), business);
+    expect(html).toContain('Aussie Plumbing Co');
+    expect(html).not.toContain('QuoteMate');
+  });
+
+  it('renders a signature svgPath inline in the output', () => {
+    const svgPath = 'M10 10 L20 20 L30 5';
+    const html = buildReportPdfHtml(
+      reportData({
+        customerSignature: { svgPath, name: 'Craig Customer' },
+      }),
+      business,
+    );
+    expect(html).toContain(svgPath);
+    expect(html).toContain('I am satisfied the above work has been carried out as stated.');
+    expect(html).toContain('Craig Customer');
+  });
+
+  it('renders photos from dataUri or url', () => {
+    const html = buildReportPdfHtml(
+      reportData({
+        photos: [{ url: 'https://example.com/a.jpg' }, { dataUri: 'data:image/png;base64,AAAA' }],
+      }),
+      business,
+    );
+    expect(html).toContain('https://example.com/a.jpg');
+    expect(html).toContain('data:image/png;base64,AAAA');
+  });
+
+  // Regression: the signature viewBox must match the pad the ink was drawn
+  // on. A hardcoded 300×150 clipped the bottom of every signature captured
+  // on the real pad (~360×180).
+  it('uses the captured pad dimensions as the signature viewBox', () => {
+    const html = buildReportPdfHtml(
+      reportData({
+        customerSignature: {
+          svgPath: 'M10 10 L200 170',
+          name: 'Craig Customer',
+          width: 384,
+          height: 180,
+        },
+      }),
+      business,
+    );
+    expect(html).toContain('viewBox="0 0 384 180"');
+  });
+
+  it('falls back to a 300x150 viewBox for legacy captures without dimensions', () => {
+    const html = buildReportPdfHtml(
+      reportData({
+        customerSignature: { svgPath: 'M10 10 L20 20', name: 'Craig Customer' },
+      }),
+      business,
+    );
+    expect(html).toContain('viewBox="0 0 300 150"');
+  });
+
+  // Regression: an unsigned party must not render as a heading over blank
+  // space — it reads as "forgot to fill this in" on a customer document.
+  it('omits the block for a party who has not signed', () => {
+    const html = buildReportPdfHtml(
+      reportData({
+        technicianSignature: { svgPath: 'M1 1 L2 2', name: 'Jess Tech' },
+        customerSignature: undefined,
+      }),
+      business,
+    );
+    expect(html).toContain('Technician');
+    expect(html).toContain('Jess Tech');
+    expect(html).not.toContain('report-signature-label">Customer<');
+  });
+});

--- a/shared/pdf/types.ts
+++ b/shared/pdf/types.ts
@@ -116,6 +116,25 @@ export interface InvoicePdfData extends QuotePdfData {
   depositCredit?: number;
 }
 
+export interface ReportPdfData {
+  reportNumber: string;
+  customerName: string;
+  customerEmail?: string;
+  customerPhone?: string;
+  jobAddress?: string;
+  visitDate: string; // preformatted e.g. "22 July 2026"
+  serviceType: string;
+  riskAssessment?: string;
+  equipment: string[];
+  itemsChecked: { text: string; checked: boolean }[];
+  natureOfProblem?: string;
+  workCarriedOut?: string;
+  recommendedWork?: string;
+  photos?: { dataUri?: string; url?: string }[];
+  customerSignature?: { svgPath: string; name: string; width?: number; height?: number };
+  technicianSignature?: { svgPath: string; name: string; width?: number; height?: number };
+}
+
 export interface BusinessPdfData {
   businessName: string;
   email?: string;

--- a/shared/report/types.ts
+++ b/shared/report/types.ts
@@ -1,0 +1,54 @@
+// Service Report entity — a customer-facing leave-behind document a tradie
+// produces after a service visit.
+//
+// Stored at users/{uid}/reports/{reportId}. Linked to a Job via `jobId`.
+// A report is NOT a Document: it carries no money, no stage, and no line
+// items — just what was found, what was done, and what's recommended next,
+// plus optional signatures and photos. shared/ is symlinked into
+// functions/src/shared so this same file serves client and server.
+
+import { JobPhoto } from '../job/types';
+import { SendMethod } from '../document/types';
+
+export type ServiceReportStatus = 'draft' | 'sent';
+
+export interface SignatureCapture {
+  svgPath: string;
+  name: string;
+  signedAt: number;
+  // Capture-space dimensions of the pad the signature was drawn on. The PDF
+  // renderer uses these as its SVG viewBox — without them it has to guess,
+  // and a wrong guess clips the ink. Optional for early captures; renderers
+  // fall back to 300×150.
+  width?: number;
+  height?: number;
+}
+
+export interface ReportChecklistItem {
+  id: string;
+  text: string;
+  checked: boolean;
+}
+
+export interface ServiceReport {
+  id: string;
+  jobId: string;
+  userId: string;
+  number: string; // "RP-001"
+  visitDate: number;
+  serviceType: string;
+  riskAssessment?: string;
+  equipment: string[];
+  itemsChecked: ReportChecklistItem[];
+  natureOfProblem?: string;
+  workCarriedOut?: string;
+  recommendedWork?: string;
+  photos?: JobPhoto[];
+  customerSignature?: SignatureCapture;
+  technicianSignature?: SignatureCapture;
+  status: ServiceReportStatus;
+  sentAt?: number;
+  sendMethod?: SendMethod;
+  createdAt: number;
+  updatedAt: number;
+}

--- a/src/components/JobActionsSheet.tsx
+++ b/src/components/JobActionsSheet.tsx
@@ -27,6 +27,7 @@ export type JobAction =
   | 'edit'
   | 'send'
   | 'duplicate'
+  | 'service_report'
   | 'exportPdf'
   | 'pushToXero'
   | 'archive'
@@ -101,6 +102,13 @@ const ROWS: RowDef[] = [
     label: 'Duplicate',
     sub: 'Clone scope + checklist into a new Accepted job',
     icon: 'content-duplicate',
+    when: () => true,
+  },
+  {
+    id: 'service_report',
+    label: 'Service report',
+    sub: 'Leave-behind report for the visit',
+    icon: 'clipboard-check-outline',
     when: () => true,
   },
   {

--- a/src/components/JobPhotos.tsx
+++ b/src/components/JobPhotos.tsx
@@ -50,9 +50,12 @@ interface LocalPhoto extends QuotePhoto {
 interface JobPhotosProps {
   photos: QuotePhoto[];
   onPhotosChange: (photos: QuotePhoto[]) => void;
+  /** Hide the built-in "Job Photos / optional / hint" header — for screens
+   *  that render their own section label above this component. */
+  hideHeader?: boolean;
 }
 
-export function JobPhotos({ photos, onPhotosChange }: JobPhotosProps) {
+export function JobPhotos({ photos, onPhotosChange, hideHeader }: JobPhotosProps) {
   const [localPhotos, setLocalPhotos] = useState<LocalPhoto[]>([]);
   const [annotatingPhoto, setAnnotatingPhoto] = useState<LocalPhoto | null>(null);
   const [photoSheetVisible, setPhotoSheetVisible] = useState(false);
@@ -328,13 +331,17 @@ export function JobPhotos({ photos, onPhotosChange }: JobPhotosProps) {
 
   return (
     <View style={styles.container}>
-      <View style={styles.headerRow}>
-        <Text style={styles.label}>Job Photos</Text>
-        <Text style={styles.optional}>optional</Text>
-      </View>
-      <Text style={styles.hint}>
-        Add site photos or plans to help with AI analysis and show clients the scope
-      </Text>
+      {!hideHeader && (
+        <>
+          <View style={styles.headerRow}>
+            <Text style={styles.label}>Job Photos</Text>
+            <Text style={styles.optional}>optional</Text>
+          </View>
+          <Text style={styles.hint}>
+            Add site photos or plans to help with AI analysis and show clients the scope
+          </Text>
+        </>
+      )}
 
       <View style={styles.grid}>
         {allPhotos.map((photo) => {

--- a/src/components/SignaturePad.tsx
+++ b/src/components/SignaturePad.tsx
@@ -1,0 +1,208 @@
+/**
+ * SignaturePad
+ *
+ * A lightweight, dependency-free signature capture pad that works on both
+ * native and web. Built on PanResponder (no native module, no rebuild) so it
+ * drops straight into the Expo + react-native-web setup, and renders the ink
+ * with react-native-svg.
+ *
+ * Controlled component: the parent owns the SVG path `d` string via `value`
+ * and receives updates through `onChange`. The pure `buildSvgPath` helper does
+ * the stroke → path conversion so it can be unit tested in isolation.
+ *
+ * Gesture notes — this pad lives inside scrolling forms, so it:
+ *  - refuses responder termination (the parent ScrollView can't steal a
+ *    stroke mid-signature and turn it into a scroll), and
+ *  - reports stroke start/end via onStrokeStart/onStrokeEnd so the parent
+ *    can disable its own scrolling while ink is being laid down.
+ *  - only lifts the path to the parent on stroke END, not per move-sample —
+ *    per-sample setState in the parent re-renders the whole form and makes
+ *    signing feel laggy on mid-range Androids. The in-flight stroke renders
+ *    from local state only.
+ *
+ * onChange also reports the pad's measured width/height. The PDF renderer
+ * needs the real capture-space dimensions for its viewBox — hardcoding one
+ * clips any signature drawn on a pad with different proportions.
+ */
+import React, { useEffect, useRef, useState } from 'react';
+import {
+  View,
+  StyleSheet,
+  PanResponder,
+  TouchableOpacity,
+  Text,
+  type LayoutChangeEvent,
+} from 'react-native';
+import Svg, { Path } from 'react-native-svg';
+
+import { colors } from '../theme';
+import { buildSvgPath, type Point } from './signaturePath';
+
+const DEFAULT_HEIGHT = 180;
+
+export interface SignaturePadSize {
+  width: number;
+  height: number;
+}
+
+interface SignaturePadProps {
+  value?: string;
+  onChange: (svgPath: string, size: SignaturePadSize) => void;
+  height?: number;
+  /** Stroke began — parent should disable its ScrollView. */
+  onStrokeStart?: () => void;
+  /** Stroke ended — parent can re-enable scrolling. */
+  onStrokeEnd?: () => void;
+}
+
+export function SignaturePad({
+  value,
+  onChange,
+  height = DEFAULT_HEIGHT,
+  onStrokeStart,
+  onStrokeEnd,
+}: SignaturePadProps) {
+  const [strokes, setStrokes] = useState<Point[][]>([]);
+
+  // The PanResponder is created once, so it reaches the latest callbacks
+  // through refs instead of stale closures.
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
+  const onStrokeStartRef = useRef(onStrokeStart);
+  onStrokeStartRef.current = onStrokeStart;
+  const onStrokeEndRef = useRef(onStrokeEnd);
+  onStrokeEndRef.current = onStrokeEnd;
+
+  // When the parent clears the value externally (value === ''), drop the ink.
+  useEffect(() => {
+    if (!value) {
+      setStrokes((prev) => (prev.length === 0 ? prev : []));
+    }
+  }, [value]);
+
+  // Kept in refs so the once-created PanResponder always sees current state.
+  const strokesRef = useRef(strokes);
+  strokesRef.current = strokes;
+  const [size, setSize] = useState({ width: 0, height });
+  const sizeRef = useRef(size);
+  sizeRef.current = size;
+
+  // Lift the finished ink to the parent — called on stroke end and clear,
+  // never per move-sample.
+  const commit = (next: Point[][]) => {
+    onChangeRef.current(buildSvgPath(next), {
+      width: Math.round(sizeRef.current.width),
+      height: Math.round(sizeRef.current.height),
+    });
+  };
+
+  const responder = useRef(
+    PanResponder.create({
+      onStartShouldSetPanResponder: () => true,
+      onMoveShouldSetPanResponder: () => true,
+      // A signature must survive the parent ScrollView asking for the
+      // gesture back — otherwise vertical pen movement scrolls the page
+      // and abandons the stroke.
+      onPanResponderTerminationRequest: () => false,
+      onShouldBlockNativeResponder: () => true,
+      onPanResponderGrant: (e) => {
+        onStrokeStartRef.current?.();
+        const { locationX, locationY } = e.nativeEvent;
+        setStrokes([...strokesRef.current, [{ x: locationX, y: locationY }]]);
+      },
+      onPanResponderMove: (e) => {
+        const { locationX, locationY } = e.nativeEvent;
+        const current = strokesRef.current;
+        if (current.length === 0) return;
+        const next = current.slice(0, -1);
+        const active = [...current[current.length - 1], { x: locationX, y: locationY }];
+        setStrokes([...next, active]);
+      },
+      onPanResponderRelease: () => {
+        onStrokeEndRef.current?.();
+        commit(strokesRef.current);
+      },
+      // Termination shouldn't happen (we refuse requests) but if the OS
+      // force-terminates, keep what was inked and unlock the parent.
+      onPanResponderTerminate: () => {
+        onStrokeEndRef.current?.();
+        commit(strokesRef.current);
+      },
+    }),
+  ).current;
+
+  const handleClear = () => {
+    setStrokes([]);
+    commit([]);
+  };
+
+  const onLayout = (e: LayoutChangeEvent) => {
+    const { width, height: h } = e.nativeEvent.layout;
+    setSize({ width, height: h });
+  };
+
+  // Local strokes are the live view (they include the in-flight stroke);
+  // fall back to the committed value when local state is empty (e.g. edit
+  // mode hydrating an existing signature).
+  const pathData = strokes.length > 0 ? buildSvgPath(strokes) : value ?? '';
+  const hasInk = pathData.length > 0;
+
+  return (
+    <View style={[styles.container, { height }]}>
+      <View style={styles.canvas} onLayout={onLayout} {...responder.panHandlers}>
+        <Svg width={size.width} height={size.height} pointerEvents="none">
+          {hasInk && (
+            <Path
+              d={pathData}
+              stroke={colors.text}
+              strokeWidth={2.5}
+              fill="none"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          )}
+        </Svg>
+      </View>
+
+      {hasInk && (
+        <TouchableOpacity
+          onPress={handleClear}
+          style={styles.clearButton}
+          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+          accessibilityRole="button"
+          accessibilityLabel="Clear signature"
+        >
+          <Text style={styles.clearText}>Clear</Text>
+        </TouchableOpacity>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: colors.border,
+    backgroundColor: colors.surface,
+    overflow: 'hidden',
+    position: 'relative',
+  },
+  canvas: {
+    flex: 1,
+  },
+  clearButton: {
+    position: 'absolute',
+    top: 8,
+    right: 8,
+    paddingVertical: 4,
+    paddingHorizontal: 10,
+    borderRadius: 8,
+    backgroundColor: colors.surfaceLight,
+  },
+  clearText: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: colors.textSecondary,
+  },
+});

--- a/src/components/signaturePath.test.ts
+++ b/src/components/signaturePath.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+
+import { buildSvgPath } from './signaturePath';
+
+describe('buildSvgPath', () => {
+  it('returns an empty string for empty input', () => {
+    expect(buildSvgPath([])).toBe('');
+  });
+
+  it('returns an empty string when strokes contain no points', () => {
+    expect(buildSvgPath([[], []])).toBe('');
+  });
+
+  it('produces one M and two L commands for a single 3-point stroke', () => {
+    const d = buildSvgPath([
+      [
+        { x: 0, y: 0 },
+        { x: 10, y: 5 },
+        { x: 20, y: 15 },
+      ],
+    ]);
+
+    expect(d).toBe('M 0 0 L 10 5 L 20 15');
+    expect((d.match(/M/g) || []).length).toBe(1);
+    expect((d.match(/L/g) || []).length).toBe(2);
+  });
+
+  it('starts a fresh M command for each stroke (lifted pen breaks the ink)', () => {
+    const d = buildSvgPath([
+      [
+        { x: 0, y: 0 },
+        { x: 1, y: 1 },
+      ],
+      [
+        { x: 5, y: 5 },
+        { x: 6, y: 6 },
+      ],
+      [{ x: 9, y: 9 }],
+    ]);
+
+    expect((d.match(/M/g) || []).length).toBe(3);
+    expect(d).toBe('M 0 0 L 1 1 M 5 5 L 6 6 M 9 9');
+  });
+
+  it('skips empty strokes but still joins the populated ones', () => {
+    const d = buildSvgPath([
+      [{ x: 1, y: 2 }],
+      [],
+      [{ x: 3, y: 4 }],
+    ]);
+
+    expect(d).toBe('M 1 2 M 3 4');
+    expect((d.match(/M/g) || []).length).toBe(2);
+  });
+});

--- a/src/components/signaturePath.ts
+++ b/src/components/signaturePath.ts
@@ -1,0 +1,39 @@
+/**
+ * signaturePath
+ *
+ * Pure helper that turns captured pointer strokes into an SVG path `d` string.
+ * Each stroke starts with an `M` (move-to) command for its first point and
+ * emits an `L` (line-to) command for every subsequent point. Multiple strokes
+ * are concatenated, so a lifted pen produces a fresh `M` (a break in the ink).
+ *
+ * Kept dependency-free and side-effect-free so it can be unit tested in
+ * isolation and reused by both the on-device SignaturePad and any renderer.
+ */
+
+export interface Point {
+  x: number;
+  y: number;
+}
+
+/**
+ * Build an SVG path `d` string from captured strokes.
+ * Empty input (or strokes that contain no points) yields an empty string.
+ */
+export function buildSvgPath(strokes: Point[][]): string {
+  if (!strokes || strokes.length === 0) return '';
+
+  const segments: string[] = [];
+
+  for (const stroke of strokes) {
+    if (!stroke || stroke.length === 0) continue;
+
+    const [first, ...rest] = stroke;
+    let segment = `M ${first.x} ${first.y}`;
+    for (const point of rest) {
+      segment += ` L ${point.x} ${point.y}`;
+    }
+    segments.push(segment);
+  }
+
+  return segments.join(' ');
+}

--- a/src/navigation/RootNavigator.tsx
+++ b/src/navigation/RootNavigator.tsx
@@ -52,6 +52,7 @@ import { AddMaterialScreen } from '../screens/NewQuote/AddMaterialScreen';
 import { LaborMarkupScreen } from '../screens/NewQuote/LaborMarkupScreen';
 import { JobPreviewScreen } from '../screens/NewQuote/JobPreviewScreen';
 import { ReeceOrderScreen } from '../screens/ReeceOrderScreen';
+import { ServiceReportScreen } from '../screens/ServiceReport/ServiceReportScreen';
 
 import { colors } from '../theme';
 
@@ -70,6 +71,14 @@ export type NewQuoteStackParamList = {
   AddMaterial: { materialId?: string; mode?: 'quote' | 'invoice' } | undefined;
   LaborMarkup: { mode?: 'quote' | 'invoice' } | undefined;
   JobPreview: { mode?: 'quote' | 'invoice'; viewing?: boolean; editing?: boolean } | undefined;
+};
+
+// Param types for full-screen routes on the RootStack. The navigator itself is
+// left untyped (it hosts many screens); this is the shared source of truth for
+// callers navigating into these routes. The Wiring phase reads ServiceReport
+// from here to type its navigation.navigate(...) call.
+export type RootStackParamList = {
+  ServiceReport: { jobId: string; reportId?: string };
 };
 
 const Tab = createBottomTabNavigator<RootTabParamList>();
@@ -491,6 +500,20 @@ export function RootNavigator() {
           headerTintColor: colors.white,
           headerTitleStyle: { fontWeight: '700' },
           title: 'Job',
+        }}
+      />
+      <RootStack.Screen
+        name="ServiceReport"
+        component={ServiceReportScreen}
+        options={{
+          presentation: 'card',
+          headerShown: true,
+          headerStyle: {
+            backgroundColor: colors.primary,
+          },
+          headerTintColor: colors.white,
+          headerTitleStyle: { fontWeight: '700' },
+          title: 'Service Report',
         }}
       />
       <RootStack.Screen

--- a/src/screens/ServiceReport/ServiceReportScreen.tsx
+++ b/src/screens/ServiceReport/ServiceReportScreen.tsx
@@ -1,0 +1,831 @@
+/**
+ * ServiceReportScreen
+ *
+ * Capture screen for a Service Report — the customer-facing leave-behind a
+ * tradie fills in after a service visit. Route params: { jobId, reportId? }.
+ *
+ * Pulls the customer + address off the linked Job (read-only here), then lets
+ * the tradie set the visit date, service type and risk assessment; manage a
+ * short equipment list and a tick-box checklist (Mate NEVER pre-ticks — every
+ * tick is a manual tap); jot rough notes into the three narrative fields and
+ * tap "Write it up" to have Mate tidy them into customer-ready prose; attach
+ * photos; and capture technician + customer signatures. Save persists via
+ * reportService; "Export / Share" renders the PDF via exportReportPDF.
+ *
+ * Copy here is Australian English, gender-neutral, and never says the two-letter
+ * word for the assistant — it is "Mate". Nothing on this screen or the exported
+ * PDF shows app branding; the customer sees only the tradie's business name.
+ */
+
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { View, StyleSheet, ScrollView, TouchableOpacity, Platform } from 'react-native';
+import { KeyboardAvoidingView } from 'react-native-keyboard-controller';
+import { Text, TextInput, ActivityIndicator } from 'react-native-paper';
+import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
+import { Calendar } from 'react-native-calendars';
+import { useNavigation, useRoute } from '@react-navigation/native';
+import { format } from 'date-fns';
+
+import { useJobStore } from '../../store/useJobStore';
+import { useStore } from '../../store/useStore';
+import { colors } from '../../theme';
+import { WebContainer } from '../../components/WebContainer';
+import { FixedBottomButton } from '../../components/FixedBottomButton';
+import { JobPhotos } from '../../components/JobPhotos';
+import { SignaturePad, type SignaturePadSize } from '../../components/SignaturePad';
+import { useAlertModal } from '../../hooks/useAlertModal';
+import { generateId } from '../../utils/generateId';
+import { getTradeCategoryById } from '../../constants/tradeCategories';
+import { reportService } from '../../services/reportService';
+import { composeServiceReport } from '../../services/reportComposeService';
+import { exportReportPDF } from '../../utils/pdfGenerator';
+import type { QuotePhoto } from '../../types';
+import type { JobPhoto } from '../../../shared/job/types';
+import type { ServiceReport, SignatureCapture } from '../../../shared/report/types';
+import {
+  buildInitialReportForm,
+  buildReportInput,
+  deriveReportContext,
+  formFromReport,
+  type ReportFormState,
+} from './reportDraft';
+
+export function ServiceReportScreen() {
+  const navigation = useNavigation<any>();
+  const route = useRoute<any>();
+  const jobId: string = route.params?.jobId;
+  const routeReportId: string | undefined = route.params?.reportId;
+
+  const job = useJobStore((s) => s.jobs.find((j) => j.id === jobId));
+  const jobsLoaded = useJobStore((s) => s.jobsLoaded);
+  const businessSettings = useStore((s) => s.businessSettings);
+  const { showAlert, alertNode } = useAlertModal();
+
+  // Editable form state. Seeded empty from the job; hydrated from an existing
+  // report in edit mode once it loads.
+  const [form, setForm] = useState<ReportFormState | null>(null);
+  // Persisted identity — set once the report is created or loaded. Carries the
+  // number / createdAt the PDF needs so re-saves don't remint them.
+  const [meta, setMeta] = useState<Pick<
+    ServiceReport,
+    'id' | 'number' | 'status' | 'createdAt'
+  > | null>(null);
+
+  const [showCalendar, setShowCalendar] = useState(false);
+  const [techSigName, setTechSigName] = useState('');
+  const [techSigPath, setTechSigPath] = useState('');
+  const [techSigSize, setTechSigSize] = useState<SignaturePadSize | null>(null);
+  const [custSigName, setCustSigName] = useState('');
+  const [custSigPath, setCustSigPath] = useState('');
+  const [custSigSize, setCustSigSize] = useState<SignaturePadSize | null>(null);
+
+  const [composing, setComposing] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [exporting, setExporting] = useState(false);
+
+  // Signing locks the ScrollView so pen strokes don't fight the scroll.
+  const [signing, setSigning] = useState(false);
+
+  // Focus the input of a just-added equipment/checklist row so "Add" flows
+  // straight into typing (autoFocus applies on mount only; cleared on blur).
+  const [autoFocusKey, setAutoFocusKey] = useState<string | null>(null);
+
+  // Anything the tradie changed since seed/load/last save. Drives the
+  // beforeRemove auto-save so backing out never silently bins a report.
+  const dirtyRef = useRef(false);
+  // Suppresses navigation.setParams once the screen is on its way out.
+  const leavingRef = useRef(false);
+
+  // Seed the form from the job (new report).
+  useEffect(() => {
+    if (form || !job) return;
+    if (routeReportId) return; // edit mode hydrates below instead
+    setForm(buildInitialReportForm(job));
+  }, [job, form, routeReportId]);
+
+  // Edit mode: load the existing report once.
+  useEffect(() => {
+    if (!routeReportId || form) return;
+    let cancelled = false;
+    reportService.getReport(routeReportId).then((report) => {
+      if (cancelled || !report) return;
+      setForm(formFromReport(report));
+      setMeta({
+        id: report.id,
+        number: report.number,
+        status: report.status,
+        createdAt: report.createdAt,
+      });
+      setTechSigName(report.technicianSignature?.name ?? '');
+      setTechSigPath(report.technicianSignature?.svgPath ?? '');
+      if (report.technicianSignature?.width && report.technicianSignature?.height) {
+        setTechSigSize({
+          width: report.technicianSignature.width,
+          height: report.technicianSignature.height,
+        });
+      }
+      setCustSigName(report.customerSignature?.name ?? '');
+      setCustSigPath(report.customerSignature?.svgPath ?? '');
+      if (report.customerSignature?.width && report.customerSignature?.height) {
+        setCustSigSize({
+          width: report.customerSignature.width,
+          height: report.customerSignature.height,
+        });
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [routeReportId, form]);
+
+  const patch = (next: Partial<ReportFormState>) => {
+    dirtyRef.current = true;
+    setForm((prev) => (prev ? { ...prev, ...next } : prev));
+  };
+
+  const context = useMemo(() => (job ? deriveReportContext(job) : null), [job]);
+
+  // Latest persist + content snapshot for the beforeRemove listener. Refs,
+  // because the listener registers once (before the loading early-return)
+  // while persist and the form only exist on full renders.
+  const persistRef = useRef<null | (() => Promise<unknown>)>(null);
+  const hasContentRef = useRef(false);
+
+  // Backing out must never silently bin a filled-in (possibly signed)
+  // report — auto-save on the way out, same pattern as JobDetailsScreen.
+  // Skipped when nothing meaningful was entered, so an open-and-back
+  // doesn't mint an empty RP number.
+  useEffect(() => {
+    const unsubscribe = navigation.addListener('beforeRemove', () => {
+      leavingRef.current = true;
+      if (!dirtyRef.current || !hasContentRef.current) return;
+      // Fire-and-forget: the screen is going away, the write completes in
+      // the background.
+      persistRef.current?.().catch(() => {});
+    });
+    return unsubscribe;
+  }, [navigation]);
+
+  if (!job || !form) {
+    // Only declare the job missing once the jobs listener has actually
+    // loaded — before that it's just not here YET. Applies to edit mode
+    // too: an existing report whose job was deleted must not spin forever.
+    const jobMissing = jobsLoaded && !job;
+    return (
+      <View style={[styles.container, styles.centered]}>
+        {jobMissing ? (
+          <>
+            <MaterialCommunityIcons
+              name={'file-alert-outline' as any}
+              size={44}
+              color={colors.textMuted}
+            />
+            <Text style={styles.missingText}>This job could not be found.</Text>
+          </>
+        ) : (
+          <ActivityIndicator color={colors.primary} />
+        )}
+      </View>
+    );
+  }
+
+  // --- Equipment ------------------------------------------------------------
+  const addEquipment = () => {
+    // Focus the new row so "Add" flows straight into typing.
+    setAutoFocusKey(`eq-${form.equipment.length}`);
+    patch({ equipment: [...form.equipment, ''] });
+  };
+  const setEquipmentAt = (i: number, value: string) => {
+    const next = [...form.equipment];
+    next[i] = value;
+    patch({ equipment: next });
+  };
+  const removeEquipmentAt = (i: number) =>
+    patch({ equipment: form.equipment.filter((_, idx) => idx !== i) });
+
+  // --- Checklist ------------------------------------------------------------
+  const addChecklistItem = () => {
+    const id = generateId();
+    setAutoFocusKey(id);
+    patch({
+      itemsChecked: [...form.itemsChecked, { id, text: '', checked: false }],
+    });
+  };
+  const setChecklistText = (id: string, text: string) =>
+    patch({
+      itemsChecked: form.itemsChecked.map((it) =>
+        it.id === id ? { ...it, text } : it,
+      ),
+    });
+  // Manual tap only — the sole place `checked` is ever flipped.
+  const toggleChecklist = (id: string) =>
+    patch({
+      itemsChecked: form.itemsChecked.map((it) =>
+        it.id === id ? { ...it, checked: !it.checked } : it,
+      ),
+    });
+  const removeChecklistItem = (id: string) =>
+    patch({ itemsChecked: form.itemsChecked.filter((it) => it.id !== id) });
+
+  // --- Write it up (compose) ------------------------------------------------
+  const handleWriteItUp = async () => {
+    const notes = {
+      natureOfProblem: form.natureOfProblem,
+      workCarriedOut: form.workCarriedOut,
+      recommendedWork: form.recommendedWork,
+    };
+    if (
+      !notes.natureOfProblem.trim() &&
+      !notes.workCarriedOut.trim() &&
+      !notes.recommendedWork.trim()
+    ) {
+      showAlert({
+        type: 'info',
+        title: 'Nothing to write up yet',
+        message: 'Jot down what you found, did, or recommend and Mate will tidy it up.',
+      });
+      return;
+    }
+    setComposing(true);
+    try {
+      const categoryId =
+        businessSettings?.tradeCategories?.[0] || businessSettings?.tradeCategory;
+      const tradeCategory = categoryId
+        ? getTradeCategoryById(categoryId)?.name
+        : undefined;
+      const composed = await composeServiceReport(notes, {
+        businessName: businessSettings?.businessName || undefined,
+        tradeCategory,
+      });
+      // Only overwrite a field when the tidy-up returned something for it —
+      // never blank out text the tradie had typed.
+      patch({
+        natureOfProblem: composed.natureOfProblem || form.natureOfProblem,
+        workCarriedOut: composed.workCarriedOut || form.workCarriedOut,
+        recommendedWork: composed.recommendedWork || form.recommendedWork,
+      });
+    } catch (err: any) {
+      showAlert({
+        type: 'error',
+        title: 'Could not write it up',
+        message: err?.message || 'Please try again in a moment.',
+      });
+    } finally {
+      setComposing(false);
+    }
+  };
+
+  // --- Save / export --------------------------------------------------------
+  const currentSignatures = (): {
+    technicianSignature?: SignatureCapture;
+    customerSignature?: SignatureCapture;
+  } => {
+    const now = Date.now();
+    return {
+      technicianSignature: techSigPath
+        ? {
+            svgPath: techSigPath,
+            name: techSigName.trim(),
+            signedAt: now,
+            width: techSigSize?.width,
+            height: techSigSize?.height,
+          }
+        : undefined,
+      customerSignature: custSigPath
+        ? {
+            svgPath: custSigPath,
+            name: custSigName.trim(),
+            signedAt: now,
+            width: custSigSize?.width,
+            height: custSigSize?.height,
+          }
+        : undefined,
+    };
+  };
+
+  // Anything worth keeping? Gates the beforeRemove auto-save (an untouched
+  // open-and-back must not mint an empty report) and the Export button.
+  const hasMeaningfulContent =
+    !!meta ||
+    form.equipment.some((e) => e.trim()) ||
+    form.itemsChecked.some((it) => it.text.trim()) ||
+    !!form.natureOfProblem.trim() ||
+    !!form.workCarriedOut.trim() ||
+    !!form.recommendedWork.trim() ||
+    !!form.riskAssessment.trim() ||
+    (form.photos?.length ?? 0) > 0 ||
+    !!techSigPath ||
+    !!custSigPath;
+  hasContentRef.current = hasMeaningfulContent;
+
+  // Firestore has no local persistence in this app, so on a dead-signal
+  // site an awaited write can hang forever with the button spinning. Cap
+  // the wait and tell the tradie the truth: nothing was lost, try again in
+  // range. (The write may still land in the background once signal
+  // returns — the meta guard prevents a duplicate create on re-save.)
+  const PERSIST_TIMEOUT_MS = 12000;
+  const withTimeout = <T,>(p: Promise<T>): Promise<T> =>
+    Promise.race([
+      p,
+      new Promise<never>((_, reject) =>
+        setTimeout(
+          () =>
+            reject(
+              new Error(
+                "Couldn't reach the server — check your signal and try again. Your report is still on this screen.",
+              ),
+            ),
+          PERSIST_TIMEOUT_MS,
+        ),
+      ),
+    ]);
+
+  // Persist and return a fully-formed ServiceReport (for the PDF export).
+  const persist = async (): Promise<ServiceReport | null> => {
+    const sigs = currentSignatures();
+    const input = {
+      ...buildReportInput({
+        ...form,
+        photos: form.photos,
+      }),
+      ...sigs,
+    };
+    if (!meta) {
+      const created = await withTimeout(reportService.createReport(input));
+      setMeta({
+        id: created.id,
+        number: created.number,
+        status: created.status,
+        createdAt: created.createdAt,
+      });
+      // Re-key the route so a later save updates instead of creating a
+      // second — unless we're already on the way out.
+      if (!leavingRef.current) {
+        navigation.setParams({ reportId: created.id });
+      }
+      dirtyRef.current = false;
+      return created;
+    }
+    await withTimeout(reportService.updateReport(meta.id, input));
+    dirtyRef.current = false;
+    return {
+      ...input,
+      id: meta.id,
+      userId: job.userId,
+      number: meta.number,
+      status: meta.status,
+      createdAt: meta.createdAt,
+      updatedAt: Date.now(),
+    } as ServiceReport;
+  };
+  persistRef.current = persist;
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      await persist();
+      navigation.goBack();
+    } catch (err: any) {
+      showAlert({
+        type: 'error',
+        title: 'Could not save',
+        message: err?.message || 'Please try again in a moment.',
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleExport = async () => {
+    if (!hasMeaningfulContent) {
+      showAlert({
+        type: 'info',
+        title: 'Nothing to share yet',
+        message: 'Fill in what you did on the visit before sharing the report.',
+      });
+      return;
+    }
+    setExporting(true);
+    try {
+      const report = await persist();
+      if (!report) return;
+      await exportReportPDF(report, businessSettings, 'share', {
+        customerName: context?.customerName,
+        customerEmail: context?.customerEmail,
+        customerPhone: context?.customerPhone,
+        jobAddress: context?.jobAddress,
+      });
+    } catch (err: any) {
+      showAlert({
+        type: 'error',
+        title: 'Could not export',
+        message: err?.message || 'Please try again in a moment.',
+      });
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  const visitDateLabel = format(new Date(form.visitDate), 'EEEE d MMMM yyyy');
+
+  return (
+    <KeyboardAvoidingView
+      style={styles.container}
+      behavior="padding"
+      keyboardVerticalOffset={Platform.OS === 'ios' ? -48 : 0}
+    >
+      <ScrollView
+        contentContainerStyle={styles.scrollContent}
+        keyboardShouldPersistTaps="handled"
+        scrollEnabled={!signing}
+      >
+        <WebContainer>
+          {/* Who + where — read straight off the job. */}
+          <View style={styles.headerCard}>
+            <Text style={styles.customerName}>
+              {context?.customerName || 'Customer'}
+            </Text>
+            {context?.jobAddress ? (
+              <Text style={styles.customerMeta}>{context.jobAddress}</Text>
+            ) : null}
+            <Text style={styles.reportNumber}>
+              {meta ? `Report ${meta.number}` : 'New service report'}
+            </Text>
+          </View>
+
+          {/* Visit date */}
+          <SectionLabel text="Visit date" />
+          <TouchableOpacity
+            style={styles.dateRow}
+            onPress={() => setShowCalendar((v) => !v)}
+            activeOpacity={0.7}
+          >
+            <MaterialCommunityIcons
+              name="calendar"
+              size={20}
+              color={colors.primary}
+            />
+            <Text style={styles.dateText}>{visitDateLabel}</Text>
+            <MaterialCommunityIcons
+              name={showCalendar ? 'chevron-up' : 'chevron-down'}
+              size={22}
+              color={colors.textMuted}
+            />
+          </TouchableOpacity>
+          {showCalendar && (
+            <Calendar
+              current={format(new Date(form.visitDate), 'yyyy-MM-dd')}
+              onDayPress={(day: { timestamp: number; dateString: string }) => {
+                // Use midday local to dodge timezone day-shift on the epoch.
+                const picked = new Date(`${day.dateString}T12:00:00`).getTime();
+                patch({ visitDate: picked });
+                setShowCalendar(false);
+              }}
+              markedDates={{
+                [format(new Date(form.visitDate), 'yyyy-MM-dd')]: {
+                  selected: true,
+                  selectedColor: colors.primary,
+                },
+              }}
+              theme={{
+                calendarBackground: colors.surface,
+                dayTextColor: colors.text,
+                monthTextColor: colors.text,
+                textDisabledColor: colors.textMuted,
+                arrowColor: colors.primary,
+                todayTextColor: colors.primary,
+              }}
+              style={styles.calendar}
+            />
+          )}
+
+          {/* Service type */}
+          <SectionLabel text="Service type" />
+          <TextInput
+            mode="outlined"
+            value={form.serviceType}
+            onChangeText={(t) => patch({ serviceType: t })}
+            placeholder="e.g. Annual gas heater service"
+            style={styles.input}
+          />
+
+          {/* Risk assessment */}
+          <SectionLabel text="Risk assessment" optional />
+          <TextInput
+            mode="outlined"
+            value={form.riskAssessment}
+            onChangeText={(t) => patch({ riskAssessment: t })}
+            placeholder="Any site hazards or safety notes"
+            multiline
+            numberOfLines={3}
+            style={styles.input}
+          />
+
+          {/* Equipment */}
+          <SectionLabel text="Equipment on site" optional />
+          {form.equipment.map((value, i) => (
+            <View key={`eq-${i}`} style={styles.listRow}>
+              <TextInput
+                mode="outlined"
+                value={value}
+                onChangeText={(t) => setEquipmentAt(i, t)}
+                placeholder="Item"
+                style={styles.listInput}
+                dense
+                autoFocus={autoFocusKey === `eq-${i}`}
+                onBlur={() => setAutoFocusKey(null)}
+              />
+              <TouchableOpacity
+                onPress={() => removeEquipmentAt(i)}
+                style={styles.rowRemove}
+                hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+                accessibilityLabel="Remove equipment"
+              >
+                <MaterialCommunityIcons
+                  name="close-circle"
+                  size={22}
+                  color={colors.textMuted}
+                />
+              </TouchableOpacity>
+            </View>
+          ))}
+          <AddRow label="Add equipment" onPress={addEquipment} />
+
+          {/* Checklist — heading matches the PDF's "Items checked" */}
+          <SectionLabel text="Items checked" optional />
+          {form.itemsChecked.map((item) => (
+            <View key={item.id} style={styles.listRow}>
+              <TouchableOpacity
+                onPress={() => toggleChecklist(item.id)}
+                style={styles.checkbox}
+                hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+                accessibilityRole="checkbox"
+                accessibilityState={{ checked: item.checked }}
+                accessibilityLabel={item.text || 'Checklist item'}
+              >
+                <MaterialCommunityIcons
+                  name={item.checked ? 'checkbox-marked' : 'checkbox-blank-outline'}
+                  size={24}
+                  color={item.checked ? colors.primary : colors.textMuted}
+                />
+              </TouchableOpacity>
+              <TextInput
+                mode="outlined"
+                value={item.text}
+                onChangeText={(t) => setChecklistText(item.id, t)}
+                placeholder="What was checked"
+                style={styles.listInput}
+                dense
+                autoFocus={autoFocusKey === item.id}
+                onBlur={() => setAutoFocusKey(null)}
+              />
+              <TouchableOpacity
+                onPress={() => removeChecklistItem(item.id)}
+                style={styles.rowRemove}
+                hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+                accessibilityLabel="Remove checklist item"
+              >
+                <MaterialCommunityIcons
+                  name="close-circle"
+                  size={22}
+                  color={colors.textMuted}
+                />
+              </TouchableOpacity>
+            </View>
+          ))}
+          <AddRow label="Add checklist item" onPress={addChecklistItem} />
+
+          {/* Narrative */}
+          <SectionLabel text="Nature of the problem" optional />
+          <TextInput
+            mode="outlined"
+            value={form.natureOfProblem}
+            onChangeText={(t) => patch({ natureOfProblem: t })}
+            placeholder="What the customer reported or what you found"
+            multiline
+            numberOfLines={3}
+            style={styles.input}
+          />
+          <SectionLabel text="Work carried out" optional />
+          <TextInput
+            mode="outlined"
+            value={form.workCarriedOut}
+            onChangeText={(t) => patch({ workCarriedOut: t })}
+            placeholder="What you did on this visit"
+            multiline
+            numberOfLines={3}
+            style={styles.input}
+          />
+          <SectionLabel text="Recommended work" optional />
+          <TextInput
+            mode="outlined"
+            value={form.recommendedWork}
+            onChangeText={(t) => patch({ recommendedWork: t })}
+            placeholder="Anything to sort on a future visit"
+            multiline
+            numberOfLines={3}
+            style={styles.input}
+          />
+
+          <TouchableOpacity
+            onPress={handleWriteItUp}
+            disabled={composing}
+            style={styles.writeUpButton}
+            activeOpacity={0.8}
+          >
+            {composing ? (
+              <ActivityIndicator size="small" color={colors.primary} />
+            ) : (
+              <MaterialCommunityIcons
+                name="auto-fix"
+                size={18}
+                color={colors.primary}
+              />
+            )}
+            <Text style={styles.writeUpText}>
+              {composing ? 'Writing it up…' : 'Write it up with Mate'}
+            </Text>
+          </TouchableOpacity>
+          <Text style={styles.writeUpHint}>
+            Tidies your rough notes into clear wording for the customer. Sticks to
+            the facts you entered.
+          </Text>
+
+          {/* Photos — reuses the standard job photo capture path; header
+              hidden because this screen renders its own section label. */}
+          <SectionLabel text="Photos" optional />
+          <JobPhotos
+            photos={form.photos as QuotePhoto[]}
+            onPhotosChange={(photos) => patch({ photos: photos as JobPhoto[] })}
+            hideHeader
+          />
+
+          {/* Signatures */}
+          <SectionLabel text="Technician signature" optional />
+          <TextInput
+            mode="outlined"
+            value={techSigName}
+            onChangeText={(t) => {
+              dirtyRef.current = true;
+              setTechSigName(t);
+            }}
+            placeholder="Technician name"
+            style={styles.input}
+            dense
+          />
+          <SignaturePad
+            value={techSigPath}
+            onChange={(path, size) => {
+              dirtyRef.current = true;
+              setTechSigPath(path);
+              setTechSigSize(size);
+            }}
+            onStrokeStart={() => setSigning(true)}
+            onStrokeEnd={() => setSigning(false)}
+          />
+
+          <View style={{ height: 16 }} />
+          <SectionLabel text="Customer signature" optional />
+          <TextInput
+            mode="outlined"
+            value={custSigName}
+            onChangeText={(t) => {
+              dirtyRef.current = true;
+              setCustSigName(t);
+            }}
+            placeholder="Customer name"
+            style={styles.input}
+            dense
+          />
+          <SignaturePad
+            value={custSigPath}
+            onChange={(path, size) => {
+              dirtyRef.current = true;
+              setCustSigPath(path);
+              setCustSigSize(size);
+            }}
+            onStrokeStart={() => setSigning(true)}
+            onStrokeEnd={() => setSigning(false)}
+          />
+        </WebContainer>
+      </ScrollView>
+
+      {/* Share is the deliverable — it lives in the fixed bar next to Save,
+          not buried at the bottom of the scroll. */}
+      <FixedBottomButton
+        label="Save report"
+        onPress={handleSave}
+        loading={saving}
+        disabled={saving || exporting}
+        secondaryLabel="Share PDF"
+        secondaryOnPress={handleExport}
+        secondaryLoading={exporting}
+        secondaryDisabled={saving}
+        disableKeyboardSticky
+      />
+
+      {alertNode}
+    </KeyboardAvoidingView>
+  );
+}
+
+function SectionLabel({ text, optional }: { text: string; optional?: boolean }) {
+  return (
+    <View style={styles.sectionLabelRow}>
+      <Text style={styles.sectionLabel}>{text}</Text>
+      {optional ? <Text style={styles.optional}>optional</Text> : null}
+    </View>
+  );
+}
+
+function AddRow({ label, onPress }: { label: string; onPress: () => void }) {
+  return (
+    <TouchableOpacity style={styles.addRow} onPress={onPress} activeOpacity={0.7}>
+      <MaterialCommunityIcons name="plus-circle-outline" size={20} color={colors.primary} />
+      <Text style={styles.addRowText}>{label}</Text>
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: colors.background },
+  scrollContent: { padding: 16, paddingBottom: 160 },
+  centered: { justifyContent: 'center', alignItems: 'center', gap: 12, padding: 32 },
+  missingText: { fontSize: 15, color: colors.textMuted, textAlign: 'center' },
+  headerCard: {
+    backgroundColor: colors.surface,
+    borderRadius: 16,
+    padding: 16,
+    marginBottom: 8,
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+  customerName: { fontSize: 18, fontWeight: '700', color: colors.text },
+  customerMeta: { fontSize: 13, color: colors.textMuted, marginTop: 2 },
+  reportNumber: {
+    fontSize: 12,
+    color: colors.textSecondary,
+    marginTop: 8,
+    fontWeight: '600',
+  },
+  sectionLabelRow: {
+    flexDirection: 'row',
+    alignItems: 'baseline',
+    gap: 6,
+    marginTop: 18,
+    marginBottom: 6,
+  },
+  sectionLabel: { fontSize: 14, fontWeight: '700', color: colors.text },
+  optional: { fontSize: 12, color: colors.textMuted, fontStyle: 'italic' },
+  input: { backgroundColor: colors.surface, marginBottom: 4 },
+  dateRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    backgroundColor: colors.surface,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: colors.border,
+    paddingHorizontal: 14,
+    paddingVertical: 14,
+  },
+  dateText: { flex: 1, fontSize: 15, color: colors.text, fontWeight: '600' },
+  calendar: {
+    marginTop: 8,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: colors.border,
+    overflow: 'hidden',
+  },
+  listRow: { flexDirection: 'row', alignItems: 'center', gap: 8, marginBottom: 8 },
+  listInput: { flex: 1, backgroundColor: colors.surface },
+  rowRemove: { padding: 2 },
+  checkbox: { padding: 2 },
+  addRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    paddingVertical: 10,
+    marginTop: 2,
+  },
+  addRowText: { fontSize: 14, color: colors.primary, fontWeight: '600' },
+  writeUpButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+    marginTop: 12,
+    paddingVertical: 12,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: colors.primary,
+    backgroundColor: colors.surface,
+  },
+  writeUpText: { fontSize: 14, fontWeight: '700', color: colors.primary },
+  writeUpHint: {
+    fontSize: 12,
+    color: colors.textMuted,
+    marginTop: 6,
+    lineHeight: 16,
+  },
+});

--- a/src/screens/ServiceReport/reportDraft.test.ts
+++ b/src/screens/ServiceReport/reportDraft.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  deriveReportContext,
+  buildInitialReportForm,
+  buildReportInput,
+  formFromReport,
+  type ReportFormState,
+} from './reportDraft';
+import type { Job } from '../../../shared/job/types';
+
+function makeJob(overrides: Partial<Job> = {}): Job {
+  return {
+    id: 'job-1',
+    userId: 'u-1',
+    customerName: 'Jane Smith',
+    customerEmail: 'jane@example.com',
+    customerPhone: '0400 000 000',
+    jobAddress: '12 Test St, Warragul',
+    name: 'Hot water service',
+    stage: 'in_progress',
+    documentIds: [],
+    totalQuoted: 0,
+    totalInvoiced: 0,
+    totalPaid: 0,
+    balanceDue: 0,
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides,
+  } as Job;
+}
+
+describe('deriveReportContext', () => {
+  it('lifts the customer + address fields off the job', () => {
+    const ctx = deriveReportContext(makeJob());
+    expect(ctx).toEqual({
+      customerName: 'Jane Smith',
+      customerEmail: 'jane@example.com',
+      customerPhone: '0400 000 000',
+      jobAddress: '12 Test St, Warragul',
+    });
+  });
+
+  it('collapses blank optional fields to undefined and trims', () => {
+    const ctx = deriveReportContext(
+      makeJob({ customerName: '  Jane  ', customerEmail: '', customerPhone: '   ', jobAddress: '' }),
+    );
+    expect(ctx.customerName).toBe('Jane');
+    expect(ctx.customerEmail).toBeUndefined();
+    expect(ctx.customerPhone).toBeUndefined();
+    expect(ctx.jobAddress).toBeUndefined();
+  });
+});
+
+describe('buildInitialReportForm', () => {
+  it('seeds serviceType from the job name and starts everything else empty', () => {
+    const form = buildInitialReportForm(makeJob(), { visitDate: 1234 });
+    expect(form.jobId).toBe('job-1');
+    expect(form.visitDate).toBe(1234);
+    expect(form.serviceType).toBe('Hot water service');
+    expect(form.equipment).toEqual([]);
+    expect(form.itemsChecked).toEqual([]);
+    expect(form.natureOfProblem).toBe('');
+    expect(form.photos).toEqual([]);
+  });
+
+  it('defaults the visit date to now when none is supplied', () => {
+    const before = Date.now();
+    const form = buildInitialReportForm(makeJob());
+    expect(form.visitDate).toBeGreaterThanOrEqual(before);
+  });
+});
+
+describe('buildReportInput', () => {
+  const base = (): ReportFormState => buildInitialReportForm(makeJob(), { visitDate: 5000 });
+
+  it('trims required fields and prunes blank equipment + checklist rows', () => {
+    const state: ReportFormState = {
+      ...base(),
+      serviceType: '  Annual service  ',
+      equipment: ['Ladder', '   ', 'Multimeter'],
+      itemsChecked: [
+        { id: 'a', text: 'Tested RCD', checked: true },
+        { id: 'b', text: '   ', checked: false },
+      ],
+    };
+    const input = buildReportInput(state);
+    expect(input.serviceType).toBe('Annual service');
+    expect(input.equipment).toEqual(['Ladder', 'Multimeter']);
+    expect(input.itemsChecked).toEqual([{ id: 'a', text: 'Tested RCD', checked: true }]);
+  });
+
+  it('collapses empty optional narrative fields to undefined', () => {
+    const input = buildReportInput({
+      ...base(),
+      riskAssessment: '   ',
+      natureOfProblem: '',
+      workCarriedOut: 'Replaced element',
+      recommendedWork: '  ',
+    });
+    expect(input.riskAssessment).toBeUndefined();
+    expect(input.natureOfProblem).toBeUndefined();
+    expect(input.workCarriedOut).toBe('Replaced element');
+    expect(input.recommendedWork).toBeUndefined();
+  });
+
+  it('omits photos when there are none', () => {
+    expect(buildReportInput(base()).photos).toBeUndefined();
+  });
+
+  it('preserves a manually-ticked checklist item exactly (Mate never pre-ticks)', () => {
+    const input = buildReportInput({
+      ...base(),
+      itemsChecked: [{ id: 'x', text: 'Isolation valve replaced', checked: true }],
+    });
+    expect(input.itemsChecked).toEqual([
+      { id: 'x', text: 'Isolation valve replaced', checked: true },
+    ]);
+  });
+});
+
+describe('formFromReport', () => {
+  it('round-trips a persisted report back into editable form state', () => {
+    const form = formFromReport({
+      jobId: 'job-9',
+      visitDate: 42,
+      serviceType: 'Leak repair',
+      riskAssessment: undefined,
+      equipment: ['Wrench'],
+      itemsChecked: [{ id: 'c', text: 'Pressure test', checked: false }],
+      workCarriedOut: 'Resealed joint',
+      photos: undefined,
+    });
+    expect(form.jobId).toBe('job-9');
+    expect(form.serviceType).toBe('Leak repair');
+    expect(form.riskAssessment).toBe('');
+    expect(form.equipment).toEqual(['Wrench']);
+    expect(form.workCarriedOut).toBe('Resealed joint');
+    expect(form.photos).toEqual([]);
+  });
+});

--- a/src/screens/ServiceReport/reportDraft.ts
+++ b/src/screens/ServiceReport/reportDraft.ts
@@ -1,0 +1,158 @@
+/**
+ * Service Report — pure form helpers.
+ *
+ * Kept network- and React-free so the draft-building logic can be unit tested
+ * without a live Job store or Firestore. The capture screen owns the editable
+ * `ReportFormState`; these helpers seed it from a Job and fold it back into the
+ * `CreateReportInput` shape reportService.createReport expects.
+ *
+ * Discipline: optional narrative/risk fields collapse to `undefined` when the
+ * tradie left them blank (Firestore rejects undefined at write time, and
+ * stripUndefined in reportService drops them cleanly), and equipment /
+ * checklist rows with only whitespace are pruned so they never reach the
+ * customer-facing document.
+ */
+
+import type { Job, JobPhoto } from '../../../shared/job/types';
+import type {
+  ReportChecklistItem,
+  SignatureCapture,
+} from '../../../shared/report/types';
+import type { CreateReportInput } from '../../services/reportService';
+
+/** Customer context lifted off the Job for the PDF export options. */
+export interface ReportCustomerContext {
+  customerName: string;
+  customerEmail?: string;
+  customerPhone?: string;
+  jobAddress?: string;
+}
+
+/** The editable state the capture screen holds. Strings stay strings (never
+ *  undefined) so the controlled inputs never flip between controlled and
+ *  uncontrolled; buildReportInput narrows blanks to undefined at save time. */
+export interface ReportFormState {
+  jobId: string;
+  visitDate: number;
+  serviceType: string;
+  riskAssessment: string;
+  equipment: string[];
+  itemsChecked: ReportChecklistItem[];
+  natureOfProblem: string;
+  workCarriedOut: string;
+  recommendedWork: string;
+  photos: JobPhoto[];
+  customerSignature?: SignatureCapture;
+  technicianSignature?: SignatureCapture;
+}
+
+const trim = (v: string | undefined | null): string => (v || '').trim();
+
+/** Empty string → undefined; anything else → its trimmed value. */
+const orUndefined = (v: string | undefined | null): string | undefined => {
+  const t = trim(v);
+  return t.length > 0 ? t : undefined;
+};
+
+/**
+ * Pull the customer/address fields off a Job for the report PDF + email
+ * context. Only fields with content survive so the PDF builder can skip empty
+ * rows.
+ */
+export function deriveReportContext(job: Job): ReportCustomerContext {
+  return {
+    customerName: trim(job.customerName),
+    customerEmail: orUndefined(job.customerEmail),
+    customerPhone: orUndefined(job.customerPhone),
+    jobAddress: orUndefined(job.jobAddress),
+  };
+}
+
+/**
+ * Seed a fresh, empty report form from a Job. The service type defaults to the
+ * job name (the tradie's own label for the work) so the most common case needs
+ * no typing; everything else starts blank. Mate never pre-fills the checklist
+ * or ticks anything — ticking is a manual tap only.
+ */
+export function buildInitialReportForm(
+  job: Job,
+  opts?: { visitDate?: number },
+): ReportFormState {
+  return {
+    jobId: job.id,
+    visitDate: opts?.visitDate ?? Date.now(),
+    serviceType: trim(job.name),
+    riskAssessment: '',
+    equipment: [],
+    itemsChecked: [],
+    natureOfProblem: '',
+    workCarriedOut: '',
+    recommendedWork: '',
+    photos: [],
+  };
+}
+
+/**
+ * Fold the editable form state into the CreateReportInput shape. Trims every
+ * text field, prunes blank equipment / checklist rows, and collapses empty
+ * optional fields to undefined.
+ */
+export function buildReportInput(state: ReportFormState): CreateReportInput {
+  const equipment = state.equipment
+    .map((e) => trim(e))
+    .filter((e) => e.length > 0);
+
+  const itemsChecked = state.itemsChecked
+    .map((it) => ({ ...it, text: trim(it.text) }))
+    .filter((it) => it.text.length > 0);
+
+  return {
+    jobId: state.jobId,
+    visitDate: state.visitDate,
+    serviceType: trim(state.serviceType),
+    riskAssessment: orUndefined(state.riskAssessment),
+    equipment,
+    itemsChecked,
+    natureOfProblem: orUndefined(state.natureOfProblem),
+    workCarriedOut: orUndefined(state.workCarriedOut),
+    recommendedWork: orUndefined(state.recommendedWork),
+    photos: state.photos.length > 0 ? state.photos : undefined,
+    customerSignature: state.customerSignature,
+    technicianSignature: state.technicianSignature,
+  };
+}
+
+/** Hydrate the editable form from a persisted report (edit mode). */
+export function formFromReport(
+  report: {
+    jobId: string;
+    visitDate: number;
+    serviceType: string;
+    riskAssessment?: string;
+    equipment: string[];
+    itemsChecked: ReportChecklistItem[];
+    natureOfProblem?: string;
+    workCarriedOut?: string;
+    recommendedWork?: string;
+    photos?: JobPhoto[];
+    customerSignature?: SignatureCapture;
+    technicianSignature?: SignatureCapture;
+  },
+): ReportFormState {
+  return {
+    jobId: report.jobId,
+    visitDate: report.visitDate,
+    serviceType: report.serviceType || '',
+    riskAssessment: report.riskAssessment || '',
+    equipment: Array.isArray(report.equipment) ? [...report.equipment] : [],
+    itemsChecked: Array.isArray(report.itemsChecked)
+      ? report.itemsChecked.map((it) => ({ ...it }))
+      : [],
+    natureOfProblem: report.natureOfProblem || '',
+    workCarriedOut: report.workCarriedOut || '',
+    recommendedWork: report.recommendedWork || '',
+    photos: Array.isArray(report.photos) ? [...report.photos] : [],
+    customerSignature: report.customerSignature,
+    technicianSignature: report.technicianSignature,
+  };
+}

--- a/src/screens/ViewJobScreen.tsx
+++ b/src/screens/ViewJobScreen.tsx
@@ -26,6 +26,7 @@ import { JobScopeCard, type ScopeStep } from '../components/JobScopeCard';
 import { JobDetailHeader } from '../components/JobDetailHeader';
 import { JobActionsSheet, type JobAction } from '../components/JobActionsSheet';
 import { exportDocumentPDF } from '../utils/pdfGenerator';
+import { canUseServiceReports } from '../utils/reportEntitlement';
 import { StageSheet } from '../components/StageSheet';
 import { JobStageSheet, stageMetaFor } from '../components/JobStageSheet';
 import {
@@ -69,6 +70,7 @@ export function ViewJobScreen() {
 
   const documents = useStore((s) => s.documents);
   const subscriptionStatus = useStore((s) => s.subscriptionStatus);
+  const getEffectivePlan = useStore((s) => s.getEffectivePlan);
   const businessSettings = useStore((s) => s.businessSettings);
   const saveQuote = useStore((s) => s.saveQuote);
   const saveInvoice = useStore((s) => s.saveInvoice);
@@ -609,6 +611,13 @@ export function ViewJobScreen() {
         break;
       case 'duplicate':
         handleDuplicate();
+        break;
+      case 'service_report':
+        if (canUseServiceReports(getEffectivePlan())) {
+          navigation.navigate('ServiceReport', { jobId: job.id });
+        } else {
+          navigation.navigate('Paywall');
+        }
         break;
       case 'exportPdf':
         if (primaryDoc) {

--- a/src/services/__tests__/reportService.test.ts
+++ b/src/services/__tests__/reportService.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeNextReportNumber,
+  stripUndefined,
+  normaliseReport,
+} from '../reportService';
+
+describe('computeNextReportNumber', () => {
+  it('starts at RP-001 when there are no existing reports', () => {
+    expect(computeNextReportNumber([])).toBe('RP-001');
+  });
+
+  it('zero-pads to three digits', () => {
+    expect(computeNextReportNumber([{ number: 'RP-008' }])).toBe('RP-009');
+    expect(computeNextReportNumber([{ number: 'RP-099' }])).toBe('RP-100');
+  });
+
+  it('reconciles against the existing max, not the count', () => {
+    // Gaps + out-of-order: max is 42, so next is 43 (never count-based).
+    const reports = [
+      { number: 'RP-001' },
+      { number: 'RP-042' },
+      { number: 'RP-007' },
+    ];
+    expect(computeNextReportNumber(reports)).toBe('RP-043');
+  });
+
+  it('ignores foreign prefixes and malformed numbers', () => {
+    const reports = [
+      { number: 'Q-999' }, // wrong prefix
+      { number: 'INV-500' }, // wrong prefix
+      { number: 'RP-005' },
+      { number: undefined }, // no number yet
+    ];
+    expect(computeNextReportNumber(reports)).toBe('RP-006');
+  });
+
+  it('matches case-insensitively', () => {
+    expect(computeNextReportNumber([{ number: 'rp-011' }])).toBe('RP-012');
+  });
+
+  it('respects a cached floor that is ahead of the derived max', () => {
+    expect(computeNextReportNumber([{ number: 'RP-003' }], 50)).toBe('RP-050');
+  });
+});
+
+describe('stripUndefined', () => {
+  it('drops undefined keys while keeping null and falsy-but-defined values', () => {
+    const input = {
+      a: 1,
+      b: undefined,
+      c: null,
+      d: 0,
+      e: '',
+      f: false,
+    };
+    expect(stripUndefined(input)).toEqual({
+      a: 1,
+      c: null,
+      d: 0,
+      e: '',
+      f: false,
+    });
+    expect('b' in stripUndefined(input)).toBe(false);
+  });
+
+  it('recurses into nested objects and arrays', () => {
+    const input = {
+      keep: 'yes',
+      drop: undefined,
+      nested: { inner: 1, gone: undefined },
+      list: [{ x: 1, y: undefined }],
+    };
+    expect(stripUndefined(input)).toEqual({
+      keep: 'yes',
+      nested: { inner: 1 },
+      list: [{ x: 1 }],
+    });
+  });
+
+  it('round-trips a report payload so it is Firestore-safe', () => {
+    const report = {
+      id: 'r1',
+      jobId: 'j1',
+      userId: 'u1',
+      number: 'RP-001',
+      visitDate: 1_753_000_000_000,
+      serviceType: 'Annual service',
+      riskAssessment: undefined, // optional, not filled in
+      equipment: ['Ladder', 'Multimeter'],
+      itemsChecked: [{ id: 'c1', text: 'Test RCDs', checked: true }],
+      natureOfProblem: 'Tripping RCD',
+      workCarriedOut: undefined, // still a draft
+      recommendedWork: undefined,
+      customerSignature: { svgPath: 'M0 0', name: 'Sam', signedAt: 1 },
+      technicianSignature: undefined,
+      status: 'draft',
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    const cleaned = stripUndefined(report);
+    expect(cleaned).not.toHaveProperty('riskAssessment');
+    expect(cleaned).not.toHaveProperty('workCarriedOut');
+    expect(cleaned).not.toHaveProperty('recommendedWork');
+    expect(cleaned).not.toHaveProperty('technicianSignature');
+    expect(cleaned.customerSignature).toEqual({
+      svgPath: 'M0 0',
+      name: 'Sam',
+      signedAt: 1,
+    });
+    expect(cleaned.itemsChecked).toEqual([
+      { id: 'c1', text: 'Test RCDs', checked: true },
+    ]);
+    expect(JSON.stringify(cleaned)).not.toContain('undefined');
+  });
+});
+
+describe('normaliseReport', () => {
+  it('coerces numeric strings and injects the doc id', () => {
+    const raw = {
+      jobId: 'j1',
+      userId: 'u1',
+      number: 'RP-002',
+      visitDate: '1753000000000',
+      serviceType: 'Repair',
+      equipment: ['Drill'],
+      itemsChecked: [{ id: 'c1', text: 'Check', checked: false }],
+      status: 'sent',
+      createdAt: '5',
+      updatedAt: '10',
+    };
+    const report = normaliseReport(raw, 'doc-id');
+    expect(report.id).toBe('doc-id');
+    expect(report.visitDate).toBe(1_753_000_000_000);
+    expect(report.createdAt).toBe(5);
+    expect(report.updatedAt).toBe(10);
+    expect(report.status).toBe('sent');
+  });
+
+  it('defaults missing/invalid fields to safe values', () => {
+    const report = normaliseReport({}, 'doc-id');
+    expect(report.jobId).toBe('');
+    expect(report.userId).toBe('');
+    expect(report.number).toBe('');
+    expect(report.serviceType).toBe('');
+    expect(report.visitDate).toBe(0);
+    expect(report.createdAt).toBe(0);
+    expect(report.updatedAt).toBe(0);
+    expect(report.equipment).toEqual([]);
+    expect(report.itemsChecked).toEqual([]);
+    expect(report.photos).toBeUndefined();
+    // Any non-'sent' value normalises to the safe default 'draft'.
+    expect(report.status).toBe('draft');
+  });
+
+  it('coerces an unknown status to draft', () => {
+    expect(normaliseReport({ status: 'archived' }, 'x').status).toBe('draft');
+  });
+});

--- a/src/services/reportComposeService.ts
+++ b/src/services/reportComposeService.ts
@@ -1,0 +1,79 @@
+/**
+ * Service Report write-up compose — client helper.
+ *
+ * Posts the tradie's rough notes to the `composeServiceReport` Firebase
+ * Function, which proxies the text model server-side (the master key never
+ * touches the device) and returns the three cleaned write-up fields. Mirrors
+ * emailService.ts for the auth header + functions URL so we stay on one auth
+ * path.
+ *
+ * Strictly a rewrite of what the tradie typed — the server prompt forbids
+ * invented detail — so an empty source field always comes back empty.
+ */
+
+import { auth } from '../config/firebase';
+
+const USE_EMULATOR = process.env.USE_FIREBASE_EMULATOR === 'true';
+const FIREBASE_FUNCTIONS_URL = USE_EMULATOR
+  ? 'http://127.0.0.1:5001/hansendev/us-central1'
+  : 'https://us-central1-hansendev.cloudfunctions.net';
+
+async function getAuthHeaders(): Promise<Record<string, string>> {
+  const token = await auth.currentUser?.getIdToken();
+  return {
+    'Content-Type': 'application/json',
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  };
+}
+
+export interface ComposeNotes {
+  natureOfProblem?: string;
+  workCarriedOut?: string;
+  recommendedWork?: string;
+}
+
+export interface ComposeContext {
+  businessName?: string;
+  tradeCategory?: string;
+}
+
+export interface ComposedReport {
+  natureOfProblem: string;
+  workCarriedOut: string;
+  recommendedWork: string;
+}
+
+/**
+ * Send the rough notes off for a clean write-up. Throws on a non-2xx reply so
+ * the caller can surface a retry; the returned object always carries all three
+ * keys (blank where the source note was blank).
+ */
+export async function composeServiceReport(
+  notes: ComposeNotes,
+  context?: ComposeContext,
+): Promise<ComposedReport> {
+  const headers = await getAuthHeaders();
+  const response = await fetch(`${FIREBASE_FUNCTIONS_URL}/composeServiceReport`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ notes, context }),
+  });
+
+  if (!response.ok) {
+    let message = 'Could not write up the notes. Please try again.';
+    try {
+      const body = await response.json();
+      if (body?.error) message = String(body.error);
+    } catch {
+      /* keep the default message */
+    }
+    throw new Error(message);
+  }
+
+  const data = (await response.json()) as Partial<ComposedReport>;
+  return {
+    natureOfProblem: data.natureOfProblem || '',
+    workCarriedOut: data.workCarriedOut || '',
+    recommendedWork: data.recommendedWork || '',
+  };
+}

--- a/src/services/reportService.ts
+++ b/src/services/reportService.ts
@@ -1,0 +1,224 @@
+/**
+ * Service Report Service
+ * Reads/writes the `users/{uid}/reports/{reportId}` collection. A Service
+ * Report is a customer-facing leave-behind document a tradie produces after a
+ * service visit — linked to a Job via `jobId`, it carries no money, no stage,
+ * and no line items (see shared/report/types.ts).
+ *
+ * Mirrors jobService.ts: getUserId, stripUndefined, normalise, class +
+ * singleton, onSnapshot subscribe. Report numbers ("RP-001") are reconciled
+ * against existing reports via reconcileNextNumber so a fresh device doesn't
+ * mint a colliding number.
+ */
+
+import {
+  collection,
+  doc,
+  setDoc,
+  getDoc,
+  getDocs,
+  deleteDoc,
+  onSnapshot,
+  Unsubscribe,
+  query,
+  orderBy,
+  where,
+} from 'firebase/firestore';
+import { auth, db } from '../config/firebase';
+import { generateId } from '../utils/generateId';
+import { reconcileNextNumber } from '../utils/nextNumber';
+import type {
+  ServiceReport,
+  ServiceReportStatus,
+} from '../../shared/report/types';
+
+function getUserId(): string | null {
+  return auth.currentUser?.uid || null;
+}
+
+/** Recursively strip undefined values — Firestore rejects them. */
+export function stripUndefined(value: any): any {
+  if (value === null || value === undefined) return value;
+  if (Array.isArray(value)) return value.map(stripUndefined);
+  if (value instanceof Date) return value;
+  if (typeof value !== 'object') return value;
+  const cleaned: any = {};
+  for (const [k, v] of Object.entries(value)) {
+    if (v !== undefined)
+      cleaned[k] =
+        typeof v === 'object' && v !== null && !(v instanceof Date)
+          ? stripUndefined(v)
+          : v;
+  }
+  return cleaned;
+}
+
+/** Coerce a raw Firestore doc into a well-formed ServiceReport. */
+export function normaliseReport(raw: any, id: string): ServiceReport {
+  return {
+    ...raw,
+    id,
+    jobId: String(raw.jobId || ''),
+    userId: String(raw.userId || ''),
+    number: String(raw.number || ''),
+    visitDate: Number(raw.visitDate) || 0,
+    serviceType: String(raw.serviceType || ''),
+    equipment: Array.isArray(raw.equipment) ? raw.equipment : [],
+    itemsChecked: Array.isArray(raw.itemsChecked) ? raw.itemsChecked : [],
+    photos: Array.isArray(raw.photos) ? raw.photos : undefined,
+    status: (raw.status === 'sent' ? 'sent' : 'draft') as ServiceReportStatus,
+    createdAt: Number(raw.createdAt) || 0,
+    updatedAt: Number(raw.updatedAt) || 0,
+  } as ServiceReport;
+}
+
+/**
+ * Compute the next "RP-NNN" report number from a list of existing reports.
+ * Pure — extracted so it can be tested without live Firestore. Reconciles the
+ * derived max against a cached floor (defaults to 1) exactly like quote/invoice
+ * numbering.
+ */
+export function computeNextReportNumber(
+  reports: Array<{ number?: string }>,
+  cached = 1,
+): string {
+  const next = reconcileNextNumber({
+    items: reports,
+    field: (r) => r.number,
+    prefix: 'RP',
+    cached,
+  });
+  return `RP-${String(next).padStart(3, '0')}`;
+}
+
+/** Fields the caller supplies when creating a report. */
+export type CreateReportInput = Omit<
+  ServiceReport,
+  'id' | 'userId' | 'number' | 'createdAt' | 'updatedAt' | 'status'
+> &
+  Partial<Pick<ServiceReport, 'status' | 'number'>>;
+
+class ReportService {
+  private unsubscribe: Unsubscribe | null = null;
+
+  private colRef(uid: string) {
+    return collection(db, 'users', uid, 'reports');
+  }
+
+  /** Derive the next "RP-001"-style number from existing reports. */
+  async nextReportNumber(): Promise<string> {
+    const uid = getUserId();
+    if (!uid) return computeNextReportNumber([]);
+    try {
+      const snap = await getDocs(this.colRef(uid));
+      const reports = snap.docs.map((d) => d.data() as { number?: string });
+      return computeNextReportNumber(reports);
+    } catch {
+      return computeNextReportNumber([]);
+    }
+  }
+
+  async createReport(input: CreateReportInput): Promise<ServiceReport> {
+    const uid = getUserId();
+    if (!uid) throw new Error('Not signed in');
+    const now = Date.now();
+    const id = generateId();
+    const number = input.number || (await this.nextReportNumber());
+    const report: ServiceReport = {
+      ...input,
+      id,
+      userId: uid,
+      number,
+      status: input.status || 'draft',
+      createdAt: now,
+      updatedAt: now,
+    };
+    const ref = doc(db, 'users', uid, 'reports', id);
+    await setDoc(ref, stripUndefined(report));
+    return report;
+  }
+
+  async updateReport(
+    id: string,
+    patch: Partial<ServiceReport>,
+  ): Promise<void> {
+    const uid = getUserId();
+    if (!uid) return;
+    const ref = doc(db, 'users', uid, 'reports', id);
+    const payload = stripUndefined({
+      ...patch,
+      updatedAt: Date.now(),
+    });
+    await setDoc(ref, payload, { merge: true });
+  }
+
+  async getReport(id: string): Promise<ServiceReport | null> {
+    const uid = getUserId();
+    if (!uid) return null;
+    try {
+      const ref = doc(db, 'users', uid, 'reports', id);
+      const snap = await getDoc(ref);
+      if (!snap.exists()) return null;
+      return normaliseReport(snap.data(), snap.id);
+    } catch {
+      return null;
+    }
+  }
+
+  async listReports(jobId?: string): Promise<ServiceReport[]> {
+    const uid = getUserId();
+    if (!uid) return [];
+    try {
+      const ref = this.colRef(uid);
+      const q = jobId
+        ? query(ref, where('jobId', '==', jobId), orderBy('updatedAt', 'desc'))
+        : query(ref, orderBy('updatedAt', 'desc'));
+      const snap = await getDocs(q);
+      return snap.docs.map((d) => normaliseReport(d.data(), d.id));
+    } catch {
+      return [];
+    }
+  }
+
+  subscribeReports(
+    callback: (reports: ServiceReport[]) => void,
+    jobId?: string,
+  ): Unsubscribe {
+    const uid = getUserId();
+    if (!uid) return () => {};
+    try {
+      // Release prior listener — token-refresh re-invokes this every ~hour.
+      this.unsubscribe?.();
+      const ref = this.colRef(uid);
+      const q = jobId
+        ? query(ref, where('jobId', '==', jobId), orderBy('updatedAt', 'desc'))
+        : query(ref, orderBy('updatedAt', 'desc'));
+      this.unsubscribe = onSnapshot(
+        q,
+        (snap) => {
+          callback(snap.docs.map((d) => normaliseReport(d.data(), d.id)));
+        },
+        () => {},
+      );
+      return this.unsubscribe;
+    } catch {
+      return () => {};
+    }
+  }
+
+  async deleteReport(id: string): Promise<void> {
+    const uid = getUserId();
+    if (!uid) return;
+    const ref = doc(db, 'users', uid, 'reports', id);
+    await deleteDoc(ref);
+  }
+
+  cleanup(): void {
+    if (this.unsubscribe) {
+      this.unsubscribe();
+      this.unsubscribe = null;
+    }
+  }
+}
+
+export const reportService = new ReportService();

--- a/src/utils/pdfGenerator.ts
+++ b/src/utils/pdfGenerator.ts
@@ -23,10 +23,13 @@ import { Platform, Alert } from 'react-native';
 import {
   buildQuotePdfHtml,
   buildInvoicePdfHtml,
+  buildReportPdfHtml,
   QuotePdfData,
   InvoicePdfData,
+  ReportPdfData,
   BusinessPdfData,
 } from '../../shared/pdf';
+import { ServiceReport } from '../../shared/report/types';
 import { useStore } from '../store/useStore';
 import { checkSquareConnection } from '../services/squareService';
 
@@ -393,6 +396,224 @@ export async function exportDocumentPDF(
                 await MailComposer.composeAsync({
                   subject: emailSubject,
                   recipients: doc.customerEmail ? [doc.customerEmail] : [],
+                  body: emailBody,
+                  attachments: [newUri],
+                });
+              } else {
+                Alert.alert('Error', 'Email is not available on this device');
+              }
+            } catch (error) {
+              Alert.alert('Error', 'Failed to compose email');
+            }
+          },
+        },
+        {
+          text: 'Share',
+          onPress: async () => {
+            const isAvailable = await Sharing.isAvailableAsync();
+            if (isAvailable) {
+              await Sharing.shareAsync(newUri, {
+                UTI: Platform.OS === 'ios' ? 'com.adobe.pdf' : undefined,
+                mimeType: 'application/pdf',
+                dialogTitle: filename,
+              });
+            }
+          },
+        },
+        { text: 'OK' },
+      ],
+    );
+  } catch (error) {
+    Alert.alert('Error', 'Failed to export PDF. Please try again.');
+  }
+}
+
+// ============================================================
+// SERVICE REPORT PDF
+// ============================================================
+
+/**
+ * Context the report itself doesn't carry. A ServiceReport links to a Job by
+ * id and holds no customer fields, so the caller passes the resolved customer
+ * / address details (read off the linked Job) through options.
+ */
+export interface ReportPdfOptions {
+  isPro?: boolean;
+  customerName?: string;
+  customerEmail?: string;
+  customerPhone?: string;
+  jobAddress?: string;
+}
+
+/**
+ * Build the ReportPdfData payload from a ServiceReport plus the customer
+ * context supplied by the caller, resolve the business chrome the same way
+ * quotes/invoices do, and render via the shared report HTML builder.
+ */
+// Session cache for base64-inlined report photos, keyed by source URI —
+// same rationale as logoHtmlCache above: re-encoding on every export blocks
+// the main thread for no reason.
+const photoDataUriCache = new Map<string, string>();
+
+/**
+ * Resolve a report photo to something the PDF renderer can safely embed.
+ *
+ * Web: the browser fetches remote images natively — pass the URL through.
+ * Mobile: remote <img src="https://…"> stalls Android's print bridge
+ * indefinitely (same failure documented on prepareLogoHtml above) and races
+ * expo-print's snapshot on iOS, silently dropping photos on slow signal. So
+ * photos are downloaded and inlined as base64 data URIs, exactly like the
+ * logo. A photo that can't be fetched (offline) is skipped rather than
+ * hanging the export.
+ */
+async function prepareReportPhoto(uri: string): Promise<{ dataUri?: string; url?: string } | null> {
+  if (Platform.OS === 'web') return { url: uri };
+
+  const cached = photoDataUriCache.get(uri);
+  if (cached) return { dataUri: cached };
+
+  try {
+    const isRemote = uri.startsWith('http://') || uri.startsWith('https://');
+    let base64: string;
+    if (isRemote) {
+      const tmp = `${FileSystem.cacheDirectory}report-photo-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.img`;
+      const downloaded = await FileSystem.downloadAsync(uri, tmp);
+      base64 = await FileSystem.readAsStringAsync(downloaded.uri, {
+        encoding: FileSystem.EncodingType.Base64,
+      });
+    } else {
+      base64 = await FileSystem.readAsStringAsync(uri, {
+        encoding: FileSystem.EncodingType.Base64,
+      });
+    }
+    // image/jpeg decodes fine for both JPEG and PNG payloads in the print
+    // renderers (WebKit / Android print WebView) — same as the logo path.
+    const dataUri = `data:image/jpeg;base64,${base64}`;
+    photoDataUriCache.set(uri, dataUri);
+    return { dataUri };
+  } catch {
+    return null;
+  }
+}
+
+export async function generateReportPDF(
+  report: ServiceReport,
+  businessSettings: BusinessSettings | null,
+  options?: ReportPdfOptions,
+): Promise<string> {
+  const logoHtml = await prepareLogoHtml(businessSettings, options?.isPro);
+  const business = mapBusinessData(businessSettings, logoHtml);
+
+  // Inline photos before building the HTML — remote URLs hang the Android
+  // print bridge and race the iOS snapshot (see prepareReportPhoto).
+  const preparedPhotos = report.photos?.length
+    ? (await Promise.all(report.photos.map((p) => prepareReportPhoto(p.storageUrl)))).filter(
+        (p): p is { dataUri?: string; url?: string } => p !== null,
+      )
+    : undefined;
+
+  const pdfData: ReportPdfData = {
+    reportNumber: report.number,
+    customerName: options?.customerName || '',
+    customerEmail: options?.customerEmail,
+    customerPhone: options?.customerPhone,
+    jobAddress: options?.jobAddress,
+    visitDate: format(new Date(report.visitDate), 'dd MMMM yyyy'),
+    serviceType: report.serviceType,
+    riskAssessment: report.riskAssessment,
+    equipment: report.equipment,
+    itemsChecked: report.itemsChecked.map(it => ({ text: it.text, checked: it.checked })),
+    natureOfProblem: report.natureOfProblem,
+    workCarriedOut: report.workCarriedOut,
+    recommendedWork: report.recommendedWork,
+    photos: preparedPhotos,
+    customerSignature: report.customerSignature
+      ? {
+          svgPath: report.customerSignature.svgPath,
+          name: report.customerSignature.name,
+          width: report.customerSignature.width,
+          height: report.customerSignature.height,
+        }
+      : undefined,
+    technicianSignature: report.technicianSignature
+      ? {
+          svgPath: report.technicianSignature.svgPath,
+          name: report.technicianSignature.name,
+          width: report.technicianSignature.width,
+          height: report.technicianSignature.height,
+        }
+      : undefined,
+  };
+
+  return buildReportPdfHtml(pdfData, business);
+}
+
+/**
+ * Export a service report PDF. Mirrors `exportDocumentPDF`'s platform
+ * handling (web print window / mobile expo-print + share-or-email sheet)
+ * with report-appropriate filename and copy.
+ */
+export async function exportReportPDF(
+  report: ServiceReport,
+  businessSettings: BusinessSettings | null,
+  action: 'export' | 'share' = 'export',
+  options?: ReportPdfOptions,
+): Promise<void> {
+  try {
+    const html = await generateReportPDF(report, businessSettings, options);
+
+    const customerName = options?.customerName || 'Customer';
+    const filename = `Service_Report_${sanitizeForFilename(customerName)}_${format(new Date(report.visitDate), 'dd-MMM-yyyy')}.pdf`;
+    const emailSubject = `Service report for ${customerName}`;
+    const emailBody = `Please find attached your service report from ${format(new Date(report.visitDate), 'dd MMMM yyyy')}.\n\nThank you.`;
+
+    if (Platform.OS === 'web') {
+      const printWindow = window.open('', '_blank');
+      if (printWindow) {
+        printWindow.document.write(html);
+        printWindow.document.close();
+        printWindow.document.title = filename;
+        printWindow.onload = () => {
+          printWindow.focus();
+          printWindow.print();
+        };
+      } else {
+        Alert.alert('Error', 'Please allow popups to export PDF');
+      }
+      return;
+    }
+
+    const { uri } = await Print.printToFileAsync({ html });
+    const newUri = `${FileSystem.cacheDirectory}${filename}`;
+    await FileSystem.copyAsync({ from: uri, to: newUri });
+
+    if (action === 'share') {
+      const isAvailable = await Sharing.isAvailableAsync();
+      if (isAvailable) {
+        await Sharing.shareAsync(newUri, {
+          UTI: Platform.OS === 'ios' ? 'com.adobe.pdf' : undefined,
+          mimeType: 'application/pdf',
+          dialogTitle: filename,
+        });
+      } else {
+        Alert.alert('PDF Created', `${filename} saved successfully`);
+      }
+      return;
+    }
+
+    Alert.alert(
+      'PDF Exported',
+      `${filename} created successfully`,
+      [
+        {
+          text: 'Email',
+          onPress: async () => {
+            try {
+              const isAvailable = await MailComposer.isAvailableAsync();
+              if (isAvailable) {
+                await MailComposer.composeAsync({
+                  subject: emailSubject,
+                  recipients: options?.customerEmail ? [options.customerEmail] : [],
                   body: emailBody,
                   attachments: [newUri],
                 });

--- a/src/utils/reportEntitlement.test.ts
+++ b/src/utils/reportEntitlement.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { canUseServiceReports } from './reportEntitlement';
+
+describe('canUseServiceReports', () => {
+  it('allows trial and pro', () => {
+    expect(canUseServiceReports('trial')).toBe(true);
+    expect(canUseServiceReports('pro')).toBe(true);
+  });
+
+  it('locks free (expired trial) out', () => {
+    expect(canUseServiceReports('free')).toBe(false);
+  });
+});

--- a/src/utils/reportEntitlement.ts
+++ b/src/utils/reportEntitlement.ts
@@ -1,0 +1,10 @@
+/**
+ * Service Report entitlement.
+ *
+ * Reports are available on trial and pro. A 'free' plan means the trial has
+ * elapsed with no subscription — that state is locked to the paywall, matching
+ * how the rest of the app gates create/premium actions once the trial ends.
+ */
+export function canUseServiceReports(plan: 'trial' | 'free' | 'pro'): boolean {
+  return plan !== 'free';
+}


### PR DESCRIPTION
Integrates the **service reports** feature onto current `main`.

The feature was committed on a local branch (`feat/service-reports`) that had been cut from the pre-#51 `main`, so it was missing the Firefox Google Sign-In fix + the PAY-01/02/03 payment criticals. This branch cherry-picks it cleanly onto current `main` (`5c50bbd`) — **zero conflicts** — so `main` ends up with the sign-in fix, the payment fixes, **and** service reports together.

## What service reports adds (`5f8f0da`, 27 files)
- Service report capture screen + signature pad (`src/screens/ServiceReport/`, `SignaturePad`), draft persistence.
- Mate write-up + PDF generation (`shared/pdf/`, `src/utils/pdfGenerator.ts`) and email delivery (`functions/src/composeServiceReport*`, `serviceReportEmail*`).
- Report service + entitlement gating (`src/services/reportService.ts`, `reportEntitlement.ts`), wired into Job actions / navigation.

## Verification (on this integrated branch)
- **App:** 938 tests pass (82 files); `tsc` clean.
- **Functions:** 417 tests pass (34 files); `tsc` clean.
- The one overlap with merged work (`functions/src/index.ts`) cherry-picked cleanly; both changes coexist.

> Not deployed / not built — merging is code integration only. Functions (`composeServiceReport`, `serviceReportEmail`) still need `firebase deploy`; the native build (for the sign-in fix) is a separate step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
