### PR TITLE
Mate: voice mint throttle + anchor-laundering send gate (last stranded work → main)

### DIFF
--- a/src/components/DocumentEmailPreviewModal.tsx
+++ b/src/components/DocumentEmailPreviewModal.tsx
@@ -430,7 +430,7 @@ export function DocumentEmailPreviewModal({
     }
 
     const warning = buildPresendWarning(
-      reviewQuoteMaterials(doc.materials),
+      reviewQuoteMaterials(doc.materials, doc.sections),
       doc.type === 'invoice' ? 'invoice' : 'quote',
       { materialsShownToCustomer: doc.showMaterialCosts !== false },
     );

--- a/src/services/assistant/__tests__/textTransport.test.ts
+++ b/src/services/assistant/__tests__/textTransport.test.ts
@@ -11,6 +11,8 @@ import {
   MINT_TIMEOUT_MS,
   LiveOfflineError,
   LiveQuotaError,
+  LiveRateLimitError,
+  __resetMintThrottle,
 } from '../liveSession';
 import type { ChatMessage } from '../../../types/assistant';
 
@@ -47,7 +49,9 @@ const history: ChatMessage[] = [
 
 beforeEach(() => {
   vi.useFakeTimers();
+  vi.setSystemTime(0);
   fetchMock.mockReset();
+  __resetMintThrottle();
   vi.stubGlobal('fetch', fetchMock);
   (auth as any).currentUser = { uid: 'test-uid', getIdToken: async () => 'id-tok' };
 });
@@ -153,6 +157,37 @@ describe('mintLiveToken', () => {
     await rejection;
     // The voice reconnect loop owns retries — the mint itself must not.
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces the server 429 as a LiveRateLimitError', async () => {
+    fetchMock.mockResolvedValueOnce(errorResponse(429));
+    await expect(mintLiveToken('voice')).rejects.toBeInstanceOf(LiveRateLimitError);
+  });
+
+  it('throttles a mint storm client-side before it can trip the server limit', async () => {
+    const ok = { ok: true, status: 200, json: async () => ({ token: 'tok', model: 'm' }) } as unknown as Response;
+    fetchMock.mockResolvedValue(ok);
+
+    // The server allows 10/min; we self-limit at 8. Burn the window.
+    for (let i = 0; i < 8; i++) await mintLiveToken('voice');
+    expect(fetchMock).toHaveBeenCalledTimes(8);
+
+    // The 9th mint inside the same window fails fast and never hits the network.
+    await expect(mintLiveToken('voice')).rejects.toBeInstanceOf(LiveRateLimitError);
+    expect(fetchMock).toHaveBeenCalledTimes(8);
+  });
+
+  it('lets mints through again once the rolling window elapses', async () => {
+    const ok = { ok: true, status: 200, json: async () => ({ token: 'tok', model: 'm' }) } as unknown as Response;
+    fetchMock.mockResolvedValue(ok);
+
+    for (let i = 0; i < 8; i++) await mintLiveToken('voice');
+    await expect(mintLiveToken('voice')).rejects.toBeInstanceOf(LiveRateLimitError);
+
+    // Age the earlier mints out of the window, then a fresh mint is allowed.
+    vi.setSystemTime(61_000);
+    await expect(mintLiveToken('voice')).resolves.toEqual({ token: 'tok', model: 'm' });
+    expect(fetchMock).toHaveBeenCalledTimes(9);
   });
 });
 

--- a/src/services/assistant/__tests__/voiceSession.reconnect.test.ts
+++ b/src/services/assistant/__tests__/voiceSession.reconnect.test.ts
@@ -23,7 +23,7 @@ import {
   RECONNECT_DELAYS_MS,
   VoiceSessionCallbacks,
 } from '../voiceSession';
-import { mintLiveToken, LiveOfflineError, LiveQuotaError } from '../liveSession';
+import { mintLiveToken, LiveOfflineError, LiveQuotaError, LiveRateLimitError } from '../liveSession';
 
 const mintMock = vi.mocked(mintLiveToken);
 
