### PR TITLE
fix(ios): modular headers for GoogleSignIn pod deps

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -103,6 +103,9 @@ export default {
       ],
       "expo-iap",
       ["./plugins/withKotlinVersion", "2.2.0"],
+      // GoogleSignIn iOS SDK (native Google sign-in) pulls Swift pod
+      // AppCheckCore whose ObjC deps need module maps — see the plugin.
+      "./plugins/withModularHeaders",
       "./plugins/withFmtConstevalFix",
       "./plugins/withBouncyCastleDedup",
       // Skip the Square plugin entirely if SQUARE_APP_ID_PRODUCTION is missing

--- a/plugins/withModularHeaders.js
+++ b/plugins/withModularHeaders.js
@@ -1,0 +1,61 @@
+/**
+ * withModularHeaders
+ *
+ * Config plugin that marks specific CocoaPods dependencies with
+ * `:modular_headers => true` in the prebuilt ios/Podfile.
+ *
+ * Why: the GoogleSignIn iOS SDK (via @react-native-google-signin/google-signin)
+ * pulls in the Swift pod `AppCheckCore`, which depends on `GoogleUtilities`
+ * and `RecaptchaInterop`. Those are Objective-C pods that don't define
+ * modules, so `pod install` fails with "The following Swift pods cannot yet
+ * be integrated as static libraries" unless they opt into module-map
+ * generation. Scoped per-pod on purpose — a global `use_modular_headers!`
+ * changes header semantics for every pod and risks breaking others.
+ *
+ * Idempotent: skips pods already declared in the Podfile.
+ */
+
+const { withDangerousMod, createRunOncePlugin } = require('@expo/config-plugins');
+const fs = require('fs');
+const path = require('path');
+
+const DEFAULT_PODS = ['GoogleUtilities', 'RecaptchaInterop'];
+
+/**
+ * Pure transform: insert `pod '<name>', :modular_headers => true` lines right
+ * after the target's `use_expo_modules!` marker. Returns the Podfile unchanged
+ * if every pod is already declared (idempotency for repeated prebuilds).
+ */
+function injectModularHeaders(podfile, pods = DEFAULT_PODS) {
+  const missing = pods.filter(
+    (name) => !new RegExp(`^\\s*pod\\s+['"]${name}['"]`, 'm').test(podfile)
+  );
+  if (missing.length === 0) return podfile;
+
+  const marker = /^([ \t]*)use_expo_modules!.*$/m;
+  if (!marker.test(podfile)) {
+    throw new Error(
+      'withModularHeaders: could not find `use_expo_modules!` in ios/Podfile — Expo template changed?'
+    );
+  }
+  const lines = (indent) =>
+    missing.map((name) => `${indent}pod '${name}', :modular_headers => true`).join('\n');
+  return podfile.replace(marker, (line, indent) => `${line}\n${lines(indent)}`);
+}
+
+function withModularHeaders(config, props = {}) {
+  const pods = props.pods || DEFAULT_PODS;
+  return withDangerousMod(config, [
+    'ios',
+    (config) => {
+      const podfilePath = path.join(config.modRequest.platformProjectRoot, 'Podfile');
+      const contents = fs.readFileSync(podfilePath, 'utf-8');
+      fs.writeFileSync(podfilePath, injectModularHeaders(contents, pods));
+      return config;
+    },
+  ]);
+}
+
+module.exports = createRunOncePlugin(withModularHeaders, 'withModularHeaders', '1.0.0');
+// Exported for tests — pure string transform.
+module.exports.injectModularHeaders = injectModularHeaders;

--- a/plugins/withModularHeaders.test.ts
+++ b/plugins/withModularHeaders.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Tests for the withModularHeaders Podfile transform.
+ *
+ * Regression context: adding @react-native-google-signin (native GoogleSignIn
+ * iOS SDK) broke `pod install` — its Swift dep `AppCheckCore` needs
+ * `GoogleUtilities` and `RecaptchaInterop` to generate module maps. The plugin
+ * injects `:modular_headers => true` for exactly those pods at prebuild.
+ */
+import { describe, it, expect } from 'vitest';
+// @ts-expect-error — plain JS config plugin, no types
+import { injectModularHeaders } from './withModularHeaders';
+
+const PODFILE = `require File.join(...)
+platform :ios, podfile_properties['ios.deploymentTarget']
+
+target 'QuoteMate' do
+  use_expo_modules!(exclude: ['expo-updates'])
+
+  config = use_native_modules!(config_command)
+end
+`;
+
+describe('injectModularHeaders', () => {
+  it('injects modular_headers pods right after use_expo_modules! with matching indent', () => {
+    const out = injectModularHeaders(PODFILE);
+    expect(out).toContain(
+      "  use_expo_modules!(exclude: ['expo-updates'])\n" +
+        "  pod 'GoogleUtilities', :modular_headers => true\n" +
+        "  pod 'RecaptchaInterop', :modular_headers => true"
+    );
+  });
+
+  it('is idempotent — a second pass changes nothing', () => {
+    const once = injectModularHeaders(PODFILE);
+    expect(injectModularHeaders(once)).toBe(once);
+  });
+
+  it('only adds pods that are missing', () => {
+    const withOne = PODFILE.replace(
+      "use_expo_modules!(exclude: ['expo-updates'])",
+      "use_expo_modules!(exclude: ['expo-updates'])\n  pod 'GoogleUtilities', :modular_headers => true"
+    );
+    const out = injectModularHeaders(withOne);
+    expect(out.match(/pod 'GoogleUtilities'/g)).toHaveLength(1);
+    expect(out.match(/pod 'RecaptchaInterop'/g)).toHaveLength(1);
+  });
+
+  it('supports a custom pod list', () => {
+    const out = injectModularHeaders(PODFILE, ['FooKit']);
+    expect(out).toContain("  pod 'FooKit', :modular_headers => true");
+    expect(out).not.toContain('GoogleUtilities');
+  });
+
+  it('throws loudly if the Expo Podfile marker is gone (template drift guard)', () => {
+    expect(() => injectModularHeaders('target "X" do\nend\n')).toThrow(/use_expo_modules!/);
+  });
+});


### PR DESCRIPTION
pod install failed after adding the native GoogleSignIn SDK: Swift pod AppCheckCore needs GoogleUtilities + RecaptchaInterop to generate module maps. New withModularHeaders config plugin injects :modular_headers => true for those two pods at prebuild (scoped per-pod, not global).

5 plugin tests + verified against real expo prebuild output. Full suite 954 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)