@@ -274,6 +274,24 @@ describe('drop with reconnect (sticky)', () => {
     expect(cb.onError.mock.calls[0][0]).toBeInstanceOf(LiveQuotaError);
     expect(cb.onClose).toHaveBeenCalledTimes(1);
     // No second socket was ever opened.
+    expect(MockWebSocket.instances).toHaveLength(1);
+  });
+
+  it('stops retrying immediately on a rate-limit error', async () => {
+    const cb = makeCallbacks();
+    await openSticky(cb);
+
+    // A drop while the mint endpoint is rate-limited must not spin through the
+    // remaining attempts re-minting — that only deepens the storm.
+    mintMock.mockRejectedValue(new LiveRateLimitError('Whoa — too many requests. Wait a moment.'));
+    MockWebSocket.instances[0].onclose?.({ code: 1006 });
+    await vi.advanceTimersByTimeAsync(RECONNECT_DELAYS_MS[0]);
+
+    expect(cb.onReconnecting).toHaveBeenCalledTimes(1);
+    expect(cb.onError).toHaveBeenCalledTimes(1);
+    expect(cb.onError.mock.calls[0][0]).toBeInstanceOf(LiveRateLimitError);
+    expect(cb.onClose).toHaveBeenCalledTimes(1);
+    // No second socket was ever opened — the loop bailed after one attempt.
     expect(MockWebSocket.instances).toHaveLength(1);
   });
 

--- a/src/services/assistant/liveSession.ts
+++ b/src/services/assistant/liveSession.ts
@@ -44,6 +44,20 @@ export class LiveOfflineError extends Error {
   }
 }
 
+/**
+ * The token mint was rate-limited — the server returned 429, or we throttled
+ * ourselves client-side before hammering it. A subclass of LiveOfflineError so
+ * every existing `instanceof LiveOfflineError` handler still surfaces the
+ * message, while the voice reconnect loop can single it out and stop re-minting
+ * (retrying into a rate limit only deepens it).
+ */
+export class LiveRateLimitError extends LiveOfflineError {
+  constructor(message: string) {
+    super(message);
+    this.name = 'LiveRateLimitError';
+  }
+}
+
 export interface MintedToken {
   token: string;
   model: string;
@@ -77,6 +91,33 @@ export async function fetchWithTimeout(
   }
 }
 
+// Client-side mint throttle. The server caps ephemeral-token mints at 10/min
+// per user (assistantToken's HEAVY rate limit). Under patchy coverage the voice
+// reconnect loop fires up to a mint per attempt, and repeated drops — plus any
+// AppState/focus-driven auto-restart — used to blow past that ceiling and spray
+// the tradie with "too many requests" (each attempt also reserving a quota turn
+// server-side). We pace ourselves just below the server ceiling: once this many
+// mints land inside the rolling window, the next one fails fast client-side
+// instead of hammering the endpoint. 8 leaves headroom under the server's 10
+// while staying above what legit use reaches — rapid PTT turns run ~4-6/min
+// (each turn is speak + full spoken reply), and a drop cycle is 1 open + 3
+// reconnect mints, so two full drop cycles fit before the throttle bites.
+const MINT_WINDOW_MS = 60_000;
+const MINT_MAX_PER_WINDOW = 8;
+let mintTimestamps: number[] = [];
+
+/** Test-only: clear the rolling mint window between cases. */
+export function __resetMintThrottle(): void {
+  mintTimestamps = [];
+}
+
+// Drop timestamps that have aged out of the window, then report whether another
+// mint is allowed right now.
+function mintAllowed(now: number): boolean {
+  mintTimestamps = mintTimestamps.filter((t) => now - t < MINT_WINDOW_MS);
+  return mintTimestamps.length < MINT_MAX_PER_WINDOW;
+}
+
 // Mint a single-use ephemeral Gemini Live token via the assistantToken
 // Function. `mode` distinguishes the voice quota bucket from text; omit it for
 // the text path. The Function verifies the ID token, rate-limits, reserves a
@@ -84,6 +125,15 @@ export async function fetchWithTimeout(
 export async function mintLiveToken(mode?: 'voice'): Promise<MintedToken> {
   const idToken = await auth.currentUser?.getIdToken();
   if (!idToken) throw new LiveAuthError('Sign in to use Mate.');
+
+  // Self-limit before touching the network so a reconnect/restart storm can't
+  // trip the server's 10/min mint ceiling. Record the attempt only once it
+  // clears the throttle — a rejected call never left the device.
+  const now = Date.now();
+  if (!mintAllowed(now)) {
+    throw new LiveRateLimitError('Whoa — too many requests. Wait a moment.');
+  }
+  mintTimestamps.push(now);
 
   // No retry here on purpose: the voice reconnect loop already retries whole
   // connect attempts, and each successful mint reserves a quota turn — a
@@ -106,7 +156,7 @@ export async function mintLiveToken(mode?: 'voice'): Promise<MintedToken> {
     throw new LiveQuotaError(data.error || "You've hit today's Mate limit.");
   }
   if (response.status === 429) {
-    throw new LiveOfflineError('Whoa — too many requests. Wait a moment.');
+    throw new LiveRateLimitError('Whoa — too many requests. Wait a moment.');
   }
   if (!response.ok) {
     const data = await response.json().catch(() => ({}));

--- a/src/services/assistant/readTools.ts
+++ b/src/services/assistant/readTools.ts
@@ -559,7 +559,7 @@ export async function reviewQuote(input: { quoteId: string }): Promise<unknown> 
     return { error: res?.error || 'Quote not found.' };
   }
   const q = res.quote;
-  const review = reviewQuoteMaterials((q.materials as Material[]) || []);
+  const review = reviewQuoteMaterials((q.materials as Material[]) || [], q.sections);
   return {
     quoteId,
     number: q.number,

--- a/src/services/assistant/voiceSession.ts
+++ b/src/services/assistant/voiceSession.ts
@@ -37,6 +37,7 @@ import {
   LiveAuthError,
   LiveOfflineError,
   LiveQuotaError,
+  LiveRateLimitError,
   mintLiveToken,
 } from './liveSession';
 
@@ -302,9 +303,14 @@ export async function openVoiceSession(
         return;
       } catch (err: any) {
         lastErr = err instanceof Error ? err : new LiveOfflineError('Voice reconnect failed.');
-        // Quota/auth failures won't heal with another attempt — bail now
-        // rather than burning more mints.
-        if (err instanceof LiveQuotaError || err instanceof LiveAuthError) break;
+        // Quota, auth, and rate-limit failures won't heal with another attempt
+        // — and re-minting into a rate limit only deepens it. Bail now rather
+        // than burning more mints.
+        if (
+          err instanceof LiveQuotaError ||
+          err instanceof LiveAuthError ||
+          err instanceof LiveRateLimitError
+        ) break;
       }
     }
     reconnecting = false;

--- a/src/store/useStore.ts
+++ b/src/store/useStore.ts
@@ -2914,7 +2914,7 @@ export const useStore = create<AppState>((set, get) => ({
 
             get().updateQuote(pricedResult.updatedQuote);
             await get().saveDraft(get().currentQuote!);
-            review = reviewQuoteMaterials(pricedResult.updatedQuote.materials);
+            review = reviewQuoteMaterials(pricedResult.updatedQuote.materials, pricedResult.updatedQuote.sections);
 
             const parts: string[] = [];
             if (pricedResult.fetchedCount > 0) parts.push(`${pricedResult.fetchedCount} priced`);
@@ -3316,7 +3316,7 @@ export const useStore = create<AppState>((set, get) => ({
               total: priced.total,
             };
             await get().saveDocument(repricedDoc);
-            const review = reviewQuoteMaterials(priced.materials);
+            const review = reviewQuoteMaterials(priced.materials, priced.sections);
             onProgress?.({ phase: 'done', status: 'Prices re-checked.', done: true, summary: review.summary });
             return { ok: true, navigate: { kind: 'job_preview', quoteId: doc.id }, review };
           }
@@ -3326,7 +3326,7 @@ export const useStore = create<AppState>((set, get) => ({
           if (!quote) return { ok: false, error: 'Quote not found.' };
           const { priced } = await runReprice(quote);
           await get().saveQuote(priced);
-          const review = reviewQuoteMaterials(priced.materials);
+          const review = reviewQuoteMaterials(priced.materials, priced.sections);
           onProgress?.({ phase: 'done', status: 'Prices re-checked.', done: true, summary: review.summary });
           return { ok: true, navigate: { kind: 'job_preview', quoteId: quote.id }, review };
         }

--- a/src/utils/quoteReview.test.ts
+++ b/src/utils/quoteReview.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { reviewQuoteMaterials, isFlaggedRow, buildPresendWarning } from './quoteReview';
-import type { Material } from '../types';
+import { reviewQuoteMaterials, isFlaggedRow, buildPresendWarning, detectAnchorLaunderedIssues } from './quoteReview';
+import type { Material, QuoteSection } from '../types';
 
 // Minimal Material factory — only the fields the classifier reads matter; the
 // rest get harmless defaults so a test row is a valid Material.
@@ -15,6 +15,42 @@ function mat(overrides: Partial<Material>): Material {
     manualPriceOverride: false,
     ...overrides,
   };
+}
+
+// Minimal QuoteSection factory — the detector reads name/multiplier/laborHours.
+function sec(overrides: Partial<QuoteSection>): QuoteSection {
+  return {
+    id: 's1',
+    name: 'Section',
+    multiplier: 1,
+    laborHours: 1,
+    laborRate: 85,
+    laborUnit: 'hours',
+    laborTotal: 85,
+    sortOrder: 0,
+    ...overrides,
+  };
+}
+
+// The exact QU-178425 quote: a 165 m² tile-to-Colorbond re-roof mis-classed as
+// a per-m² section (multiplier 165, 0.5 h/m²), so Round-1 emitted "1 per m²"
+// for every material and × 165 laundered the roof area onto each line.
+function roofFixture(): { materials: Material[]; sections: QuoteSection[] } {
+  const sections = [
+    sec({ id: 'roof', name: 'Roof Replacement', multiplier: 165, laborHours: 0.5 }),
+    sec({ id: 'site', name: 'Site Setup & Waste', multiplier: 1, laborHours: 7.5 }),
+  ];
+  const base = { section: 'Roof Replacement', priceConfidence: 'low' as const };
+  const materials: Material[] = [
+    mat({ id: 'r1', name: 'Colorbond Corrugated Roofing Sheets 0.48mm BMT', quantity: 165, unit: 'm', requiredQty: 165, requiredUnit: 'm', templateBaseQuantity: 1, price: 42, pricingSource: 'scraper', ...base }),
+    mat({ id: 'r2', name: 'Anticon Roofing Blanket', quantity: 9, unit: 'each', requiredQty: 165, requiredUnit: 'm²', templateBaseQuantity: 1, price: 89.9, pricingSource: 'scraper', ...base }),
+    mat({ id: 'r3', name: 'Metal Roof Battens 40mm', quantity: 28, unit: 'each', requiredQty: 165, requiredUnit: 'm', templateBaseQuantity: 1, price: 18.5, pricingSource: 'scraper', ...base }),
+    mat({ id: 'r4', name: 'Roofing Screws (Timber Fixing)', quantity: 495, unit: 'each', templateBaseQuantity: 3, price: 0.07, pricingSource: 'ai', ...base }),
+    mat({ id: 'r5', name: 'Batten Screws', quantity: 165, unit: 'each', templateBaseQuantity: 1, price: 0.07, pricingSource: 'ai', ...base }),
+    mat({ id: 'r6', name: 'Colorbond Ridge Capping', quantity: 55, unit: 'each', requiredQty: 165, requiredUnit: 'm', templateBaseQuantity: 1, price: 38.9, pricingSource: 'scraper', ...base }),
+    mat({ id: 'r7', name: 'Roof and Gutter Silicone Sealant', quantity: 165, unit: 'each', requiredQty: 165, requiredUnit: 'each', templateBaseQuantity: 1, price: 17.5, pricingSource: 'scraper', ...base }),
+  ];
+  return { materials, sections };
 }
 
 describe('reviewQuoteMaterials', () => {
@@ -170,5 +206,82 @@ describe('buildPresendWarning — hidden materials and labour-only quotes', () =
   it('uses the visible wording by default', () => {
     const w = buildPresendWarning(reviewQuoteMaterials([zero()]));
     expect(w?.message).toContain("will show as $0 on the customer's quote");
+  });
+});
+
+describe('detectAnchorLaunderedIssues — QU-178425 (165 m² re-roof)', () => {
+  it('flags every anchor-showing line in the laundered roof section', () => {
+    const { materials, sections } = roofFixture();
+    const issues = detectAnchorLaunderedIssues(materials, sections);
+    // All seven roof lines carry the laundered area, one way or another
+    // (quantity === 165, requiredQty === 165, or 495 = 3 × 165).
+    expect(issues.map((i) => i.materialId).sort()).toEqual(['r1', 'r2', 'r3', 'r4', 'r5', 'r6', 'r7']);
+    expect(issues.every((i) => i.kind === 'inflated_quantity')).toBe(true);
+    // The detail names the area anchor and the section.
+    expect(issues[0].detail).toContain('165');
+    expect(issues[0].detail).toContain('Roof Replacement');
+  });
+
+  it('is a no-op when sections are not supplied (back-compat)', () => {
+    const { materials } = roofFixture();
+    expect(detectAnchorLaunderedIssues(materials, undefined)).toEqual([]);
+    // Without sections the rows still surface — but as their pricing verdict
+    // (low-confidence / estimated), NOT as inflated_quantity.
+    const review = reviewQuoteMaterials(materials);
+    expect(review.counts.inflatedQuantity).toBe(0);
+    expect(review.counts.total).toBe(7);
+  });
+
+  it('reviewQuoteMaterials surfaces the launder and dedupes it against the pricing verdict', () => {
+    const { materials, sections } = roofFixture();
+    const review = reviewQuoteMaterials(materials, sections);
+    // Every row is also low-confidence/ai-priced, but inflated_quantity wins the
+    // dedupe so nothing is listed twice.
+    expect(review.counts.inflatedQuantity).toBe(7);
+    expect(review.counts.estimated).toBe(0);
+    expect(review.counts.lowConfidence).toBe(0);
+    expect(review.counts.total).toBe(7);
+    expect(review.summary).toContain('7 with an inflated quantity');
+  });
+
+  it('gates the send with the silicone/sheet blow-out named and quantified', () => {
+    const { materials, sections } = roofFixture();
+    const w = buildPresendWarning(reviewQuoteMaterials(materials, sections), 'quote');
+    expect(w).not.toBeNull();
+    expect(w?.title).toBe('Some quantities need a look');
+    expect(w?.message).toContain('• Colorbond Corrugated Roofing Sheets 0.48mm BMT (165 m)');
+    expect(w?.message).toContain('(+4 more)');
+  });
+});
+
+describe('detectAnchorLaunderedIssues — does not fire on genuine sections', () => {
+  it('leaves a real per-m² paver patio alone (materials carry real densities)', () => {
+    const sections = [sec({ id: 'pave', name: 'Paver Patio', multiplier: 25, laborHours: 0.5 })];
+    const materials = [
+      mat({ id: 'p1', name: 'Concrete Pavers 400x400', quantity: 172, unit: 'each', templateBaseQuantity: 6, section: 'Paver Patio', priceConfidence: 'high' }),
+      mat({ id: 'p2', name: 'Crusher Dust', quantity: 4000, unit: 'kg', templateBaseQuantity: 160, section: 'Paver Patio', priceConfidence: 'high' }),
+      mat({ id: 'p3', name: 'Bedding Sand', quantity: 1275, unit: 'kg', templateBaseQuantity: 68, section: 'Paver Patio', priceConfidence: 'high' }),
+    ];
+    expect(detectAnchorLaunderedIssues(materials, sections)).toEqual([]);
+  });
+
+  it('leaves a discrete fence-bay section alone (per-unit labour >= 1 h)', () => {
+    const sections = [sec({ id: 'fence', name: 'Colorbond Fence Bay', multiplier: 9, laborHours: 1.5 })];
+    const materials = [
+      mat({ id: 'f1', name: 'Steel Fence Post', quantity: 18, unit: 'each', templateBaseQuantity: 2, section: 'Colorbond Fence Bay' }),
+      mat({ id: 'f2', name: 'Colorbond Fence Sheet', quantity: 27, unit: 'each', templateBaseQuantity: 3, section: 'Colorbond Fence Bay' }),
+      mat({ id: 'f3', name: 'Post Cap', quantity: 9, unit: 'each', templateBaseQuantity: 1, section: 'Colorbond Fence Bay' }),
+    ];
+    expect(detectAnchorLaunderedIssues(materials, sections)).toEqual([]);
+  });
+
+  it('does not fire on a small area (< 20 m²) — reserved for area-scale blow-ups', () => {
+    const sections = [sec({ id: 'tile', name: 'Bathroom Tiling', multiplier: 10, laborHours: 0.5 })];
+    const materials = [
+      mat({ id: 't1', name: 'Wall Tiles', quantity: 10, unit: 'each', templateBaseQuantity: 1, section: 'Bathroom Tiling' }),
+      mat({ id: 't2', name: 'Tile Adhesive', quantity: 10, unit: 'each', templateBaseQuantity: 1, section: 'Bathroom Tiling' }),
+      mat({ id: 't3', name: 'Grout', quantity: 10, unit: 'each', templateBaseQuantity: 1, section: 'Bathroom Tiling' }),
+    ];
+    expect(detectAnchorLaunderedIssues(materials, sections)).toEqual([]);
   });
 });

--- a/src/utils/quoteReview.ts
+++ b/src/utils/quoteReview.ts
@@ -19,9 +19,9 @@
  * Manual price overrides are always left alone: the tradie set those on purpose.
  */
 
-import { Material } from '../types';
+import { Material, QuoteSection } from '../types';
 
-export type QuoteIssueKind = 'unpriced' | 'estimated' | 'low_confidence';
+export type QuoteIssueKind = 'unpriced' | 'estimated' | 'low_confidence' | 'inflated_quantity';
 
 export interface QuoteIssue {
   materialId: string;
@@ -40,6 +40,8 @@ export interface QuoteReview {
     unpriced: number;
     estimated: number;
     lowConfidence: number;
+    /** Quantities laundered from a job area anchor (see detectAnchorLaunderedIssues). */
+    inflatedQuantity: number;
     /** Total flagged rows — equals issues.length. */
     total: number;
   };
@@ -51,6 +53,7 @@ const DEFAULT_DETAIL: Record<QuoteIssueKind, string> = {
   unpriced: 'No price yet — needs a product match.',
   estimated: 'Estimated price, not a real supplier quote — verify before sending.',
   low_confidence: 'Low-confidence price — worth a quick check.',
+  inflated_quantity: 'Quantity looks scaled from the job size, not real coverage — verify before sending.',
 };
 
 /**
@@ -78,6 +81,7 @@ function buildSummary(issues: QuoteIssue[], counts: QuoteReview['counts']): stri
   if (issues.length === 0) return 'All good — every line came back with a real price.';
 
   const parts: string[] = [];
+  if (counts.inflatedQuantity) parts.push(`${counts.inflatedQuantity} with an inflated quantity`);
   if (counts.unpriced) parts.push(`${counts.unpriced} with no price`);
   if (counts.estimated) parts.push(`${counts.estimated} estimated`);
   if (counts.lowConfidence) parts.push(`${counts.lowConfidence} low-confidence`);
@@ -88,16 +92,108 @@ function buildSummary(issues: QuoteIssue[], counts: QuoteReview['counts']): stri
   return `${issues.length} ${noun} need a look — ${parts.join(', ')}. (${names.join(', ')}${more})`;
 }
 
+// --- Anchor-launder detection (QU-178425) ---------------------------------
+//
+// Round-1 generation classifies a job into sections. A "per-m² surface-covering"
+// section carries the job area as its multiplier and hours-PER-m² as its labour
+// rate; each material is meant to hold a real per-m² density (6.25 pavers/m²,
+// ~160 kg sand/m²) that × area gives the total. The failure mode: the model
+// mis-classifies a job as per-m² but derives NOTHING — it emits "1 per m²" for
+// every material, so × area launders the raw job size onto each line (a 165 m²
+// re-roof → 165 sheets, 165 silicone tubes, 495 screws). The reconcile pass
+// then divides by real pack sizes where it can, so some lines end up plausible
+// and the wrong ones hide inside a plausible-looking total.
+//
+// This detector keys on the fingerprint that survives to the stored quote: a
+// per-m² section in which not one material carries a real density. Deterministic.
+
+// A per-m² / area-scaled section carries a fractional hours-PER-UNIT rate (e.g.
+// 0.5 h/m²) over a large multiplier that is really an area. Discrete-unit
+// sections (fence bays, gates) carry >= 1 h per unit and small counts, so this
+// never trips on them.
+const AREA_SECTION_MAX_HOURS = 1;        // hours-per-unit below 1 => a per-m² rate
+const AREA_SECTION_MIN_MULTIPLIER = 20;  // an area big enough that "1 per m²" is absurd
+// A per-unit quantity this small in a per-m² section is an un-derived stand-in.
+// A genuine per-m² section always has at least one substantial density.
+const PLACEHOLDER_PER_UNIT_MAX = 3;
+
+/** Per-unit quantity Round-1 emitted before × multiplier. Prefers the stored
+ *  templateBaseQuantity; falls back to quantity ÷ multiplier for older rows. */
+function perUnitQuantity(m: Material, multiplier: number): number {
+  if (typeof m.templateBaseQuantity === 'number' && m.templateBaseQuantity > 0) {
+    return m.templateBaseQuantity;
+  }
+  return multiplier > 0 ? m.quantity / multiplier : m.quantity;
+}
+
+/** A row still showing the raw area anchor: its buy-qty equals the area, its
+ *  underlying requirement equals the area, or its buy-qty is a small integer
+ *  multiple of the area (495 = 3 × 165). These are the laundered lines. */
+function showsAreaAnchor(m: Material, multiplier: number): boolean {
+  if (multiplier <= 0) return false;
+  if (m.quantity === multiplier) return true;
+  if (m.requiredQty === multiplier) return true;
+  return m.quantity % multiplier === 0 && m.quantity / multiplier <= PLACEHOLDER_PER_UNIT_MAX;
+}
+
+/**
+ * Detect sections where Round-1 laundered the job's area anchor into every
+ * material quantity instead of deriving real coverage. Returns one issue per
+ * anchor-showing row in a laundered section. Deterministic — no model.
+ */
+export function detectAnchorLaunderedIssues(
+  materials: Material[] | undefined | null,
+  sections: QuoteSection[] | undefined | null,
+): QuoteIssue[] {
+  if (!materials?.length || !sections?.length) return [];
+  const issues: QuoteIssue[] = [];
+  for (const s of sections) {
+    const multiplier = s.multiplier;
+    const areaScaled =
+      s.laborHours > 0 &&
+      s.laborHours < AREA_SECTION_MAX_HOURS &&
+      multiplier >= AREA_SECTION_MIN_MULTIPLIER;
+    if (!areaScaled) continue;
+
+    const mats = materials.filter((m) => m.section === s.name);
+    if (mats.length < 3) continue;
+
+    // Laundered iff NOT ONE material carries a real per-m² density — every
+    // per-unit quantity is a trivial placeholder. A genuine per-m² section
+    // (tiling, paving, screeding) always has at least one substantial density.
+    const everyPlaceholder = mats.every((m) => perUnitQuantity(m, multiplier) <= PLACEHOLDER_PER_UNIT_MAX);
+    if (!everyPlaceholder) continue;
+
+    for (const m of mats) {
+      if (!showsAreaAnchor(m, multiplier)) continue;
+      issues.push({
+        materialId: m.id,
+        name: m.name,
+        kind: 'inflated_quantity',
+        detail: `Quantity looks scaled from the ${multiplier} m² job size, not real coverage — every line in “${s.name}” was multiplied by the area. Verify before sending.`,
+        price: m.price,
+        quantity: m.quantity,
+        unit: m.unit,
+      });
+    }
+  }
+  return issues;
+}
+
 /**
  * Scan a quote's materials and report the rows the pipeline already flagged.
  * Deterministic — no network, no model, safe to call after every pricing pass.
+ * Pass `sections` to also catch area-anchor-laundered quantities (QU-178425).
  */
-export function reviewQuoteMaterials(materials: Material[] | undefined | null): QuoteReview {
-  const issues: QuoteIssue[] = [];
+export function reviewQuoteMaterials(
+  materials: Material[] | undefined | null,
+  sections?: QuoteSection[] | null,
+): QuoteReview {
+  const rowIssues: QuoteIssue[] = [];
   for (const m of materials ?? []) {
     const kind = classifyRow(m);
     if (!kind) continue;
-    issues.push({
+    rowIssues.push({
       materialId: m.id,
       name: m.name,
       kind,
@@ -108,10 +204,18 @@ export function reviewQuoteMaterials(materials: Material[] | undefined | null): 
     });
   }
 
+  // Inflated-quantity is the more actionable verdict, so it leads and wins the
+  // dedupe: a laundered row is almost always also low-confidence priced, and we
+  // don't want to list the same material twice.
+  const inflated = detectAnchorLaunderedIssues(materials, sections);
+  const inflatedIds = new Set(inflated.map((i) => i.materialId));
+  const issues = [...inflated, ...rowIssues.filter((i) => !inflatedIds.has(i.materialId))];
+
   const counts = {
     unpriced: issues.filter((i) => i.kind === 'unpriced').length,
     estimated: issues.filter((i) => i.kind === 'estimated').length,
     lowConfidence: issues.filter((i) => i.kind === 'low_confidence').length,
+    inflatedQuantity: issues.filter((i) => i.kind === 'inflated_quantity').length,
     total: issues.length,
   };
 
@@ -124,8 +228,10 @@ export interface PresendWarning {
 }
 
 /**
- * Pre-send gate message: built ONLY when the document still contains $0 rows
- * — those print as $0 line items on the customer's copy. Estimated /
+ * Pre-send gate message: built when the document still contains $0 rows (they
+ * print as $0 line items on the customer's copy) OR area-anchor-laundered
+ * quantities (an absurd count like "165 silicone tubes" is a trust-killer on
+ * the customer copy — see detectAnchorLaunderedIssues). Estimated /
  * low-confidence rows alone don't gate the send (they're priced and flagged
  * in the list already; warning on every estimate would teach tradies to
  * dismiss the dialog without reading it).
@@ -142,22 +248,51 @@ export function buildPresendWarning(
   } = {},
 ): PresendWarning | null {
   const unpriced = review.issues.filter((i) => i.kind === 'unpriced');
-  if (unpriced.length === 0) return null;
+  const inflated = review.issues.filter((i) => i.kind === 'inflated_quantity');
+  if (unpriced.length === 0 && inflated.length === 0) return null;
 
-  const visible = options.materialsShownToCustomer !== false;
-  const consequence = visible
-    ? `will show as $0 on the customer's ${docLabel}`
-    : `${unpriced.length === 1 ? "isn't" : "aren't"} counted in the ${docLabel} total`;
-  const shown = unpriced.slice(0, 3).map((i) => `• ${i.name}`);
-  const more = unpriced.length - shown.length;
-  const lines = [
-    `${unpriced.length} item${unpriced.length === 1 ? ' has' : 's have'} no price and ${consequence}:`,
-    ...shown,
-    ...(more > 0 ? [`(+${more} more)`] : []),
-  ];
-  const estimated = review.counts.estimated + review.counts.lowConfidence;
-  if (estimated > 0) {
-    lines.push('', `${estimated} more ${estimated === 1 ? 'is an estimate' : 'are estimates'} — worth a quick check too.`);
+  const lines: string[] = [];
+
+  if (unpriced.length > 0) {
+    const visible = options.materialsShownToCustomer !== false;
+    const consequence = visible
+      ? `will show as $0 on the customer's ${docLabel}`
+      : `${unpriced.length === 1 ? "isn't" : "aren't"} counted in the ${docLabel} total`;
+    const shown = unpriced.slice(0, 3).map((i) => `• ${i.name}`);
+    const more = unpriced.length - shown.length;
+    lines.push(
+      `${unpriced.length} item${unpriced.length === 1 ? ' has' : 's have'} no price and ${consequence}:`,
+      ...shown,
+      ...(more > 0 ? [`(+${more} more)`] : []),
+    );
   }
-  return { title: 'Some prices need a look', message: lines.join('\n') };
+
+  if (inflated.length > 0) {
+    if (lines.length > 0) lines.push('');
+    const shown = inflated.slice(0, 3).map((i) => `• ${i.name} (${i.quantity} ${i.unit})`);
+    const more = inflated.length - shown.length;
+    lines.push(
+      `${inflated.length} ${inflated.length === 1 ? "item's quantity looks" : "items' quantities look"} scaled from the job size, not real coverage — check ${inflated.length === 1 ? 'it' : 'them'} before sending:`,
+      ...shown,
+      ...(more > 0 ? [`(+${more} more)`] : []),
+    );
+  }
+
+  // Estimate tail only alongside unpriced rows (unchanged behaviour) — warning
+  // on every estimate would train tradies to dismiss the dialog unread.
+  if (unpriced.length > 0) {
+    const estimated = review.counts.estimated + review.counts.lowConfidence;
+    if (estimated > 0) {
+      lines.push('', `${estimated} more ${estimated === 1 ? 'is an estimate' : 'are estimates'} — worth a quick check too.`);
+    }
+  }
+
+  const title =
+    unpriced.length > 0 && inflated.length > 0
+      ? 'Some prices and quantities need a look'
+      : inflated.length > 0
+        ? 'Some quantities need a look'
+        : 'Some prices need a look';
+
+  return { title, message: lines.join('\n') };
 }


### PR DESCRIPTION
Lands the last two unmerged pieces of the Mate workstream onto `main` (found stranded on `fix/phase0-payment-criticals` + `stash@{0}` after the swarm hand-off).

## `6374ad7` — fix(mate): client-side voice token mint throttle
Kills the 429 mint storm: the reconnect loop could fire a mint per attempt, blowing the server's 10/min cap. A rolling-window client throttle fails fast before the server 429s; the reconnect loop singles out rate-limit errors and stops re-minting. (+55 test lines in textTransport / voiceSession.reconnect.)

## `6633d97` — feat(quoteReview): anchor-laundering send gate
`reviewQuoteMaterials` is now section-aware: flags per-m² rates smuggled into per-unit lines on area-scale sections (≥20 m², per-unit labour < 1 h), names + quantifies the blow-out in the send gate, dedupes against the pricing verdict. Genuine per-m² and discrete-bay sections untouched; omitting sections is a back-compat no-op. Includes the QU-178425 165 m² re-roof regression case (9 new tests).

## Not included (deliberate)
- `stash@{1}` voiceSession rewrite — **stale**; main's version is newer and safer. Recommend dropping.
- The stash's `expo-speech-recognition` bump — already on main via #50.
- `hotfix/1.45-mate-mintstorm` branch — an older, different mint-storm fix (grace-controller approach), still unmerged; separate decision.

## Verification
App: **949 tests pass** (82 files); `tsc` clean. Both commits cherry-picked/applied onto current main with zero conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
