### PR TITLE
feat(reports): service reports round 2 — dictation, compose v2, Quote-it, hardening

### DIFF
--- a/functions/src/composeServiceReport.helpers.test.ts
+++ b/functions/src/composeServiceReport.helpers.test.ts
@@ -3,6 +3,7 @@ import {
   buildComposePrompt,
   sanitizeComposed,
   ComposeNotes,
+  MAX_SUGGESTIONS,
 } from './composeServiceReport.helpers';
 
 describe('buildComposePrompt — factual, Aussie, no forbidden term', () => {
@@ -18,7 +19,52 @@ describe('buildComposePrompt — factual, Aussie, no forbidden term', () => {
     // Names the categories of invention that are forbidden.
     expect(prompt).toContain('measurements');
     expect(prompt).toContain('equipment');
-    expect(prompt).toMatch(/never add|do not add|only what is in the note|not already present/);
+    expect(prompt).toMatch(/never add|do not add|nothing may be added|not already present/);
+  });
+
+  it('allows redistribution — facts may move to the field where they belong', () => {
+    const prompt = buildComposePrompt(notes);
+    expect(prompt).toMatch(/may move a fact/i);
+    // Spells out the canonical example: a recommendation typed elsewhere
+    // belongs in recommendedWork.
+    expect(prompt).toContain(
+      '"recommend" or "should be done later" statement belongs in "recommendedWork"',
+    );
+    // And makes clear moving is not licence to add.
+    expect(prompt).toMatch(/facts may move between fields, but nothing may be added/i);
+  });
+
+  it('permits filling a field whose own note was blank from other notes', () => {
+    const prompt = buildComposePrompt({ workCarriedOut: 'cleaned filters, recommend replacing the belt' });
+    expect(prompt).toMatch(/filled even though its own note was blank/i);
+    expect(prompt).toMatch(/every fact in it came from one of the supplied notes/i);
+  });
+
+  it('always requests all three write-up keys, even for partial notes', () => {
+    const prompt = buildComposePrompt({ workCarriedOut: 'swapped the tap washer' });
+    expect(prompt).toContain('"natureOfProblem"');
+    expect(prompt).toContain('"workCarriedOut"');
+    expect(prompt).toContain('"recommendedWork"');
+  });
+
+  it('only includes the supplied notes in the source block', () => {
+    const prompt = buildComposePrompt({ workCarriedOut: 'swapped the tap washer' });
+    const sourceBlock = prompt.split('NOTES TO REWRITE:')[1];
+    expect(sourceBlock).toContain('Work carried out');
+    expect(sourceBlock).not.toContain('Nature of the problem');
+    expect(sourceBlock).not.toContain('Recommended work');
+  });
+
+  it('asks for both suggestion lists as optional, review-only extras', () => {
+    const prompt = buildComposePrompt(notes);
+    expect(prompt).toContain('"suggestedEquipment"');
+    expect(prompt).toContain('"suggestedChecklist"');
+    expect(prompt).toMatch(/optional extras/i);
+    expect(prompt).toMatch(/review/i);
+    expect(prompt).toMatch(/nothing is added to the report automatically/i);
+    expect(prompt).toContain(`at most ${MAX_SUGGESTIONS}`);
+    // Suggestions come strictly from the notes.
+    expect(prompt).toMatch(/strictly from the notes/i);
   });
 
   it('demands Australian English and gender-neutral tone', () => {
@@ -37,13 +83,6 @@ describe('buildComposePrompt — factual, Aussie, no forbidden term', () => {
     // Word-boundary match so "maintain"/"claims" etc. don't trip it.
     expect(prompt).not.toMatch(/\bAI\b/);
     expect(prompt).not.toMatch(/\bai\b/i);
-  });
-
-  it('only asks for the fields that were supplied', () => {
-    const prompt = buildComposePrompt({ workCarriedOut: 'swapped the tap washer' });
-    expect(prompt).toContain('"workCarriedOut"');
-    expect(prompt).not.toContain('"natureOfProblem"');
-    expect(prompt).not.toContain('"recommendedWork"');
   });
 });
 
@@ -67,29 +106,95 @@ describe('sanitizeComposed — cleans model output', () => {
     expect(out.workCarriedOut).toContain('Replaced the damaged flexible connection');
   });
 
-  it('blanks a field whose source note was empty, even if the model returned prose', () => {
+  it('allows redistribution — a field can be filled although its own note was empty', () => {
+    // Tradie typed a recommendation under workCarriedOut; the model moved it
+    // to recommendedWork. The sanitiser must keep the moved fact, not blank it.
     const raw = JSON.stringify({
-      natureOfProblem: 'Leaking mixer tap in the kitchen.',
-      recommendedWork: 'You should really re-plumb the whole kitchen and add three new taps.',
+      natureOfProblem: '',
+      workCarriedOut: 'Cleaned the filters on both split systems.',
+      recommendedWork: 'Replace the outdoor unit fan belt on a future visit.',
     });
     const out = sanitizeComposed(raw, {
-      natureOfProblem: 'leaking kitchen mixer',
-      // workCarriedOut and recommendedWork were never entered by the tradie.
+      workCarriedOut:
+        'cleaned filters both splits, outdoor unit fan belt needs replacing later',
+      // natureOfProblem and recommendedWork were never entered by the tradie.
     });
-    expect(out.natureOfProblem).toBe('Leaking mixer tap in the kitchen.');
-    expect(out.workCarriedOut).toBe('');
-    expect(out.recommendedWork).toBe('');
+    expect(out.recommendedWork).toBe('Replace the outdoor unit fan belt on a future visit.');
+    expect(out.workCarriedOut).toBe('Cleaned the filters on both split systems.');
+    expect(out.natureOfProblem).toBe('');
   });
 
-  it('keeps the tradie note when the model drops a supplied field', () => {
-    const raw = JSON.stringify({ natureOfProblem: 'Reported a blocked drain.' });
-    const out = sanitizeComposed(raw, {
+  it('returns all-empty output when ALL source notes were empty', () => {
+    const raw = JSON.stringify({
+      natureOfProblem: 'Invented problem.',
+      workCarriedOut: 'Invented work.',
+      recommendedWork: 'Invented recommendation.',
+      suggestedEquipment: ['Invented unit'],
+      suggestedChecklist: ['Invented task'],
+    });
+    const out = sanitizeComposed(raw, {});
+    expect(out).toEqual({
+      natureOfProblem: '',
+      workCarriedOut: '',
+      recommendedWork: '',
+      suggestedEquipment: [],
+      suggestedChecklist: [],
+    });
+  });
+
+  it('clamps suggestion lists: strings only, trimmed, deduped, max 8', () => {
+    const raw = JSON.stringify({
+      workCarriedOut: 'Serviced all split systems.',
+      suggestedEquipment: [
+        '  Split system ×2 ',
+        'split system ×2', // case-insensitive duplicate
+        42, // non-string dropped
+        null,
+        '', // blank dropped
+        'Ducted unit',
+        'Unit A',
+        'Unit B',
+        'Unit C',
+        'Unit D',
+        'Unit E',
+        'Unit F',
+        'Unit G', // 9th unique — over the cap
+      ],
+      suggestedChecklist: 'not an array',
+    });
+    const out = sanitizeComposed(raw, { workCarriedOut: 'serviced all splits' });
+    expect(out.suggestedEquipment[0]).toBe('Split system ×2');
+    expect(out.suggestedEquipment).toHaveLength(8);
+    expect(out.suggestedEquipment).not.toContain('Unit G');
+    expect(out.suggestedEquipment.every((s) => typeof s === 'string')).toBe(true);
+    expect(out.suggestedChecklist).toEqual([]);
+  });
+
+  it('keeps the tradie notes when the reply is not JSON at all', () => {
+    const out = sanitizeComposed('sorry, I cannot do that', {
       natureOfProblem: 'blocked drain',
       workCarriedOut: 'cleared the blockage with the eel',
     });
-    expect(out.natureOfProblem).toBe('Reported a blocked drain.');
-    // Model omitted workCarriedOut — the tradie's own note is preserved.
+    expect(out.natureOfProblem).toBe('blocked drain');
     expect(out.workCarriedOut).toBe('cleared the blockage with the eel');
+    expect(out.recommendedWork).toBe('');
+    expect(out.suggestedEquipment).toEqual([]);
+    expect(out.suggestedChecklist).toEqual([]);
+  });
+
+  it('keeps the tradie notes when the model returned no write-up text', () => {
+    const raw = JSON.stringify({
+      natureOfProblem: '',
+      workCarriedOut: '',
+      recommendedWork: '',
+      suggestedEquipment: ['Split system'],
+    });
+    const out = sanitizeComposed(raw, {
+      natureOfProblem: 'blocked drain',
+      workCarriedOut: 'cleared the blockage',
+    });
+    expect(out.natureOfProblem).toBe('blocked drain');
+    expect(out.workCarriedOut).toBe('cleared the blockage');
   });
 
   it('tolerates a code-fenced JSON reply', () => {
@@ -98,8 +203,14 @@ describe('sanitizeComposed — cleans model output', () => {
     expect(out.natureOfProblem).toBe('Faulty powerpoint in the garage.');
   });
 
-  it('returns all-blank when source notes are empty and the reply is unusable', () => {
+  it('returns the all-empty shape when source notes are empty and the reply is unusable', () => {
     const out = sanitizeComposed('not json at all', {});
-    expect(out).toEqual({ natureOfProblem: '', workCarriedOut: '', recommendedWork: '' });
+    expect(out).toEqual({
+      natureOfProblem: '',
+      workCarriedOut: '',
+      recommendedWork: '',
+      suggestedEquipment: [],
+      suggestedChecklist: [],
+    });
   });
 });

--- a/functions/src/composeServiceReport.helpers.ts
+++ b/functions/src/composeServiceReport.helpers.ts
@@ -8,13 +8,20 @@
  * that must stay unit-testable without touching Gemini or Firestore:
  *
  *   buildComposePrompt — assembles the model instruction, and
- *   sanitizeComposed   — cleans the model output back into the three fields.
+ *   sanitizeComposed   — cleans the model output back into the report shape.
  *
  * The discipline mirrors src/utils/sanitizeJobDescription.ts: the rewrite is
- * STRICTLY FACTUAL. The model may tidy grammar and tone but must never invent
- * equipment, measurements, part numbers, or claims that aren't in the note.
- * An empty source note always yields an empty output field — the model is
- * never allowed to fill a blank.
+ * STRICTLY FACTUAL. The model may tidy grammar and tone, and it may MOVE a
+ * fact into the field where it belongs (a "recommend…" line typed under work
+ * carried out belongs in recommended work), but it must never invent
+ * equipment, measurements, part numbers, or claims that aren't in the notes.
+ * When every source note is empty the output is empty — the model is never
+ * allowed to fill a blank from nothing.
+ *
+ * The same round-trip also extracts two OPTIONAL suggestion lists — equipment
+ * the notes mention and checklist-style actions the notes say were done. They
+ * are surfaced for the tradie to review and tap to add; nothing is ever added
+ * to the report automatically.
  */
 
 export interface ComposeNotes {
@@ -32,7 +39,12 @@ export interface ComposedReport {
   natureOfProblem: string;
   workCarriedOut: string;
   recommendedWork: string;
+  suggestedEquipment: string[];
+  suggestedChecklist: string[];
 }
+
+/** Longest suggestion list we will pass back to the client. */
+export const MAX_SUGGESTIONS = 8;
 
 /** The three note fields, in output order, with their customer-facing labels. */
 const FIELDS: { key: keyof ComposeNotes; label: string; hint: string }[] = [
@@ -59,10 +71,13 @@ function clean(v: string | undefined | null): string {
 
 /**
  * Build the single prompt string sent to the text model. Only the fields the
- * tradie actually filled in are included, so the model is never handed a blank
- * to complete. The instruction forbids invention, demands Australian English
- * and gender-neutral wording, bans any greeting, and requires a JSON reply
- * keyed by the field names so sanitizeComposed can parse it deterministically.
+ * tradie actually filled in are shown as source notes, but the reply always
+ * carries all three write-up keys: the model is allowed to REDISTRIBUTE facts
+ * into the field where they belong, so a field can come back filled even
+ * though its own note was blank — provided every fact in it came from one of
+ * the supplied notes. The instruction forbids invention, demands Australian
+ * English and gender-neutral wording, bans any greeting, and requires a JSON
+ * reply so sanitizeComposed can parse it deterministically.
  *
  * Note: the strings below never use the two-letter term for machine
  * intelligence — this prose can surface in review and must not seed it into a
@@ -84,16 +99,20 @@ export function buildComposePrompt(notes: ComposeNotes, context?: ComposeContext
   const rules = [
     'You are cleaning up a tradesperson\'s rough notes into the write-up section of a service report that their customer will read.',
     who,
-    'Rewrite ONLY the notes provided below into clear, professional prose.',
+    'The write-up has three fields: "natureOfProblem" (what the customer reported or what was found on arrival), "workCarriedOut" (what was actually done during this visit), and "recommendedWork" (work suggested for a future visit).',
+    'Rewrite the notes provided below into clear, professional prose across those three fields.',
+    'You may MOVE a fact into the field where it belongs, even if the tradesperson typed it under a different heading. A "needs replacing", "recommend" or "should be done later" statement belongs in "recommendedWork". A symptom or complaint belongs in "natureOfProblem". Work that was actually done belongs in "workCarriedOut". A field may come back filled even though its own note was blank, as long as every fact in it came from one of the supplied notes.',
+    'STRICTLY FACTUAL: facts may move between fields, but nothing may be added. Never add equipment, materials, measurements, part numbers, brands, times, prices, or any claim that is not already present in the notes. If a detail is not in the notes, leave it out.',
     'Use Australian English spelling.',
     'Write in a plain, factual, gender-neutral tone. Do not use "he", "she", "guys", "blokes" or similar.',
-    'STRICTLY FACTUAL: rewrite only what is in the note. Never add equipment, materials, measurements, part numbers, brands, times, prices, or any claim that is not already present. If a detail is not in the note, leave it out.',
     'Do not add a greeting, sign-off, salutation, or any address to the reader (no "Hi", "Hello", "Dear", "G\'day"). Return the write-up text only.',
     'Do not mention that this text was generated or assisted by any tool.',
     'Keep each field to a sentence or two. Do not invent headings.',
-    'Reply with ONLY a JSON object, no code fences, with a string value for each of these keys: '
-      + present.map((f) => `"${f.key}"`).join(', ')
-      + '. Do not include keys that were not supplied.',
+    'Also extract two short suggestion lists, strictly from the notes:',
+    '- "suggestedEquipment": equipment or assets the notes MENTION (for example "both split systems" becomes "Split system ×2").',
+    `- "suggestedChecklist": checklist-style actions the notes say WERE DONE (for example "cleaned filters" becomes "Clean air filters").`,
+    `Suggestions are optional extras the tradesperson will review and choose from — nothing is added to the report automatically. Use short labels of a few words, at most ${MAX_SUGGESTIONS} entries in each list, and empty arrays when the notes mention nothing suitable.`,
+    'Reply with ONLY a JSON object, no code fences, with these keys: string values for "natureOfProblem", "workCarriedOut" and "recommendedWork" (use an empty string where nothing applies), and arrays of strings for "suggestedEquipment" and "suggestedChecklist".',
   ]
     .filter(Boolean)
     .join('\n');
@@ -155,29 +174,75 @@ function extractJson(raw: string): Record<string, unknown> | null {
 }
 
 /**
- * Turn a raw model reply into the three write-up fields.
+ * Clamp a model-supplied suggestion list: strings only, trimmed, non-empty,
+ * de-duplicated case-insensitively, capped at MAX_SUGGESTIONS.
+ */
+function clampSuggestions(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const entry of value) {
+    if (typeof entry !== 'string') continue;
+    const label = entry.trim();
+    if (!label) continue;
+    const key = label.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(label);
+    if (out.length >= MAX_SUGGESTIONS) break;
+  }
+  return out;
+}
+
+const EMPTY_COMPOSED: ComposedReport = {
+  natureOfProblem: '',
+  workCarriedOut: '',
+  recommendedWork: '',
+  suggestedEquipment: [],
+  suggestedChecklist: [],
+};
+
+/**
+ * Turn a raw model reply into the write-up fields plus suggestion lists.
  *
  * Rules:
- *  - A field whose SOURCE note was empty is always blank, whatever the model
- *    returned — the model is never allowed to fill a gap.
- *  - A leading greeting the model added is stripped.
- *  - If the model dropped a field that had a source note, the tradie's own
- *    (trimmed) note is kept rather than losing their factual content.
+ *  - When ALL source notes are empty, everything comes back empty — the model
+ *    is never allowed to compose a report from nothing. (A single empty note
+ *    no longer forces its field blank: redistribution means a field can be
+ *    legitimately filled from facts the tradie typed under another heading.)
+ *  - A leading greeting the model added is stripped from each field.
+ *  - If the reply is unusable (no JSON) or carries no write-up text at all,
+ *    the tradie's own trimmed notes are kept rather than losing their facts.
+ *  - Suggestion lists are clamped: strings only, trimmed, deduped, max 8.
  */
 export function sanitizeComposed(raw: string, notes: ComposeNotes): ComposedReport {
-  const parsed = extractJson(raw) || {};
-  const out = {} as ComposedReport;
+  const sources = FIELDS.map((f) => clean(notes[f.key]));
+  if (sources.every((s) => !s)) return { ...EMPTY_COMPOSED };
 
+  const keepSources = (): ComposedReport => ({
+    natureOfProblem: sources[0],
+    workCarriedOut: sources[1],
+    recommendedWork: sources[2],
+    suggestedEquipment: [],
+    suggestedChecklist: [],
+  });
+
+  const parsed = extractJson(raw);
+  if (!parsed) return keepSources();
+
+  const out: ComposedReport = { ...EMPTY_COMPOSED };
+  let anyText = false;
   for (const f of FIELDS) {
-    const source = clean(notes[f.key]);
-    if (!source) {
-      out[f.key] = '';
-      continue;
-    }
     const modelValue = typeof parsed[f.key] === 'string' ? (parsed[f.key] as string) : '';
-    const chosen = clean(modelValue) || source;
-    out[f.key] = stripLeadingGreeting(chosen);
+    const value = stripLeadingGreeting(clean(modelValue));
+    out[f.key] = value;
+    if (value) anyText = true;
   }
+  // The model dropped every write-up field despite having source notes —
+  // fall back to the tradie's own words instead of wiping their input.
+  if (!anyText) return keepSources();
 
+  out.suggestedEquipment = clampSuggestions(parsed.suggestedEquipment);
+  out.suggestedChecklist = clampSuggestions(parsed.suggestedChecklist);
   return out;
 }

--- a/functions/src/composeServiceReport.ts
+++ b/functions/src/composeServiceReport.ts
@@ -1,8 +1,11 @@
 // Service Report write-up compose — authenticated proxy to the Gemini text
 // model, mirroring assistantChat.ts (cors + verifyAuth + GEMINI_API_KEY guard
 // + generateContent fetch). The client posts the tradie's rough notes; we
-// build a strictly-factual rewrite prompt, forward it with the master key kept
-// off the device, and return the three cleaned write-up fields.
+// build a strictly-factual rewrite prompt (facts may be redistributed between
+// the three fields but never invented), forward it with the master key kept
+// off the device, and return the three cleaned write-up fields plus two
+// suggestion lists (suggestedEquipment / suggestedChecklist) extracted from
+// the notes for the tradie to review — nothing is added automatically.
 //
 // Kept as its own onRequest (not folded into assistantChat) because it is a
 // one-shot rewrite with no tool loop and no per-turn quota: a service report

--- a/shared/pdf/htmlBuilders.ts
+++ b/shared/pdf/htmlBuilders.ts
@@ -626,8 +626,10 @@ function buildReportSignatureHTML(
   sig: { svgPath: string; name: string; width?: number; height?: number } | undefined,
 ): string {
   // No signature → no block. A heading over blank space on a customer
-  // document reads as "forgot to fill this in", not "optional".
-  if (!sig?.svgPath) return '';
+  // document reads as "forgot to fill this in", not "optional". A path
+  // without a single line-to is an accidental tap, not a signature — the
+  // pad filters these now, but legacy captures may still carry them.
+  if (!sig?.svgPath || !sig.svgPath.includes('L')) return '';
   const name = sig.name ? escapeHtml(sig.name) : '';
   // viewBox must match the capture-space of the pad the ink was drawn on;
   // a fixed guess clips signatures from pads with other proportions. The
@@ -638,7 +640,7 @@ function buildReportSignatureHTML(
   return `
       <div class="report-signature">
         <div class="report-signature-label">${escapeHtml(label)}</div>
-        <div class="report-signature-name">${name}</div>
+        ${name ? `<div class="report-signature-name">${name}</div>` : ''}
         ${svg}
       </div>`;
 }
@@ -691,7 +693,11 @@ export function buildReportPdfHtml(data: ReportPdfData, business: BusinessPdfDat
       })()
     : '';
 
-  const hasSignature = !!(data.customerSignature || data.technicianSignature);
+  // Only real ink counts — a signature whose path has no line-to is an
+  // accidental tap and renders nothing, so it must not pull in the
+  // "I am satisfied…" statement either.
+  const hasInk = (s?: { svgPath: string }) => !!s?.svgPath && s.svgPath.includes('L');
+  const hasSignature = hasInk(data.customerSignature) || hasInk(data.technicianSignature);
   const signaturesHtml = hasSignature
     ? `
       <div class="section-wrapper report-signatures" style="page-break-inside: avoid;">

--- a/shared/pdf/htmlBuilders.ts
+++ b/shared/pdf/htmlBuilders.ts
@@ -8,6 +8,7 @@ import { formatCurrency } from './formatCurrency';
 import { printMediaCSS, getTemplateCSS } from './templates';
 import { PASSTHROUGH_SURCHARGE_PCT } from './squareFees';
 import { resolveGstMode, NO_GST_NOTE } from '../document/gstMode';
+import { pathHasInk } from './signatureInk';
 
 const escapeHtml = (s: string) =>
   s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
@@ -626,10 +627,10 @@ function buildReportSignatureHTML(
   sig: { svgPath: string; name: string; width?: number; height?: number } | undefined,
 ): string {
   // No signature → no block. A heading over blank space on a customer
-  // document reads as "forgot to fill this in", not "optional". A path
-  // without a single line-to is an accidental tap, not a signature — the
-  // pad filters these now, but legacy captures may still carry them.
-  if (!sig?.svgPath || !sig.svgPath.includes('L')) return '';
+  // document reads as "forgot to fill this in", not "optional". Structural
+  // checks aren't enough — a tap with a micro-twitch captures a zero-length
+  // line-to — so "signed" means measurable ink (see signatureInk).
+  if (!sig || !pathHasInk(sig.svgPath)) return '';
   const name = sig.name ? escapeHtml(sig.name) : '';
   // viewBox must match the capture-space of the pad the ink was drawn on;
   // a fixed guess clips signatures from pads with other proportions. The
@@ -693,11 +694,10 @@ export function buildReportPdfHtml(data: ReportPdfData, business: BusinessPdfDat
       })()
     : '';
 
-  // Only real ink counts — a signature whose path has no line-to is an
-  // accidental tap and renders nothing, so it must not pull in the
-  // "I am satisfied…" statement either.
-  const hasInk = (s?: { svgPath: string }) => !!s?.svgPath && s.svgPath.includes('L');
-  const hasSignature = hasInk(data.customerSignature) || hasInk(data.technicianSignature);
+  // Only measurable ink counts — an accidental tap renders nothing, so it
+  // must not pull in the "I am satisfied…" statement either.
+  const hasSignature =
+    pathHasInk(data.customerSignature?.svgPath) || pathHasInk(data.technicianSignature?.svgPath);
   const signaturesHtml = hasSignature
     ? `
       <div class="section-wrapper report-signatures" style="page-break-inside: avoid;">

--- a/shared/pdf/reportHtml.test.ts
+++ b/shared/pdf/reportHtml.test.ts
@@ -123,4 +123,29 @@ describe('buildReportPdfHtml', () => {
     expect(html).toContain('Jess Tech');
     expect(html).not.toContain('report-signature-label">Customer<');
   });
+
+  // Regression: an accidental tap on the pad captured `M x y` (no line-to)
+  // — invisible ink that rendered an empty "signed" block plus the
+  // satisfaction statement on the customer PDF.
+  it('treats a tap-only path as unsigned — no block, no statement', () => {
+    const html = buildReportPdfHtml(
+      reportData({
+        customerSignature: { svgPath: 'M 224 92', name: '.' },
+      }),
+      business,
+    );
+    expect(html).not.toContain('class="report-signature-label"');
+    expect(html).not.toContain('I am satisfied the above work');
+  });
+
+  it('omits the name row when the signer name is blank', () => {
+    const html = buildReportPdfHtml(
+      reportData({
+        technicianSignature: { svgPath: 'M 1 1 L 50 20', name: '' },
+      }),
+      business,
+    );
+    expect(html).toContain('report-signature-label">Technician<');
+    expect(html).not.toContain('class="report-signature-name"');
+  });
 });

--- a/shared/pdf/reportHtml.test.ts
+++ b/shared/pdf/reportHtml.test.ts
@@ -114,7 +114,7 @@ describe('buildReportPdfHtml', () => {
   it('omits the block for a party who has not signed', () => {
     const html = buildReportPdfHtml(
       reportData({
-        technicianSignature: { svgPath: 'M1 1 L2 2', name: 'Jess Tech' },
+        technicianSignature: { svgPath: 'M 10 80 L 60 20 L 110 90', name: 'Jess Tech' },
         customerSignature: undefined,
       }),
       business,
@@ -131,6 +131,25 @@ describe('buildReportPdfHtml', () => {
     const html = buildReportPdfHtml(
       reportData({
         customerSignature: { svgPath: 'M 224 92', name: '.' },
+      }),
+      business,
+    );
+    expect(html).not.toContain('class="report-signature-label"');
+    expect(html).not.toContain('I am satisfied the above work');
+  });
+
+  // Regression: the exact ghost path from RP-001 in production — a tap with
+  // a micro-twitch captures a ZERO-LENGTH line-to, which defeats any
+  // structural "contains an L" check. Only measured ink length catches it.
+  it('treats a zero-length line-to as unsigned (RP-001 ghost)', () => {
+    const html = buildReportPdfHtml(
+      reportData({
+        customerSignature: {
+          svgPath: 'M 400 57.0625 L 400 57.0625 M 369 86.0625',
+          name: '',
+          width: 798,
+          height: 178,
+        },
       }),
       business,
     );

--- a/shared/pdf/signatureInk.test.ts
+++ b/shared/pdf/signatureInk.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+
+import { pathInkLength, pathHasInk, MIN_SIGNATURE_INK_LENGTH } from './signatureInk';
+
+describe('pathInkLength', () => {
+  it('measures 0 for empty / missing / malformed paths', () => {
+    expect(pathInkLength('')).toBe(0);
+    expect(pathInkLength(undefined)).toBe(0);
+    expect(pathInkLength(null)).toBe(0);
+    expect(pathInkLength('not a path')).toBe(0);
+  });
+
+  it('measures 0 for a bare move-to', () => {
+    expect(pathInkLength('M 224 92')).toBe(0);
+  });
+
+  it('measures 0 for a zero-length line-to (tap with micro-twitch)', () => {
+    // Real capture from RP-001: grant + move event at the identical point.
+    expect(pathInkLength('M 400 57.0625 L 400 57.0625 M 369 86.0625')).toBe(0);
+  });
+
+  it('sums segment lengths across strokes, ignoring the pen-lift jump', () => {
+    // Stroke 1: 3-4-5 triangle → 5. Stroke 2: horizontal 10. M-jump not counted.
+    expect(pathInkLength('M 0 0 L 3 4 M 100 100 L 110 100')).toBe(15);
+  });
+});
+
+describe('pathHasInk', () => {
+  it('rejects the real-world ghost signature from RP-001', () => {
+    expect(pathHasInk('M 400 57.0625 L 400 57.0625 M 369 86.0625')).toBe(false);
+  });
+
+  it('rejects ink below the minimum threshold', () => {
+    expect(pathHasInk('M 0 0 L 2 0')).toBe(false);
+  });
+
+  it('accepts a real signature stroke', () => {
+    expect(pathHasInk('M 10 80 L 60 20 L 110 90 L 160 30')).toBe(true);
+  });
+
+  it('threshold is far below any real signature', () => {
+    expect(MIN_SIGNATURE_INK_LENGTH).toBeLessThanOrEqual(20);
+  });
+});

--- a/shared/pdf/signatureInk.ts
+++ b/shared/pdf/signatureInk.ts
@@ -1,0 +1,55 @@
+/**
+ * signatureInk — is a captured signature path real ink?
+ *
+ * Point-count and "contains an L" checks both fail in practice: a tap with a
+ * micro-twitch captures `M 400 57 L 400 57` — a line-to of zero length that
+ * passes structural checks and renders as an invisible "signed" mark on the
+ * customer PDF. The only robust test is the measured length of the drawn ink.
+ *
+ * Lives in shared/ so the on-device SignaturePad and both PDF renderers
+ * (client expo-print, server Puppeteer) agree on one definition of "signed".
+ */
+
+/**
+ * Total drawn length of an `M x y L x y …` path, in capture-space units.
+ * Malformed input measures 0.
+ */
+export function pathInkLength(d: string | undefined | null): number {
+  if (!d) return 0;
+  // Tokenise into commands with coordinate pairs. Only M and L are ever
+  // produced by the pad; anything else is ignored.
+  const tokens = d.match(/[ML]\s*[-\d.]+\s+[-\d.]+/g);
+  if (!tokens) return 0;
+
+  let length = 0;
+  let prev: { x: number; y: number } | null = null;
+  for (const token of tokens) {
+    const cmd = token[0];
+    const [x, y] = token
+      .slice(1)
+      .trim()
+      .split(/\s+/)
+      .map(Number);
+    if (!Number.isFinite(x) || !Number.isFinite(y)) continue;
+    if (cmd === 'L' && prev) {
+      length += Math.hypot(x - prev.x, y - prev.y);
+    }
+    prev = { x, y };
+  }
+  return length;
+}
+
+/**
+ * Minimum drawn length (capture-space px) for a path to count as a
+ * signature. Real signatures measure in the hundreds; taps and twitches
+ * measure ~0–5.
+ */
+export const MIN_SIGNATURE_INK_LENGTH = 10;
+
+/** True when the path carries enough measured ink to count as signed. */
+export function pathHasInk(
+  d: string | undefined | null,
+  minLength: number = MIN_SIGNATURE_INK_LENGTH,
+): boolean {
+  return pathInkLength(d) >= minLength;
+}

--- a/src/components/DictationButton.tsx
+++ b/src/components/DictationButton.tsx
@@ -1,0 +1,351 @@
+/**
+ * DictationButton
+ *
+ * Reusable mic toggle that dictates into any text field. Follows the exact
+ * voice pattern from JobDetailsScreen: Web Speech API on web,
+ * expo-speech-recognition on native (guarded require — the module may be
+ * absent if the dev client wasn't rebuilt), same permission flow with the
+ * 10s request timeout, continuous recognition with auto-restart on silent
+ * 'end' events.
+ *
+ * Controlled: the parent owns the text via `value` and receives every
+ * interim/final update through `onText(next)`. Recognised speech is APPENDED
+ * to whatever was in the field when recording started (single-space joins —
+ * see utils/dictationTranscript.ts, where the segment folding lives as pure,
+ * tested helpers).
+ *
+ * On platforms with no speech support (browser without the Web Speech API,
+ * native build without the module) it renders nothing — graceful absence,
+ * never an error.
+ *
+ * Multiple instances can be mounted on one screen: native speech events are
+ * global, so every handler guards on isRecordingRef and only the instance
+ * whose mic was tapped reacts.
+ */
+import React, { useEffect, useRef, useState } from 'react';
+import {
+  View,
+  StyleSheet,
+  TouchableOpacity,
+  Text,
+  Alert,
+  Platform,
+} from 'react-native';
+import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
+
+import { colors } from '../theme';
+import {
+  appendTranscript,
+  commitSegment,
+  emptyDictationState,
+  finalizeDictation,
+  foldDictationResult,
+  type DictationSegmentState,
+} from '../utils/dictationTranscript';
+
+// Safe import — native module may not be available if dev client wasn't rebuilt
+let ExpoSpeechRecognitionModule: any = null;
+let useSpeechRecognitionEvent: any = (_event: string, _callback: Function) => {};
+try {
+  const speechModule = require('expo-speech-recognition');
+  ExpoSpeechRecognitionModule = speechModule.ExpoSpeechRecognitionModule;
+  useSpeechRecognitionEvent = speechModule.useSpeechRecognitionEvent;
+} catch (e) {
+  // silently ignore - speech features disabled
+}
+
+const NATIVE_START_OPTIONS = {
+  lang: 'en-AU',
+  interimResults: true,
+  maxAlternatives: 1,
+  continuous: true, // Keep recording until the tradie taps stop
+  requiresOnDeviceRecognition: false,
+};
+
+function getWebSpeechRecognition(): any {
+  if (Platform.OS !== 'web' || typeof window === 'undefined') return null;
+  // @ts-ignore - Web Speech API
+  return (window as any).SpeechRecognition || (window as any).webkitSpeechRecognition || null;
+}
+
+export interface DictationButtonProps {
+  /** Current text of the field being dictated into. */
+  value: string;
+  /** Receives the full updated text (existing + recognised speech). */
+  onText: (next: string) => void;
+  /** Idle helper label. Defaults to "Talk instead of type". */
+  hint?: string;
+  disabled?: boolean;
+}
+
+export function DictationButton({
+  value,
+  onText,
+  hint = 'Talk instead of type',
+  disabled = false,
+}: DictationButtonProps) {
+  const [isRecording, setIsRecording] = useState(false);
+  const isRecordingRef = useRef(false);
+  const [isRequestingPermission, setIsRequestingPermission] = useState(false);
+  const segmentRef = useRef<DictationSegmentState>(emptyDictationState());
+  const webRecognitionRef = useRef<any>(null);
+
+  // Latest props via refs so the once-registered event handlers never close
+  // over stale values (same pattern as SignaturePad).
+  const valueRef = useRef(value);
+  valueRef.current = value;
+  const onTextRef = useRef(onText);
+  onTextRef.current = onText;
+
+  // Ref is set synchronously alongside state so global event handlers see
+  // the change in the same frame (no effect-sync lag).
+  const setRecording = (next: boolean) => {
+    isRecordingRef.current = next;
+    setIsRecording(next);
+  };
+
+  // --- Native speech events (no-op stubs on web / when module missing) ---
+
+  useSpeechRecognitionEvent('end', () => {
+    // Recogniser ended on its own (silence) while the tradie is still
+    // recording — bank the in-flight segment and restart.
+    if (!isRecordingRef.current) return;
+    segmentRef.current = commitSegment(segmentRef.current);
+    setTimeout(async () => {
+      if (!isRecordingRef.current) return;
+      try {
+        await ExpoSpeechRecognitionModule.start(NATIVE_START_OPTIONS);
+      } catch (error) {
+        setRecording(false);
+      }
+    }, 100);
+  });
+
+  useSpeechRecognitionEvent('result', (event: any) => {
+    if (!isRecordingRef.current) return; // Not this instance / not recording
+
+    const allResults = event.results || [];
+    // Each result carries the full transcript for its segment, not
+    // incremental text — the latest one is what we fold in.
+    const lastResult = allResults[allResults.length - 1];
+    if (!lastResult?.transcript) return;
+
+    const folded = foldDictationResult(segmentRef.current, lastResult.transcript, allResults.length);
+    if (!folded) return;
+    segmentRef.current = folded.state;
+    onTextRef.current(folded.display);
+  });
+
+  useSpeechRecognitionEvent('error', (event: any) => {
+    if (!isRecordingRef.current) return;
+    setRecording(false);
+    Alert.alert('Voice recognition error', event.error || 'Could not recognise speech');
+  });
+
+  // Stop listening if the screen unmounts mid-recording — never leave the
+  // mic running with nowhere to put the words.
+  useEffect(() => {
+    return () => {
+      if (!isRecordingRef.current) return;
+      isRecordingRef.current = false;
+      if (webRecognitionRef.current) {
+        try { webRecognitionRef.current.stop(); } catch {}
+      } else if (ExpoSpeechRecognitionModule) {
+        ExpoSpeechRecognitionModule.stop().catch(() => {});
+      }
+    };
+  }, []);
+
+  const handleToggle = async () => {
+    // Web: Use native Web Speech API directly
+    if (Platform.OS === 'web') {
+      if (isRecordingRef.current) {
+        if (webRecognitionRef.current) {
+          webRecognitionRef.current.stop();
+        }
+        setRecording(false);
+        return;
+      }
+
+      const SpeechRecognition = getWebSpeechRecognition();
+      if (!SpeechRecognition) return; // Unsupported — button isn't rendered anyway
+
+      const recognition = new SpeechRecognition();
+      recognition.continuous = true;
+      recognition.interimResults = true;
+      recognition.lang = 'en-AU';
+
+      let finalTranscript = valueRef.current; // Start with existing text
+
+      recognition.onresult = (event: any) => {
+        let interimTranscript = '';
+        for (let i = event.resultIndex; i < event.results.length; i++) {
+          const transcript = event.results[i][0].transcript;
+          if (event.results[i].isFinal) {
+            finalTranscript = appendTranscript(finalTranscript, transcript);
+          } else {
+            interimTranscript += transcript;
+          }
+        }
+        // Show final + interim
+        onTextRef.current(
+          interimTranscript ? appendTranscript(finalTranscript, interimTranscript) : finalTranscript,
+        );
+      };
+
+      recognition.onerror = (event: any) => {
+        setRecording(false);
+        Alert.alert('Voice recognition error', event.error || 'Could not recognise speech');
+      };
+
+      recognition.onend = () => {
+        if (isRecordingRef.current) {
+          // Restart if still recording
+          recognition.start();
+        }
+      };
+
+      webRecognitionRef.current = recognition;
+      recognition.start();
+      setRecording(true);
+      return;
+    }
+
+    // Native: Use expo-speech-recognition
+    if (!ExpoSpeechRecognitionModule) return; // Unsupported — button isn't rendered anyway
+
+    if (isRecordingRef.current) {
+      // Stop recording manually
+      try {
+        // Compose final text from accumulated + last segment BEFORE stopping,
+        // so a late 'end' event can't reset the field.
+        onTextRef.current(finalizeDictation(segmentRef.current, valueRef.current));
+        // Flip the flag FIRST so the 'end' handler knows this was a manual stop.
+        setRecording(false);
+        await ExpoSpeechRecognitionModule.stop();
+        segmentRef.current = emptyDictationState();
+      } catch (error) {
+        setRecording(false);
+        Alert.alert('Error', 'Failed to stop voice recording');
+      }
+      return;
+    }
+
+    // Start recording — append to whatever is already in the field
+    try {
+      // First check if we already have permission
+      const currentStatus = await ExpoSpeechRecognitionModule.getPermissionsAsync();
+      let result = currentStatus;
+
+      // Only request if not already granted
+      if (!currentStatus.granted) {
+        setIsRequestingPermission(true);
+
+        // Add a timeout to prevent infinite loading
+        const permissionPromise = ExpoSpeechRecognitionModule.requestPermissionsAsync();
+        const timeoutPromise = new Promise((_, reject) =>
+          setTimeout(() => reject(new Error('Permission request timed out')), 10000)
+        );
+
+        try {
+          result = await Promise.race([permissionPromise, timeoutPromise]) as any;
+        } catch (timeoutError) {
+          setIsRequestingPermission(false);
+          Alert.alert(
+            'Permission Request Failed',
+            Platform.OS === 'ios'
+              ? 'The permission dialog did not appear. Please go to Settings > QuoteMate > Microphone and enable it, then try again.'
+              : 'The permission dialog did not appear. Please check:\n\n1. Go to Settings > Apps > QuoteMate > Permissions\n2. Enable Microphone permission\n3. Try again'
+          );
+          return;
+        }
+
+        setIsRequestingPermission(false);
+
+        if (!result.granted) {
+          Alert.alert('Permission Required', 'Microphone permission is required for voice recording');
+          return;
+        }
+      }
+
+      // Check if speech recognition is available
+      await ExpoSpeechRecognitionModule.getStateAsync();
+
+      // Seed the segment state with the field's existing text
+      segmentRef.current = { accumulated: valueRef.current, lastSegment: '' };
+
+      await ExpoSpeechRecognitionModule.start(NATIVE_START_OPTIONS);
+      setRecording(true);
+    } catch (error: any) {
+      // Ensure we always reset the loading state
+      setIsRequestingPermission(false);
+      setRecording(false);
+      Alert.alert(
+        'Error Starting Recording',
+        `Failed to start voice recording: ${error?.message || 'Unknown error'}\n\nPlease check:\n1. Microphone permission is granted\n2. Speech recognition is available on your device\n3. Internet connection (for cloud recognition)`
+      );
+    }
+  };
+
+  // Graceful absence: no speech support on this platform → render nothing.
+  // Module presence and the window API are static, so this never flips
+  // mid-session (hooks above always run in the same order).
+  const supported = Platform.OS === 'web' ? !!getWebSpeechRecognition() : !!ExpoSpeechRecognitionModule;
+  if (!supported) return null;
+
+  return (
+    <View style={styles.row}>
+      <TouchableOpacity
+        onPress={() => { handleToggle(); }}
+        disabled={disabled || isRequestingPermission}
+        style={[styles.micButton, isRecording && styles.micButtonActive]}
+        activeOpacity={0.8}
+        hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+        accessibilityRole="button"
+        accessibilityLabel={isRecording ? 'Stop dictating' : 'Dictate into this field'}
+      >
+        <MaterialCommunityIcons
+          name={isRecording ? 'stop' : 'microphone'}
+          size={20}
+          color="#FFFFFF"
+        />
+      </TouchableOpacity>
+
+      <Text style={[styles.hintText, isRecording && styles.hintTextActive]}>
+        {isRequestingPermission
+          ? 'Requesting microphone permission…'
+          : isRecording
+            ? 'Listening — tap to stop'
+            : hint}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+  },
+  micButton: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: colors.primary,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  micButtonActive: {
+    backgroundColor: colors.error,
+  },
+  hintText: {
+    flex: 1,
+    fontSize: 13,
+    color: colors.textSecondary,
+  },
+  hintTextActive: {
+    color: colors.success,
+    fontWeight: '600',
+  },
+});

--- a/src/components/SignaturePad.tsx
+++ b/src/components/SignaturePad.tsx
@@ -36,7 +36,7 @@ import {
 import Svg, { Path } from 'react-native-svg';
 
 import { colors } from '../theme';
-import { buildSvgPath, type Point } from './signaturePath';
+import { buildSvgPath, pathHasInk, type Point } from './signaturePath';
 
 const DEFAULT_HEIGHT = 180;
 
@@ -90,7 +90,10 @@ export function SignaturePad({
   // Lift the finished ink to the parent — called on stroke end and clear,
   // never per move-sample.
   const commit = (next: Point[][]) => {
-    onChangeRef.current(buildSvgPath(next), {
+    const d = buildSvgPath(next);
+    // Sub-threshold ink (taps, micro-twitches) commits as unsigned — an
+    // invisible mark must never count as a signature on the customer PDF.
+    onChangeRef.current(pathHasInk(d) ? d : '', {
       width: Math.round(sizeRef.current.width),
       height: Math.round(sizeRef.current.height),
     });

--- a/src/components/signaturePath.test.ts
+++ b/src/components/signaturePath.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-import { buildSvgPath } from './signaturePath';
+import { buildSvgPath, pathHasInk } from './signaturePath';
 
 describe('buildSvgPath', () => {
   it('returns an empty string for empty input', () => {
@@ -35,21 +35,50 @@ describe('buildSvgPath', () => {
         { x: 5, y: 5 },
         { x: 6, y: 6 },
       ],
-      [{ x: 9, y: 9 }],
     ]);
 
-    expect((d.match(/M/g) || []).length).toBe(3);
-    expect(d).toBe('M 0 0 L 1 1 M 5 5 L 6 6 M 9 9');
+    expect((d.match(/M/g) || []).length).toBe(2);
+    expect(d).toBe('M 0 0 L 1 1 M 5 5 L 6 6');
   });
 
-  it('skips empty strokes but still joins the populated ones', () => {
+  // Regression: an accidental tap produced `M x y` with no line — invisible
+  // ink that still rendered a "signed" block on the customer PDF.
+  it('drops single-point strokes (a tap is not a signature)', () => {
+    expect(buildSvgPath([[{ x: 9, y: 9 }]])).toBe('');
+    expect(
+      buildSvgPath([
+        [{ x: 1, y: 2 }],
+        [],
+        [{ x: 3, y: 4 }],
+      ]),
+    ).toBe('');
+  });
+
+  it('keeps real strokes while dropping taps around them', () => {
     const d = buildSvgPath([
-      [{ x: 1, y: 2 }],
-      [],
-      [{ x: 3, y: 4 }],
+      [{ x: 9, y: 9 }], // tap — dropped
+      [
+        { x: 0, y: 0 },
+        { x: 4, y: 4 },
+      ],
     ]);
 
-    expect(d).toBe('M 1 2 M 3 4');
-    expect((d.match(/M/g) || []).length).toBe(2);
+    expect(d).toBe('M 0 0 L 4 4');
+  });
+});
+
+describe('pathHasInk', () => {
+  it('is false for empty / missing paths', () => {
+    expect(pathHasInk('')).toBe(false);
+    expect(pathHasInk(undefined)).toBe(false);
+    expect(pathHasInk(null)).toBe(false);
+  });
+
+  it('is false for a bare move-to (legacy tap capture)', () => {
+    expect(pathHasInk('M 10 10')).toBe(false);
+  });
+
+  it('is true for a path with a line-to', () => {
+    expect(pathHasInk('M 10 10 L 20 20')).toBe(true);
   });
 });

--- a/src/components/signaturePath.ts
+++ b/src/components/signaturePath.ts
@@ -6,6 +6,11 @@
  * emits an `L` (line-to) command for every subsequent point. Multiple strokes
  * are concatenated, so a lifted pen produces a fresh `M` (a break in the ink).
  *
+ * Single-point strokes are DROPPED: an accidental tap on the pad produces
+ * `M x y` with no line — invisible ink that still counts as "signed" and
+ * renders an empty signature block on the customer PDF. Real signatures
+ * always move the pen, so a stroke needs at least two points to count.
+ *
  * Kept dependency-free and side-effect-free so it can be unit tested in
  * isolation and reused by both the on-device SignaturePad and any renderer.
  */
@@ -17,7 +22,8 @@ export interface Point {
 
 /**
  * Build an SVG path `d` string from captured strokes.
- * Empty input (or strokes that contain no points) yields an empty string.
+ * Empty input, strokes with no points, and single-point strokes (accidental
+ * taps) yield no ink; all-degenerate input yields an empty string.
  */
 export function buildSvgPath(strokes: Point[][]): string {
   if (!strokes || strokes.length === 0) return '';
@@ -25,7 +31,8 @@ export function buildSvgPath(strokes: Point[][]): string {
   const segments: string[] = [];
 
   for (const stroke of strokes) {
-    if (!stroke || stroke.length === 0) continue;
+    // A tap is not a signature — require actual pen movement.
+    if (!stroke || stroke.length < 2) continue;
 
     const [first, ...rest] = stroke;
     let segment = `M ${first.x} ${first.y}`;
@@ -36,4 +43,13 @@ export function buildSvgPath(strokes: Point[][]): string {
   }
 
   return segments.join(' ');
+}
+
+/**
+ * True when a path `d` string contains actual ink — at least one line-to.
+ * Used by renderers as defence in depth: a legacy or hand-crafted path of
+ * bare move-to commands must not produce a "signed" block.
+ */
+export function pathHasInk(d: string | undefined | null): boolean {
+  return !!d && d.includes('L');
 }

--- a/src/components/signaturePath.ts
+++ b/src/components/signaturePath.ts
@@ -45,11 +45,8 @@ export function buildSvgPath(strokes: Point[][]): string {
   return segments.join(' ');
 }
 
-/**
- * True when a path `d` string contains actual ink — at least one line-to.
- * Used by renderers as defence in depth: a legacy or hand-crafted path of
- * bare move-to commands must not produce a "signed" block.
- */
-export function pathHasInk(d: string | undefined | null): boolean {
-  return !!d && d.includes('L');
-}
+// Canonical "is this real ink?" lives in shared/pdf/signatureInk so the pad
+// and both PDF renderers (client expo-print, server Puppeteer) agree on one
+// definition of "signed". A structural check (path contains an L) is not
+// enough — a tap with a micro-twitch captures a zero-length line-to.
+export { pathHasInk, pathInkLength, MIN_SIGNATURE_INK_LENGTH } from '../../shared/pdf/signatureInk';

--- a/src/screens/ServiceReport/ServiceReportScreen.tsx
+++ b/src/screens/ServiceReport/ServiceReportScreen.tsx
@@ -47,6 +47,7 @@ import {
   buildReportInput,
   deriveReportContext,
   formFromReport,
+  latestTechnicianSignature,
   type ReportFormState,
 } from './reportDraft';
 
@@ -102,6 +103,29 @@ export function ServiceReportScreen() {
     if (routeReportId) return; // edit mode hydrates below instead
     setForm(buildInitialReportForm(job));
   }, [job, form, routeReportId]);
+
+  // New report: pre-fill the technician pad with the tradie's most recent
+  // real signature — their squiggle never changes, so re-drawing it on
+  // every docket is pure friction. Visible in the pad, one tap to Clear.
+  // Functional setters keep any ink the tradie laid down before this fetch
+  // resolved; the CUSTOMER pad is never pre-filled — fresh ink every visit.
+  useEffect(() => {
+    if (routeReportId) return;
+    let cancelled = false;
+    reportService.listReports().then((reports) => {
+      if (cancelled) return;
+      const sig = latestTechnicianSignature(reports);
+      if (!sig) return;
+      setTechSigPath((prev) => prev || sig.svgPath);
+      setTechSigName((prev) => prev || sig.name);
+      setTechSigSize((prev) =>
+        prev ?? (sig.width && sig.height ? { width: sig.width, height: sig.height } : prev),
+      );
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [routeReportId]);
 
   // Edit mode: load the existing report once.
   useEffect(() => {

--- a/src/screens/ServiceReport/ServiceReportScreen.tsx
+++ b/src/screens/ServiceReport/ServiceReportScreen.tsx
@@ -7,10 +7,16 @@
  * Pulls the customer + address off the linked Job (read-only here), then lets
  * the tradie set the visit date, service type and risk assessment; manage a
  * short equipment list and a tick-box checklist (Mate NEVER pre-ticks — every
- * tick is a manual tap); jot rough notes into the three narrative fields and
- * tap "Write it up" to have Mate tidy them into customer-ready prose; attach
- * photos; and capture technician + customer signatures. Save persists via
- * reportService; "Export / Share" renders the PDF via exportReportPDF.
+ * tick is a manual tap); jot rough notes into the three narrative fields
+ * (typed or dictated via DictationButton) and tap "Write it up" to have Mate
+ * tidy them into customer-ready prose — the write-up may redistribute facts
+ * between the three fields, and any extra equipment/checklist items Mate
+ * spots come back as tap-to-add suggestion chips (never auto-added, checklist
+ * rows always land unticked); attach photos; capture technician + customer
+ * signatures; and, when Recommended work has content and the job has a
+ * customer, spin the follow-up into a new draft quote ("Quote this work").
+ * Save persists via reportService; "Export / Share" renders the PDF via
+ * exportReportPDF.
  *
  * Copy here is Australian English, gender-neutral, and never says the two-letter
  * word for the assistant — it is "Mate". Nothing on this screen or the exported
@@ -33,21 +39,27 @@ import { WebContainer } from '../../components/WebContainer';
 import { FixedBottomButton } from '../../components/FixedBottomButton';
 import { JobPhotos } from '../../components/JobPhotos';
 import { SignaturePad, type SignaturePadSize } from '../../components/SignaturePad';
+import { DictationButton } from '../../components/DictationButton';
 import { useAlertModal } from '../../hooks/useAlertModal';
 import { generateId } from '../../utils/generateId';
 import { getTradeCategoryById } from '../../constants/tradeCategories';
 import { reportService } from '../../services/reportService';
 import { composeServiceReport } from '../../services/reportComposeService';
+import { trackEvent } from '../../services/analyticsService';
 import { exportReportPDF } from '../../utils/pdfGenerator';
+import { createQuoteFromRecommendedWork } from '../../utils/quoteFromReport';
 import type { QuotePhoto } from '../../types';
 import type { JobPhoto } from '../../../shared/job/types';
 import type { ServiceReport, SignatureCapture } from '../../../shared/report/types';
+import { pathHasInk } from '../../../shared/pdf/signatureInk';
 import {
+  applyComposedWriteUp,
   buildInitialReportForm,
   buildReportInput,
   deriveReportContext,
   formFromReport,
   latestTechnicianSignature,
+  pruneSuggestions,
   type ReportFormState,
 } from './reportDraft';
 
@@ -83,6 +95,13 @@ export function ServiceReportScreen() {
   const [composing, setComposing] = useState(false);
   const [saving, setSaving] = useState(false);
   const [exporting, setExporting] = useState(false);
+  const [quoting, setQuoting] = useState(false);
+
+  // Mate's tap-to-add suggestions from the last write-up. Review-only:
+  // nothing lands on the report until the tradie taps a chip, and checklist
+  // rows always land unticked. Not persisted — dismissing loses nothing.
+  const [suggestedEquipment, setSuggestedEquipment] = useState<string[]>([]);
+  const [suggestedChecklist, setSuggestedChecklist] = useState<string[]>([]);
 
   // Signing locks the ScrollView so pen strokes don't fight the scroll.
   const [signing, setSigning] = useState(false);
@@ -96,6 +115,14 @@ export function ServiceReportScreen() {
   const dirtyRef = useRef(false);
   // Suppresses navigation.setParams once the screen is on its way out.
   const leavingRef = useRef(false);
+
+  // Analytics one-shots. "Signed" means fresh measured ink saved for the
+  // first time this visit — the baselines flag ink that arrived via edit-mode
+  // load or the technician pre-fill, so a carried-forward squiggle never
+  // counts as a new signing.
+  const signedEventFiredRef = useRef(false);
+  const baselineTechInkRef = useRef(false);
+  const baselineCustInkRef = useRef(false);
 
   // Seed the form from the job (new report).
   useEffect(() => {
@@ -116,7 +143,13 @@ export function ServiceReportScreen() {
       if (cancelled) return;
       const sig = latestTechnicianSignature(reports);
       if (!sig) return;
-      setTechSigPath((prev) => prev || sig.svgPath);
+      setTechSigPath((prev) => {
+        if (prev) return prev;
+        // Carried-forward ink is not a fresh signing (ref set is idempotent,
+        // so a double updater run under StrictMode is harmless).
+        baselineTechInkRef.current = true;
+        return sig.svgPath;
+      });
       setTechSigName((prev) => prev || sig.name);
       setTechSigSize((prev) =>
         prev ?? (sig.width && sig.height ? { width: sig.width, height: sig.height } : prev),
@@ -140,6 +173,9 @@ export function ServiceReportScreen() {
         status: report.status,
         createdAt: report.createdAt,
       });
+      // Ink already on the loaded report is not a fresh signing.
+      baselineTechInkRef.current = pathHasInk(report.technicianSignature?.svgPath ?? '');
+      baselineCustInkRef.current = pathHasInk(report.customerSignature?.svgPath ?? '');
       setTechSigName(report.technicianSignature?.name ?? '');
       setTechSigPath(report.technicianSignature?.svgPath ?? '');
       if (report.technicianSignature?.width && report.technicianSignature?.height) {
@@ -251,6 +287,31 @@ export function ServiceReportScreen() {
   const removeChecklistItem = (id: string) =>
     patch({ itemsChecked: form.itemsChecked.filter((it) => it.id !== id) });
 
+  // --- Suggestion chips (from the write-up) ----------------------------------
+  // Chips only OFFER a row — a tap adds it and retires the chip. Re-pruned
+  // against the live rows every render so a row the tradie typed themselves
+  // hides its duplicate chip.
+  const equipmentChips = pruneSuggestions(suggestedEquipment, form.equipment);
+  const checklistChips = pruneSuggestions(
+    suggestedChecklist,
+    form.itemsChecked.map((it) => it.text),
+  );
+
+  const addSuggestedEquipment = (text: string) => {
+    setSuggestedEquipment((prev) => prev.filter((s) => s !== text));
+    patch({ equipment: [...form.equipment, text] });
+  };
+  const addSuggestedChecklist = (text: string) => {
+    setSuggestedChecklist((prev) => prev.filter((s) => s !== text));
+    // Always unticked — ticking is the tradie's tap, never Mate's.
+    patch({
+      itemsChecked: [
+        ...form.itemsChecked,
+        { id: generateId(), text, checked: false },
+      ],
+    });
+  };
+
   // --- Write it up (compose) ------------------------------------------------
   const handleWriteItUp = async () => {
     const notes = {
@@ -281,12 +342,25 @@ export function ServiceReportScreen() {
         businessName: businessSettings?.businessName || undefined,
         tradeCategory,
       });
-      // Only overwrite a field when the tidy-up returned something for it —
-      // never blank out text the tradie had typed.
-      patch({
-        natureOfProblem: composed.natureOfProblem || form.natureOfProblem,
-        workCarriedOut: composed.workCarriedOut || form.workCarriedOut,
-        recommendedWork: composed.recommendedWork || form.recommendedWork,
+      // Apply the returned trio wholesale: the write-up may REDISTRIBUTE a
+      // fact into the field where it belongs, so a field can legitimately
+      // come back empty (its fact moved) or filled (a fact moved in). The
+      // helper's only guard is all-blank — Mate never wipes the lot.
+      patch(applyComposedWriteUp(notes, composed));
+      // Anything extra Mate spotted in the notes lands as tap-to-add chips,
+      // pruned against rows already on the report. Never auto-added.
+      setSuggestedEquipment(
+        pruneSuggestions(composed.suggestedEquipment, form.equipment),
+      );
+      setSuggestedChecklist(
+        pruneSuggestions(
+          composed.suggestedChecklist,
+          form.itemsChecked.map((it) => it.text),
+        ),
+      );
+      trackEvent('report_written_up', {
+        equipment_suggested: composed.suggestedEquipment.length,
+        checklist_suggested: composed.suggestedChecklist.length,
       });
     } catch (err: any) {
       showAlert({
@@ -364,6 +438,20 @@ export function ServiceReportScreen() {
       ),
     ]);
 
+  // Fire-and-forget "report signed" the first time a save carries fresh
+  // measured ink (pathHasInk — ghost taps don't count; loaded / pre-filled
+  // ink is baselined out above). Never blocks or fails the save.
+  const trackFirstSignature = () => {
+    if (signedEventFiredRef.current) return;
+    const freshTech =
+      !baselineTechInkRef.current && !!techSigPath && pathHasInk(techSigPath);
+    const freshCust =
+      !baselineCustInkRef.current && !!custSigPath && pathHasInk(custSigPath);
+    if (!freshTech && !freshCust) return;
+    signedEventFiredRef.current = true;
+    trackEvent('report_signed', { technician: freshTech, customer: freshCust });
+  };
+
   // Persist and return a fully-formed ServiceReport (for the PDF export).
   const persist = async (): Promise<ServiceReport | null> => {
     const sigs = currentSignatures();
@@ -376,6 +464,8 @@ export function ServiceReportScreen() {
     };
     if (!meta) {
       const created = await withTimeout(reportService.createReport(input));
+      trackEvent('report_created');
+      trackFirstSignature();
       setMeta({
         id: created.id,
         number: created.number,
@@ -391,6 +481,7 @@ export function ServiceReportScreen() {
       return created;
     }
     await withTimeout(reportService.updateReport(meta.id, input));
+    trackFirstSignature();
     dirtyRef.current = false;
     return {
       ...input,
@@ -439,6 +530,7 @@ export function ServiceReportScreen() {
         customerPhone: context?.customerPhone,
         jobAddress: context?.jobAddress,
       });
+      trackEvent('report_shared', { method: 'share' });
     } catch (err: any) {
       showAlert({
         type: 'error',
@@ -447,6 +539,49 @@ export function ServiceReportScreen() {
       });
     } finally {
       setExporting(false);
+    }
+  };
+
+  // --- Quote this work --------------------------------------------------
+  // Recommended work → a fresh draft quote for the same customer, then the
+  // wizard's MaterialsList with the pipeline running. Only offered when the
+  // job actually has a customer to quote. The report is persisted FIRST so
+  // navigating away never bins unsaved edits.
+  const canQuoteRecommended =
+    !!(job.customerName || '').trim() && !!form.recommendedWork.trim();
+
+  const handleQuoteRecommendedWork = async () => {
+    if (quoting) return;
+    setQuoting(true);
+    try {
+      await persist();
+      const s = useStore.getState();
+      const result = await createQuoteFromRecommendedWork(
+        {
+          job,
+          recommendedWork: form.recommendedWork,
+          serviceTypeLabel: form.serviceType,
+        },
+        {
+          createNewQuote: s.createNewQuote,
+          getCurrentQuote: () => useStore.getState().currentQuote,
+          updateQuote: s.updateQuote,
+          saveDraft: s.saveDraft,
+        },
+      );
+      if (!result) return; // Blank recommended work — button shouldn't show
+      navigation.navigate(result.navigate.navigator, {
+        screen: result.navigate.screen,
+        params: result.navigate.params,
+      });
+    } catch (err: any) {
+      showAlert({
+        type: 'error',
+        title: 'Could not start the quote',
+        message: err?.message || 'Please try again in a moment.',
+      });
+    } finally {
+      setQuoting(false);
     }
   };
 
@@ -544,6 +679,12 @@ export function ServiceReportScreen() {
             numberOfLines={3}
             style={styles.input}
           />
+          <View style={styles.dictationRow}>
+            <DictationButton
+              value={form.riskAssessment}
+              onText={(next) => patch({ riskAssessment: next })}
+            />
+          </View>
 
           {/* Equipment */}
           <SectionLabel text="Equipment on site" optional />
@@ -574,6 +715,13 @@ export function ServiceReportScreen() {
             </View>
           ))}
           <AddRow label="Add equipment" onPress={addEquipment} />
+          {equipmentChips.length > 0 && (
+            <SuggestionChips
+              items={equipmentChips}
+              onAdd={addSuggestedEquipment}
+              onClear={() => setSuggestedEquipment([])}
+            />
+          )}
 
           {/* Checklist — heading matches the PDF's "Items checked" */}
           <SectionLabel text="Items checked" optional />
@@ -618,6 +766,13 @@ export function ServiceReportScreen() {
             </View>
           ))}
           <AddRow label="Add checklist item" onPress={addChecklistItem} />
+          {checklistChips.length > 0 && (
+            <SuggestionChips
+              items={checklistChips}
+              onAdd={addSuggestedChecklist}
+              onClear={() => setSuggestedChecklist([])}
+            />
+          )}
 
           {/* Narrative */}
           <SectionLabel text="Nature of the problem" optional />
@@ -630,6 +785,12 @@ export function ServiceReportScreen() {
             numberOfLines={3}
             style={styles.input}
           />
+          <View style={styles.dictationRow}>
+            <DictationButton
+              value={form.natureOfProblem}
+              onText={(next) => patch({ natureOfProblem: next })}
+            />
+          </View>
           <SectionLabel text="Work carried out" optional />
           <TextInput
             mode="outlined"
@@ -640,6 +801,12 @@ export function ServiceReportScreen() {
             numberOfLines={3}
             style={styles.input}
           />
+          <View style={styles.dictationRow}>
+            <DictationButton
+              value={form.workCarriedOut}
+              onText={(next) => patch({ workCarriedOut: next })}
+            />
+          </View>
           <SectionLabel text="Recommended work" optional />
           <TextInput
             mode="outlined"
@@ -650,6 +817,33 @@ export function ServiceReportScreen() {
             numberOfLines={3}
             style={styles.input}
           />
+          <View style={styles.dictationRow}>
+            <DictationButton
+              value={form.recommendedWork}
+              onText={(next) => patch({ recommendedWork: next })}
+            />
+          </View>
+          {canQuoteRecommended && (
+            <TouchableOpacity
+              onPress={handleQuoteRecommendedWork}
+              disabled={quoting || saving || exporting}
+              style={styles.quoteWorkButton}
+              activeOpacity={0.8}
+            >
+              {quoting ? (
+                <ActivityIndicator size="small" color={colors.primary} />
+              ) : (
+                <MaterialCommunityIcons
+                  name="file-document-outline"
+                  size={18}
+                  color={colors.primary}
+                />
+              )}
+              <Text style={styles.quoteWorkText}>
+                {quoting ? 'Setting up the quote…' : 'Quote this work'}
+              </Text>
+            </TouchableOpacity>
+          )}
 
           <TouchableOpacity
             onPress={handleWriteItUp}
@@ -740,11 +934,14 @@ export function ServiceReportScreen() {
         label="Save report"
         onPress={handleSave}
         loading={saving}
-        disabled={saving || exporting}
+        disabled={saving || exporting || quoting}
         secondaryLabel="Share PDF"
         secondaryOnPress={handleExport}
         secondaryLoading={exporting}
-        secondaryDisabled={saving}
+        // Without this the shared button falls back to its materials-flow
+        // default copy, "Fetching prices..." — nonsense on a report.
+        secondaryLoadingText="Preparing PDF..."
+        secondaryDisabled={saving || quoting}
         disableKeyboardSticky
       />
 
@@ -758,6 +955,54 @@ function SectionLabel({ text, optional }: { text: string; optional?: boolean }) 
     <View style={styles.sectionLabelRow}>
       <Text style={styles.sectionLabel}>{text}</Text>
       {optional ? <Text style={styles.optional}>optional</Text> : null}
+    </View>
+  );
+}
+
+/**
+ * Tap-to-add suggestions from Mate's write-up. Review-only by design: a tap
+ * adds the row (checklist rows land unticked) and retires the chip; "Clear"
+ * bins the lot. Mate never adds anything itself.
+ */
+function SuggestionChips({
+  items,
+  onAdd,
+  onClear,
+}: {
+  items: string[];
+  onAdd: (text: string) => void;
+  onClear: () => void;
+}) {
+  return (
+    <View style={styles.suggestionBlock}>
+      <View style={styles.suggestionHeader}>
+        <Text style={styles.suggestionLabel}>
+          Mate reckons these came up — tap to add
+        </Text>
+        <TouchableOpacity
+          onPress={onClear}
+          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+          accessibilityRole="button"
+          accessibilityLabel="Clear suggestions"
+        >
+          <Text style={styles.suggestionClear}>Clear</Text>
+        </TouchableOpacity>
+      </View>
+      <View style={styles.chipWrap}>
+        {items.map((text) => (
+          <TouchableOpacity
+            key={text}
+            style={styles.chip}
+            onPress={() => onAdd(text)}
+            activeOpacity={0.7}
+            accessibilityRole="button"
+            accessibilityLabel={`Add ${text}`}
+          >
+            <MaterialCommunityIcons name="plus" size={14} color={colors.primary} />
+            <Text style={styles.chipText}>{text}</Text>
+          </TouchableOpacity>
+        ))}
+      </View>
     </View>
   );
 }
@@ -852,4 +1097,47 @@ const styles = StyleSheet.create({
     marginTop: 6,
     lineHeight: 16,
   },
+  dictationRow: { marginTop: 2, marginBottom: 4 },
+  quoteWorkButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+    marginTop: 10,
+    paddingVertical: 12,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: colors.primary,
+    backgroundColor: colors.surface,
+  },
+  quoteWorkText: { fontSize: 14, fontWeight: '700', color: colors.primary },
+  suggestionBlock: {
+    backgroundColor: colors.surface,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: colors.border,
+    padding: 12,
+    marginTop: 4,
+  },
+  suggestionHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    marginBottom: 8,
+  },
+  suggestionLabel: { flex: 1, fontSize: 12, color: colors.textMuted },
+  suggestionClear: { fontSize: 12, color: colors.textSecondary, fontWeight: '600' },
+  chipWrap: { flexDirection: 'row', flexWrap: 'wrap', gap: 8 },
+  chip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    borderWidth: 1,
+    borderColor: colors.primary,
+    borderRadius: 16,
+    paddingVertical: 6,
+    paddingHorizontal: 10,
+    backgroundColor: colors.background,
+  },
+  chipText: { fontSize: 13, color: colors.primary, fontWeight: '600' },
 });

--- a/src/screens/ServiceReport/ServiceReportScreen.tsx
+++ b/src/screens/ServiceReport/ServiceReportScreen.tsx
@@ -679,12 +679,6 @@ export function ServiceReportScreen() {
             numberOfLines={3}
             style={styles.input}
           />
-          <View style={styles.dictationRow}>
-            <DictationButton
-              value={form.riskAssessment}
-              onText={(next) => patch({ riskAssessment: next })}
-            />
-          </View>
 
           {/* Equipment */}
           <SectionLabel text="Equipment on site" optional />
@@ -785,12 +779,6 @@ export function ServiceReportScreen() {
             numberOfLines={3}
             style={styles.input}
           />
-          <View style={styles.dictationRow}>
-            <DictationButton
-              value={form.natureOfProblem}
-              onText={(next) => patch({ natureOfProblem: next })}
-            />
-          </View>
           <SectionLabel text="Work carried out" optional />
           <TextInput
             mode="outlined"
@@ -801,12 +789,6 @@ export function ServiceReportScreen() {
             numberOfLines={3}
             style={styles.input}
           />
-          <View style={styles.dictationRow}>
-            <DictationButton
-              value={form.workCarriedOut}
-              onText={(next) => patch({ workCarriedOut: next })}
-            />
-          </View>
           <SectionLabel text="Recommended work" optional />
           <TextInput
             mode="outlined"
@@ -817,12 +799,6 @@ export function ServiceReportScreen() {
             numberOfLines={3}
             style={styles.input}
           />
-          <View style={styles.dictationRow}>
-            <DictationButton
-              value={form.recommendedWork}
-              onText={(next) => patch({ recommendedWork: next })}
-            />
-          </View>
           {canQuoteRecommended && (
             <TouchableOpacity
               onPress={handleQuoteRecommendedWork}
@@ -844,6 +820,18 @@ export function ServiceReportScreen() {
               </Text>
             </TouchableOpacity>
           )}
+
+          {/* One mic for the whole write-up: everything lands in Work
+              carried out, and "Write it up" sorts the facts into the right
+              sections. Four stacked mics read as clutter; one reads as a
+              feature. */}
+          <View style={styles.dictationRow}>
+            <DictationButton
+              value={form.workCarriedOut}
+              onText={(next) => patch({ workCarriedOut: next })}
+              hint="Talk through the visit — Mate sorts it into the right sections"
+            />
+          </View>
 
           <TouchableOpacity
             onPress={handleWriteItUp}

--- a/src/screens/ServiceReport/reportDraft.test.ts
+++ b/src/screens/ServiceReport/reportDraft.test.ts
@@ -1,11 +1,14 @@
 import { describe, it, expect } from 'vitest';
 
 import {
+  applyComposedWriteUp,
   deriveReportContext,
   buildInitialReportForm,
   buildReportInput,
   formFromReport,
   latestTechnicianSignature,
+  pruneSuggestions,
+  resumableReportId,
   type ReportFormState,
 } from './reportDraft';
 import type { ServiceReport } from '../../../shared/report/types';
@@ -139,6 +142,109 @@ describe('formFromReport', () => {
     expect(form.equipment).toEqual(['Wrench']);
     expect(form.workCarriedOut).toBe('Resealed joint');
     expect(form.photos).toEqual([]);
+  });
+});
+
+describe('applyComposedWriteUp', () => {
+  const current = {
+    natureOfProblem: 'heater dead. also reckon the flue needs redoing',
+    workCarriedOut: 'swapped thermocouple',
+    recommendedWork: '',
+  };
+
+  it('applies every returned field verbatim, including redistributed facts', () => {
+    const composed = {
+      natureOfProblem: 'Heater not operating on arrival.',
+      workCarriedOut: 'Replaced the thermocouple.',
+      recommendedWork: 'Flue requires replacement.',
+    };
+    expect(applyComposedWriteUp(current, composed)).toEqual(composed);
+  });
+
+  it('accepts an emptied source field when its fact moved to another field', () => {
+    const composed = {
+      natureOfProblem: '',
+      workCarriedOut: 'Replaced the thermocouple. Heater was not operating on arrival.',
+      recommendedWork: 'Flue requires replacement.',
+    };
+    const result = applyComposedWriteUp(current, composed);
+    expect(result.natureOfProblem).toBe('');
+    expect(result.workCarriedOut).toContain('thermocouple');
+  });
+
+  it('keeps the tradie text when the compose came back entirely blank', () => {
+    const result = applyComposedWriteUp(current, {
+      natureOfProblem: '',
+      workCarriedOut: '   ',
+      recommendedWork: '',
+    });
+    expect(result).toEqual(current);
+  });
+});
+
+describe('pruneSuggestions', () => {
+  it('trims entries and drops blanks', () => {
+    expect(pruneSuggestions(['  Ladder ', '   ', 'Multimeter'], [])).toEqual([
+      'Ladder',
+      'Multimeter',
+    ]);
+  });
+
+  it('drops suggestions already on the report, case-insensitively', () => {
+    expect(
+      pruneSuggestions(['ladder', 'Gas detector'], ['Ladder ', 'Hose kit']),
+    ).toEqual(['Gas detector']);
+  });
+
+  it('dedupes repeats within the suggestion list, keeping first occurrence order', () => {
+    expect(
+      pruneSuggestions(['Valve', 'Regulator', ' valve ', 'Regulator'], []),
+    ).toEqual(['Valve', 'Regulator']);
+  });
+
+  it('returns empty when everything is already covered', () => {
+    expect(pruneSuggestions(['Ladder'], ['ladder'])).toEqual([]);
+    expect(pruneSuggestions([], ['Ladder'])).toEqual([]);
+  });
+});
+
+describe('resumableReportId', () => {
+  const report = (over: Partial<ServiceReport>): ServiceReport =>
+    ({
+      id: 'r1',
+      jobId: 'j1',
+      userId: 'u1',
+      number: 'RP-001',
+      visitDate: 1,
+      serviceType: 'Service',
+      equipment: [],
+      itemsChecked: [],
+      status: 'draft',
+      createdAt: 1,
+      updatedAt: 1,
+      ...over,
+    }) as ServiceReport;
+
+  it('resumes the newest report when it is still a draft', () => {
+    expect(
+      resumableReportId([
+        report({ id: 'newest-draft', status: 'draft' }),
+        report({ id: 'older-sent', status: 'sent' }),
+      ]),
+    ).toBe('newest-draft');
+  });
+
+  it('does not resume when the newest report has been sent', () => {
+    expect(
+      resumableReportId([
+        report({ id: 'newest-sent', status: 'sent' }),
+        report({ id: 'older-draft', status: 'draft' }),
+      ]),
+    ).toBeNull();
+  });
+
+  it('returns null for an empty list', () => {
+    expect(resumableReportId([])).toBeNull();
   });
 });
 

--- a/src/screens/ServiceReport/reportDraft.test.ts
+++ b/src/screens/ServiceReport/reportDraft.test.ts
@@ -5,8 +5,10 @@ import {
   buildInitialReportForm,
   buildReportInput,
   formFromReport,
+  latestTechnicianSignature,
   type ReportFormState,
 } from './reportDraft';
+import type { ServiceReport } from '../../../shared/report/types';
 import type { Job } from '../../../shared/job/types';
 
 function makeJob(overrides: Partial<Job> = {}): Job {
@@ -137,5 +139,54 @@ describe('formFromReport', () => {
     expect(form.equipment).toEqual(['Wrench']);
     expect(form.workCarriedOut).toBe('Resealed joint');
     expect(form.photos).toEqual([]);
+  });
+});
+
+describe('latestTechnicianSignature', () => {
+  const report = (over: Partial<ServiceReport>): ServiceReport =>
+    ({
+      id: 'r1',
+      jobId: 'j1',
+      userId: 'u1',
+      number: 'RP-001',
+      visitDate: 1,
+      serviceType: 'Service',
+      equipment: [],
+      itemsChecked: [],
+      status: 'draft',
+      createdAt: 1,
+      updatedAt: 1,
+      ...over,
+    }) as ServiceReport;
+
+  const realSig = { svgPath: 'M 10 80 L 60 20 L 110 90', name: 'Jess', signedAt: 1, width: 400, height: 180 };
+  const ghostSig = { svgPath: 'M 400 57 L 400 57', name: '', signedAt: 1 };
+
+  it('returns the first (newest) report with real technician ink', () => {
+    const found = latestTechnicianSignature([
+      report({ id: 'new', technicianSignature: realSig }),
+      report({ id: 'old', technicianSignature: { ...realSig, name: 'Older' } }),
+    ]);
+    expect(found?.name).toBe('Jess');
+  });
+
+  it('skips ghost captures without measurable ink', () => {
+    const found = latestTechnicianSignature([
+      report({ id: 'ghost', technicianSignature: ghostSig }),
+      report({ id: 'real', technicianSignature: realSig }),
+    ]);
+    expect(found?.name).toBe('Jess');
+  });
+
+  it('never returns a customer signature', () => {
+    const found = latestTechnicianSignature([
+      report({ id: 'c', customerSignature: realSig }),
+    ]);
+    expect(found).toBeNull();
+  });
+
+  it('returns null when no report carries technician ink', () => {
+    expect(latestTechnicianSignature([])).toBeNull();
+    expect(latestTechnicianSignature([report({})])).toBeNull();
   });
 });

--- a/src/screens/ServiceReport/reportDraft.ts
+++ b/src/screens/ServiceReport/reportDraft.ts
@@ -16,8 +16,10 @@
 import type { Job, JobPhoto } from '../../../shared/job/types';
 import type {
   ReportChecklistItem,
+  ServiceReport,
   SignatureCapture,
 } from '../../../shared/report/types';
+import { pathHasInk } from '../../../shared/pdf/signatureInk';
 import type { CreateReportInput } from '../../services/reportService';
 
 /** Customer context lifted off the Job for the PDF export options. */
@@ -155,4 +157,22 @@ export function formFromReport(
     customerSignature: report.customerSignature,
     technicianSignature: report.technicianSignature,
   };
+}
+
+/**
+ * The tradie's most recent real technician signature, for pre-filling the
+ * pad on a NEW report — their signature never changes, so drawing it fresh
+ * on every docket is pure friction. Reports are expected newest-first (as
+ * listReports returns them); ghost captures (no measurable ink) and the
+ * customer signature are never carried forward — customer ink must be
+ * fresh on every visit.
+ */
+export function latestTechnicianSignature(
+  reports: ServiceReport[],
+): SignatureCapture | null {
+  for (const report of reports) {
+    const sig = report.technicianSignature;
+    if (sig && pathHasInk(sig.svgPath)) return sig;
+  }
+  return null;
 }

--- a/src/screens/ServiceReport/reportDraft.ts
+++ b/src/screens/ServiceReport/reportDraft.ts
@@ -159,6 +159,74 @@ export function formFromReport(
   };
 }
 
+/** The three narrative fields Mate's write-up returns. */
+export interface WriteUpFields {
+  natureOfProblem: string;
+  workCarriedOut: string;
+  recommendedWork: string;
+}
+
+/**
+ * Fold Mate's composed write-up back into the form. The compose step may
+ * REDISTRIBUTE facts between fields (a "recommend…" line jotted under work
+ * carried out comes back under recommended work), so every returned field is
+ * applied verbatim — including an emptied one whose fact moved elsewhere.
+ * The only guard: if Mate returned nothing at all, keep what the tradie
+ * typed rather than wiping the lot.
+ */
+export function applyComposedWriteUp(
+  current: WriteUpFields,
+  composed: WriteUpFields,
+): WriteUpFields {
+  const allBlank =
+    !trim(composed.natureOfProblem) &&
+    !trim(composed.workCarriedOut) &&
+    !trim(composed.recommendedWork);
+  if (allBlank) return current;
+  return {
+    natureOfProblem: composed.natureOfProblem,
+    workCarriedOut: composed.workCarriedOut,
+    recommendedWork: composed.recommendedWork,
+  };
+}
+
+/**
+ * Mate's suggested equipment / checklist rows, pruned for display as
+ * tap-to-add chips: blanks dropped, whitespace trimmed, and anything already
+ * on the report (case-insensitive) or repeated within the list removed.
+ * Chips only ever OFFER a row — the tradie taps to add it, and checklist
+ * rows always land unticked.
+ */
+export function pruneSuggestions(
+  suggestions: string[],
+  existing: string[],
+): string[] {
+  const seen = new Set(
+    existing.map((e) => trim(e).toLowerCase()).filter((e) => e.length > 0),
+  );
+  const out: string[] = [];
+  for (const raw of suggestions) {
+    const t = trim(raw);
+    const key = t.toLowerCase();
+    if (!t || seen.has(key)) continue;
+    seen.add(key);
+    out.push(t);
+  }
+  return out;
+}
+
+/**
+ * The report the actions sheet should reopen instead of minting a new one.
+ * Reports are expected newest-first (as listReports returns them): if the
+ * newest report for the job is still a draft, that's an unfinished docket —
+ * resume it. A sent newest report (or no reports at all) means the next tap
+ * is a genuinely new visit, so nothing is resumed.
+ */
+export function resumableReportId(reports: ServiceReport[]): string | null {
+  const newest = reports[0];
+  return newest && newest.status === 'draft' ? newest.id : null;
+}
+
 /**
  * The tradie's most recent real technician signature, for pre-filling the
  * pad on a NEW report — their signature never changes, so drawing it fresh

--- a/src/screens/ViewJobScreen.tsx
+++ b/src/screens/ViewJobScreen.tsx
@@ -27,6 +27,8 @@ import { JobDetailHeader } from '../components/JobDetailHeader';
 import { JobActionsSheet, type JobAction } from '../components/JobActionsSheet';
 import { exportDocumentPDF } from '../utils/pdfGenerator';
 import { canUseServiceReports } from '../utils/reportEntitlement';
+import { reportService } from '../services/reportService';
+import { resumableReportId } from './ServiceReport/reportDraft';
 import { StageSheet } from '../components/StageSheet';
 import { JobStageSheet, stageMetaFor } from '../components/JobStageSheet';
 import {
@@ -614,7 +616,15 @@ export function ViewJobScreen() {
         break;
       case 'service_report':
         if (canUseServiceReports(getEffectivePlan())) {
-          navigation.navigate('ServiceReport', { jobId: job.id });
+          // Resume an unfinished draft instead of minting a duplicate report;
+          // a sent (or absent) newest report means a genuinely new visit.
+          const reportId = resumableReportId(
+            await reportService.listReports(job.id),
+          );
+          navigation.navigate('ServiceReport', {
+            jobId: job.id,
+            ...(reportId ? { reportId } : {}),
+          });
         } else {
           navigation.navigate('Paywall');
         }

--- a/src/services/analyticsService.ts
+++ b/src/services/analyticsService.ts
@@ -64,7 +64,18 @@ export type AnalyticsEvent =
   // shown = impression per sheet open; tapped carries `outcome`
   // (connect_required / attached / failed) so attach-rate is measurable.
   | 'pay_link_optin_shown'
-  | 'pay_link_optin_tapped';
+  | 'pay_link_optin_tapped'
+  // — Service reports —
+  // First persist of a new service report (mints the RP number; re-saves
+  // don't fire again).
+  | 'report_created'
+  // Mate returned a clean write-up for the rough notes.
+  | 'report_written_up'
+  // First save carrying fresh signature ink (measured ink only — ghost
+  // taps and carried-forward/loaded signatures don't count).
+  | 'report_signed'
+  // The report PDF went out via the export/share path.
+  | 'report_shared';
 
 interface BaseProps {
   // Free-form per-event payload. Keep it flat (Firestore indexes flat fields

--- a/src/services/reportComposeService.ts
+++ b/src/services/reportComposeService.ts
@@ -3,12 +3,19 @@
  *
  * Posts the tradie's rough notes to the `composeServiceReport` Firebase
  * Function, which proxies the text model server-side (the master key never
- * touches the device) and returns the three cleaned write-up fields. Mirrors
- * emailService.ts for the auth header + functions URL so we stay on one auth
- * path.
+ * touches the device) and returns the three cleaned write-up fields plus two
+ * suggestion lists. Mirrors emailService.ts for the auth header + functions
+ * URL so we stay on one auth path.
  *
  * Strictly a rewrite of what the tradie typed — the server prompt forbids
- * invented detail — so an empty source field always comes back empty.
+ * invented detail. Facts may be REDISTRIBUTED into the field where they
+ * belong (a "recommend…" line typed under work carried out comes back under
+ * recommended work), so a field can return non-empty even when its own note
+ * was blank; when every note is blank, everything comes back blank.
+ *
+ * suggestedEquipment / suggestedChecklist are optional extras extracted from
+ * the notes for the tradie to review and tap to add — nothing is ever added
+ * to the report automatically.
  */
 
 import { auth } from '../config/firebase';
@@ -41,12 +48,19 @@ export interface ComposedReport {
   natureOfProblem: string;
   workCarriedOut: string;
   recommendedWork: string;
+  suggestedEquipment: string[];
+  suggestedChecklist: string[];
+}
+
+function asStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((v): v is string => typeof v === 'string' && v.trim().length > 0);
 }
 
 /**
  * Send the rough notes off for a clean write-up. Throws on a non-2xx reply so
- * the caller can surface a retry; the returned object always carries all three
- * keys (blank where the source note was blank).
+ * the caller can surface a retry; the returned object always carries all five
+ * keys (blank strings / empty arrays where nothing applies).
  */
 export async function composeServiceReport(
   notes: ComposeNotes,
@@ -75,5 +89,7 @@ export async function composeServiceReport(
     natureOfProblem: data.natureOfProblem || '',
     workCarriedOut: data.workCarriedOut || '',
     recommendedWork: data.recommendedWork || '',
+    suggestedEquipment: asStringArray(data.suggestedEquipment),
+    suggestedChecklist: asStringArray(data.suggestedChecklist),
   };
 }

--- a/src/utils/dictationTranscript.test.ts
+++ b/src/utils/dictationTranscript.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  appendTranscript,
+  commitSegment,
+  emptyDictationState,
+  finalizeDictation,
+  foldDictationResult,
+  type DictationSegmentState,
+} from './dictationTranscript';
+
+const state = (accumulated: string, lastSegment: string): DictationSegmentState => ({
+  accumulated,
+  lastSegment,
+});
+
+describe('appendTranscript', () => {
+  it('joins base and addition with a single space', () => {
+    expect(appendTranscript('replace downpipe', 'and clean gutters')).toBe(
+      'replace downpipe and clean gutters',
+    );
+  });
+
+  it('returns the addition alone when base is empty', () => {
+    expect(appendTranscript('', 'flush the system')).toBe('flush the system');
+  });
+
+  it('returns base untouched when the addition is blank or whitespace', () => {
+    expect(appendTranscript('serviced the unit', '')).toBe('serviced the unit');
+    expect(appendTranscript('serviced the unit', '   ')).toBe('serviced the unit');
+  });
+
+  it('does not double spaces when base has trailing whitespace or newlines', () => {
+    expect(appendTranscript('checked seals ', 'replaced filter')).toBe(
+      'checked seals replaced filter',
+    );
+    expect(appendTranscript('checked seals\n', 'replaced filter')).toBe(
+      'checked seals replaced filter',
+    );
+  });
+
+  it('trims the addition before joining', () => {
+    expect(appendTranscript('base', '  extra  ')).toBe('base extra');
+  });
+});
+
+describe('foldDictationResult', () => {
+  it('returns null for a blank transcript', () => {
+    expect(foldDictationResult(state('notes', 'seg'), '   ', 2)).toBeNull();
+  });
+
+  it('displays accumulated + current segment on a normal interim update', () => {
+    const folded = foldDictationResult(state('existing notes', ''), 'replaced the valve', 1);
+    expect(folded).not.toBeNull();
+    expect(folded!.display).toBe('existing notes replaced the valve');
+    expect(folded!.state).toEqual(state('existing notes', 'replaced the valve'));
+  });
+
+  it('replaces the in-flight segment when a growing transcript arrives (multi-result frame)', () => {
+    const folded = foldDictationResult(
+      state('existing', 'replaced the'),
+      'replaced the valve',
+      2,
+    );
+    expect(folded!.display).toBe('existing replaced the valve');
+    expect(folded!.state.lastSegment).toBe('replaced the valve');
+    expect(folded!.state.accumulated).toBe('existing');
+  });
+
+  it('treats a single-result frame with matching first words as a refinement', () => {
+    const folded = foldDictationResult(
+      state('existing', 'replaced the valve today'),
+      'replaced the valve on Tuesday',
+      1,
+    );
+    expect(folded!.display).toBe('existing replaced the valve on Tuesday');
+    expect(folded!.state).toEqual(state('existing', 'replaced the valve on Tuesday'));
+  });
+
+  it('banks the previous segment when a single-result frame is a new utterance', () => {
+    const folded = foldDictationResult(
+      state('existing', 'replaced the valve'),
+      'also flushed the lines',
+      1,
+    );
+    // Display shows accumulated only for this frame; next frame re-adds current.
+    expect(folded!.display).toBe('existing replaced the valve');
+    expect(folded!.state).toEqual(
+      state('existing replaced the valve', 'also flushed the lines'),
+    );
+  });
+
+  it('falls through to the default update when transcripts contain each other', () => {
+    const folded = foldDictationResult(
+      state('existing', 'the valve'),
+      'checked the valve',
+      1,
+    );
+    expect(folded!.display).toBe('existing checked the valve');
+    expect(folded!.state.accumulated).toBe('existing');
+    expect(folded!.state.lastSegment).toBe('checked the valve');
+  });
+
+  it('works with no pre-existing text', () => {
+    const folded = foldDictationResult(emptyDictationState(), 'first words', 1);
+    expect(folded!.display).toBe('first words');
+    expect(folded!.state).toEqual(state('', 'first words'));
+  });
+});
+
+describe('commitSegment', () => {
+  it('banks the in-flight segment into accumulated and clears it', () => {
+    expect(commitSegment(state('done first bit', 'then this'))).toEqual(
+      state('done first bit then this', ''),
+    );
+  });
+
+  it('is a no-op when nothing is in flight', () => {
+    const s = state('all committed', '');
+    expect(commitSegment(s)).toBe(s);
+  });
+});
+
+describe('finalizeDictation', () => {
+  it('joins accumulated and in-flight segment', () => {
+    expect(finalizeDictation(state('first half', 'second half'), 'fallback')).toBe(
+      'first half second half',
+    );
+  });
+
+  it('returns accumulated alone when nothing is in flight', () => {
+    expect(finalizeDictation(state('just this', ''), 'fallback')).toBe('just this');
+  });
+
+  it('returns the in-flight segment alone when nothing was banked', () => {
+    expect(finalizeDictation(state('', 'only segment'), 'fallback')).toBe('only segment');
+  });
+
+  it('falls back to the existing field text when nothing was captured', () => {
+    expect(finalizeDictation(emptyDictationState(), 'typed earlier')).toBe('typed earlier');
+  });
+});

--- a/src/utils/dictationTranscript.ts
+++ b/src/utils/dictationTranscript.ts
@@ -1,0 +1,112 @@
+/**
+ * Pure transcript-folding helpers for dictation.
+ *
+ * Extracted from the voice-capture logic in JobDetailsScreen so the segment
+ * accumulation / refinement / restart handling can be unit tested in
+ * isolation and reused by DictationButton. Mirrors the behaviour of the
+ * original 'result' / 'end' / stop handlers:
+ *
+ *  - `accumulated` is the text banked before the in-flight segment (seeded
+ *    from whatever the tradie had already typed when recording started).
+ *  - `lastSegment` is the latest interim/final transcript for the segment
+ *    the recogniser is currently working on. Each result frame carries the
+ *    FULL transcript for that segment, not incremental text, so the display
+ *    is always accumulated + latest segment.
+ */
+
+export interface DictationSegmentState {
+  /** Text committed before the in-flight segment. */
+  accumulated: string;
+  /** Latest interim/final transcript for the in-flight segment. */
+  lastSegment: string;
+}
+
+export const emptyDictationState = (): DictationSegmentState => ({
+  accumulated: '',
+  lastSegment: '',
+});
+
+/**
+ * Join dictated text onto existing text with sensible spacing: exactly one
+ * space between them, no trailing-whitespace doubling, and no stray space
+ * when either side is empty.
+ */
+export function appendTranscript(base: string, addition: string): string {
+  const trimmedAddition = addition.trim();
+  if (!trimmedAddition) return base;
+  const trimmedBase = base.replace(/\s+$/, '');
+  return trimmedBase ? `${trimmedBase} ${trimmedAddition}` : trimmedAddition;
+}
+
+/**
+ * Fold one recognition result frame into the segment state.
+ *
+ * `resultCount` is the number of results in the frame. A frame with a single
+ * result while we still hold a different `lastSegment` means the recogniser
+ * silently restarted — we then have to decide whether the new transcript is
+ * a refinement of what was already said (same first three words → replace)
+ * or a genuinely new utterance (no containment either way → bank the old
+ * segment into `accumulated` and show only the accumulated text this frame;
+ * the next frame will re-add the current segment).
+ *
+ * Returns null when the frame carries no usable transcript.
+ */
+export function foldDictationResult(
+  state: DictationSegmentState,
+  transcript: string,
+  resultCount: number,
+): { state: DictationSegmentState; display: string } | null {
+  const current = transcript.trim();
+  if (!current) return null;
+
+  if (resultCount === 1 && state.lastSegment && state.lastSegment !== current) {
+    const lastLower = state.lastSegment.toLowerCase();
+    const currentLower = current.toLowerCase();
+    const firstWords = (s: string) => s.split(/\s+/).slice(0, 3).join(' ');
+    const isRefinement = firstWords(lastLower) === firstWords(currentLower);
+
+    if (!isRefinement && !currentLower.includes(lastLower) && !lastLower.includes(currentLower)) {
+      // New utterance after a silent restart — bank the previous segment.
+      const accumulated = appendTranscript(state.accumulated, state.lastSegment);
+      return {
+        state: { accumulated, lastSegment: current },
+        display: accumulated,
+      };
+    }
+    if (isRefinement) {
+      return {
+        state: { ...state, lastSegment: current },
+        display: appendTranscript(state.accumulated, current),
+      };
+    }
+    // Containment without matching openings: treat as the default update.
+  }
+
+  return {
+    state: { ...state, lastSegment: current },
+    display: appendTranscript(state.accumulated, current),
+  };
+}
+
+/**
+ * Bank the in-flight segment into the accumulated text. Used when the
+ * recogniser fires 'end' mid-recording and is about to be restarted.
+ * No-op when there is nothing in flight.
+ */
+export function commitSegment(state: DictationSegmentState): DictationSegmentState {
+  if (!state.lastSegment) return state;
+  return {
+    accumulated: appendTranscript(state.accumulated, state.lastSegment),
+    lastSegment: '',
+  };
+}
+
+/**
+ * Compose the final text when the tradie taps stop. Falls back to the
+ * field's existing text when nothing was captured (so stopping immediately
+ * never wipes what was already typed).
+ */
+export function finalizeDictation(state: DictationSegmentState, fallback: string): string {
+  const joined = appendTranscript(state.accumulated, state.lastSegment);
+  return joined || fallback;
+}

--- a/src/utils/quoteFromReport.test.ts
+++ b/src/utils/quoteFromReport.test.ts
@@ -1,0 +1,256 @@
+/**
+ * "Quote it" — service-report Recommended Work → new draft quote.
+ *
+ * Covers the pure decision logic (name building, blank guards, verbatim
+ * description, customer carry-over) and the thin orchestrator's contract
+ * (deps call order, null short-circuit, navigation payload).
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+import {
+  buildFollowUpJobName,
+  buildFollowUpQuoteSeed,
+  applySeedToQuote,
+  createQuoteFromRecommendedWork,
+  type CreateQuoteFromReportDeps,
+} from './quoteFromReport';
+import type { Quote } from '../types';
+import type { Job } from '../../shared/job/types';
+
+function makeJob(overrides: Partial<Job> = {}): Job {
+  return {
+    id: 'job-1',
+    userId: 'user-1',
+    customerId: 'contact-9',
+    customerName: 'Sam Nguyen',
+    customerEmail: 'sam@example.com',
+    customerPhone: '0400 000 000',
+    jobAddress: '12 Wattle St, Warragul VIC',
+    name: 'Nguyen aircon service',
+    stage: 'completed',
+    documentIds: [],
+    ...overrides,
+  } as Job;
+}
+
+function makeQuote(overrides: Partial<Quote> = {}): Quote {
+  return {
+    id: 'quote-1',
+    createdAt: new Date('2026-07-20T00:00:00Z'),
+    updatedAt: new Date('2026-07-20T00:00:00Z'),
+    customerName: '',
+    job: { id: 'jobspec-1', name: '', description: '', template: 'custom' },
+    materials: [],
+    laborRate: 95,
+    laborHours: 0,
+    laborUnit: 'hours',
+    laborTotal: 0,
+    materialsSubtotal: 0,
+    markup: 25,
+    markupAmount: 0,
+    subtotal: 0,
+    gst: 0,
+    total: 0,
+    status: 'draft',
+    ...overrides,
+  };
+}
+
+describe('buildFollowUpJobName', () => {
+  it('appends "follow-up work" to the service type', () => {
+    expect(buildFollowUpJobName('Aircon service')).toBe(
+      'Aircon service — follow-up work',
+    );
+  });
+
+  it('trims whitespace around the service type', () => {
+    expect(buildFollowUpJobName('  Gutter clean  ')).toBe(
+      'Gutter clean — follow-up work',
+    );
+  });
+
+  it('falls back to a plain name when the service type is blank or missing', () => {
+    expect(buildFollowUpJobName('')).toBe('Follow-up work');
+    expect(buildFollowUpJobName('   ')).toBe('Follow-up work');
+    expect(buildFollowUpJobName(undefined)).toBe('Follow-up work');
+    expect(buildFollowUpJobName(null)).toBe('Follow-up work');
+  });
+});
+
+describe('buildFollowUpQuoteSeed', () => {
+  it('returns null when recommendedWork is missing', () => {
+    expect(buildFollowUpQuoteSeed({ job: makeJob() })).toBeNull();
+    expect(
+      buildFollowUpQuoteSeed({ job: makeJob(), recommendedWork: null }),
+    ).toBeNull();
+  });
+
+  it('returns null when recommendedWork is blank or whitespace-only', () => {
+    expect(
+      buildFollowUpQuoteSeed({ job: makeJob(), recommendedWork: '' }),
+    ).toBeNull();
+    expect(
+      buildFollowUpQuoteSeed({ job: makeJob(), recommendedWork: '  \n\t ' }),
+    ).toBeNull();
+  });
+
+  it('keeps the recommended work verbatim as the job description', () => {
+    const text =
+      'Replace the zone 2 damper motor.\nRe-gas the outdoor unit — pressure was low at 350 kPa.';
+    const seed = buildFollowUpQuoteSeed({
+      job: makeJob(),
+      recommendedWork: text,
+      serviceTypeLabel: 'Aircon service',
+    });
+    expect(seed?.jobDescription).toBe(text);
+  });
+
+  it('trims only outer whitespace, never inner content', () => {
+    const seed = buildFollowUpQuoteSeed({
+      job: makeJob(),
+      recommendedWork: '  Fix the leak.\n  Then re-test.  \n',
+    });
+    expect(seed?.jobDescription).toBe('Fix the leak.\n  Then re-test.');
+  });
+
+  it('carries the customer over from the source job, including the contact link', () => {
+    const seed = buildFollowUpQuoteSeed({
+      job: makeJob(),
+      recommendedWork: 'Replace the damper motor.',
+      serviceTypeLabel: 'Aircon service',
+    });
+    expect(seed).toEqual({
+      jobName: 'Aircon service — follow-up work',
+      jobDescription: 'Replace the damper motor.',
+      customerName: 'Sam Nguyen',
+      customerEmail: 'sam@example.com',
+      customerPhone: '0400 000 000',
+      jobAddress: '12 Wattle St, Warragul VIC',
+      contactId: 'contact-9',
+    });
+  });
+
+  it('leaves contactId undefined when the job has no linked contact', () => {
+    const seed = buildFollowUpQuoteSeed({
+      job: makeJob({ customerId: undefined }),
+      recommendedWork: 'Replace the damper motor.',
+    });
+    expect(seed?.contactId).toBeUndefined();
+  });
+
+  it('maps an empty job address to undefined rather than an empty string', () => {
+    const seed = buildFollowUpQuoteSeed({
+      job: makeJob({ jobAddress: '' }),
+      recommendedWork: 'Replace the damper motor.',
+    });
+    expect(seed?.jobAddress).toBeUndefined();
+  });
+});
+
+describe('applySeedToQuote', () => {
+  const seed = {
+    jobName: 'Aircon service — follow-up work',
+    jobDescription: 'Replace the damper motor.',
+    customerName: 'Sam Nguyen',
+    customerEmail: 'sam@example.com',
+    customerPhone: '0400 000 000',
+    jobAddress: '12 Wattle St, Warragul VIC',
+    contactId: 'contact-9',
+  };
+
+  it('stamps customer and scope onto the fresh draft', () => {
+    const out = applySeedToQuote(makeQuote(), seed);
+    expect(out.customerName).toBe('Sam Nguyen');
+    expect(out.customerEmail).toBe('sam@example.com');
+    expect(out.customerPhone).toBe('0400 000 000');
+    expect(out.jobAddress).toBe('12 Wattle St, Warragul VIC');
+    expect(out.contactId).toBe('contact-9');
+    expect(out.job.name).toBe('Aircon service — follow-up work');
+    expect(out.job.description).toBe('Replace the damper motor.');
+  });
+
+  it('keeps the draft business defaults and identity untouched', () => {
+    const fresh = makeQuote();
+    const out = applySeedToQuote(fresh, seed);
+    expect(out.id).toBe(fresh.id);
+    expect(out.laborRate).toBe(95);
+    expect(out.markup).toBe(25);
+    expect(out.status).toBe('draft');
+    expect(out.job.id).toBe(fresh.job.id);
+    expect(out.materials).toEqual([]);
+  });
+});
+
+describe('createQuoteFromRecommendedWork', () => {
+  function makeDeps(): CreateQuoteFromReportDeps & { current: Quote | null } {
+    const deps = {
+      current: null as Quote | null,
+      createNewQuote: vi.fn(() => {
+        deps.current = makeQuote();
+      }),
+      getCurrentQuote: vi.fn(() => deps.current),
+      updateQuote: vi.fn((q: Quote) => {
+        deps.current = q;
+      }),
+      saveDraft: vi.fn(async () => {}),
+    };
+    return deps;
+  }
+
+  it('returns null and touches no deps when there is no recommended work', async () => {
+    const deps = makeDeps();
+    const result = await createQuoteFromRecommendedWork(
+      { job: makeJob(), recommendedWork: '   ' },
+      deps,
+    );
+    expect(result).toBeNull();
+    expect(deps.createNewQuote).not.toHaveBeenCalled();
+    expect(deps.saveDraft).not.toHaveBeenCalled();
+  });
+
+  it('mints, seeds, saves, and returns the wizard navigation payload', async () => {
+    const deps = makeDeps();
+    const result = await createQuoteFromRecommendedWork(
+      {
+        job: makeJob(),
+        recommendedWork: 'Replace the damper motor.',
+        serviceTypeLabel: 'Aircon service',
+      },
+      deps,
+    );
+
+    expect(deps.createNewQuote).toHaveBeenCalledOnce();
+    expect(deps.updateQuote).toHaveBeenCalledOnce();
+    const seeded = deps.updateQuote.mock.calls[0][0] as Quote;
+    expect(seeded.job.name).toBe('Aircon service — follow-up work');
+    expect(seeded.job.description).toBe('Replace the damper motor.');
+    expect(seeded.contactId).toBe('contact-9');
+
+    // saveDraft receives the post-update currentQuote (calculation pass ran).
+    expect(deps.saveDraft).toHaveBeenCalledOnce();
+    expect(deps.saveDraft).toHaveBeenCalledWith(deps.current);
+
+    expect(result).toEqual({
+      quoteId: 'quote-1',
+      navigate: {
+        navigator: 'NewJob',
+        screen: 'MaterialsList',
+        params: { autoGenerate: true },
+      },
+    });
+  });
+
+  it('throws when the store fails to mint a draft', async () => {
+    const deps = makeDeps();
+    deps.createNewQuote = vi.fn(() => {
+      deps.current = null;
+    });
+    await expect(
+      createQuoteFromRecommendedWork(
+        { job: makeJob(), recommendedWork: 'Replace the damper motor.' },
+        deps,
+      ),
+    ).rejects.toThrow('Failed to create draft quote.');
+    expect(deps.saveDraft).not.toHaveBeenCalled();
+  });
+});

--- a/src/utils/quoteFromReport.ts
+++ b/src/utils/quoteFromReport.ts
@@ -1,0 +1,154 @@
+/**
+ * "Quote it" — turn a service report's Recommended Work into a new draft
+ * quote for the same customer.
+ *
+ * Mirrors the Mate applyProposal 'propose_draft_quote' flow (useStore.ts):
+ * mint a fresh draft via createNewQuote() so business defaults (labour
+ * rate, markup, GST) are stamped from settings, seed customer + scope,
+ * then saveDraft — saveDocument→ensureJobForDocument mints and links the
+ * NEW job automatically. The caller then opens the wizard's MaterialsList
+ * with autoGenerate:true so the materials pipeline runs, exactly like the
+ * wizard does after a fresh description.
+ *
+ * Factual rule: the recommended-work text becomes the job description
+ * VERBATIM (outer whitespace trimmed, nothing rewritten, nothing added).
+ *
+ * Store calls are injected as deps (pattern: cascadeDeleteJob /
+ * openJobPreview) so the decision logic stays unit-testable. Wire them
+ * from useStore in the calling screen:
+ *
+ *   const s = useStore.getState();
+ *   createQuoteFromRecommendedWork(params, {
+ *     createNewQuote: s.createNewQuote,
+ *     getCurrentQuote: () => useStore.getState().currentQuote,
+ *     updateQuote: s.updateQuote,
+ *     saveDraft: s.saveDraft,
+ *   });
+ */
+
+import type { Quote } from '../types';
+import type { Job } from '../../shared/job/types';
+
+// ─── Pure decision logic ────────────────────────────────────────────────
+
+export interface CreateQuoteFromReportParams {
+  /** The job the source report belongs to — supplies the customer. */
+  job: Job;
+  /** ServiceReport.recommendedWork — becomes the quote scope verbatim. */
+  recommendedWork?: string | null;
+  /** ServiceReport.serviceType — used only for the new job's name. */
+  serviceTypeLabel?: string;
+}
+
+/** Customer + scope fields to stamp onto a freshly minted draft quote. */
+export interface FollowUpQuoteSeed {
+  jobName: string;
+  jobDescription: string;
+  customerName: string;
+  customerEmail?: string;
+  customerPhone?: string;
+  jobAddress?: string;
+  contactId?: string;
+}
+
+/** "Aircon service — follow-up work", or "Follow-up work" when the report
+ *  has no service type. */
+export function buildFollowUpJobName(serviceTypeLabel?: string | null): string {
+  const label = (serviceTypeLabel ?? '').trim();
+  return label ? `${label} — follow-up work` : 'Follow-up work';
+}
+
+/**
+ * Decide what the new draft should contain. Returns null when there's
+ * nothing to quote (blank/whitespace-only recommended work) — callers
+ * should hide or no-op the "Quote it" action in that case.
+ */
+export function buildFollowUpQuoteSeed(
+  params: CreateQuoteFromReportParams,
+): FollowUpQuoteSeed | null {
+  const description = (params.recommendedWork ?? '').trim();
+  if (!description) return null;
+
+  const { job } = params;
+  return {
+    jobName: buildFollowUpJobName(params.serviceTypeLabel),
+    jobDescription: description,
+    customerName: job.customerName,
+    customerEmail: job.customerEmail,
+    customerPhone: job.customerPhone,
+    jobAddress: job.jobAddress || undefined,
+    contactId: job.customerId,
+  };
+}
+
+/** Stamp the seed onto a freshly minted draft, keeping the draft's
+ *  business defaults (labour rate, markup, GST flags) untouched. */
+export function applySeedToQuote(fresh: Quote, seed: FollowUpQuoteSeed): Quote {
+  return {
+    ...fresh,
+    customerName: seed.customerName,
+    customerEmail: seed.customerEmail,
+    customerPhone: seed.customerPhone,
+    jobAddress: seed.jobAddress,
+    contactId: seed.contactId,
+    job: {
+      ...fresh.job,
+      name: seed.jobName,
+      description: seed.jobDescription,
+    },
+  };
+}
+
+// ─── Thin store orchestration ───────────────────────────────────────────
+
+export interface CreateQuoteFromReportDeps {
+  createNewQuote: () => void;
+  getCurrentQuote: () => Quote | null;
+  updateQuote: (quote: Quote) => void;
+  saveDraft: (quote: Quote) => Promise<void>;
+}
+
+export interface QuoteFromReportResult {
+  /** Id of the new draft quote (currentQuote is already set to it). */
+  quoteId: string;
+  /** Wizard entry that runs the materials pipeline on mount:
+   *  navigation.navigate(navigate.navigator, { screen, params }). */
+  navigate: {
+    navigator: 'NewJob';
+    screen: 'MaterialsList';
+    params: { autoGenerate: true };
+  };
+}
+
+/**
+ * Create the follow-up draft quote and return the navigation payload for
+ * opening the wizard with the pipeline running. Returns null when the
+ * report has no recommended work. currentQuote is left set to the new
+ * draft, which is what MaterialsList reads.
+ */
+export async function createQuoteFromRecommendedWork(
+  params: CreateQuoteFromReportParams,
+  deps: CreateQuoteFromReportDeps,
+): Promise<QuoteFromReportResult | null> {
+  const seed = buildFollowUpQuoteSeed(params);
+  if (!seed) return null;
+
+  deps.createNewQuote();
+  const fresh = deps.getCurrentQuote();
+  if (!fresh) throw new Error('Failed to create draft quote.');
+
+  deps.updateQuote(applySeedToQuote(fresh, seed));
+  // Re-read: updateQuote runs the calculation pass before storing.
+  const current = deps.getCurrentQuote();
+  if (!current) throw new Error('Failed to create draft quote.');
+  await deps.saveDraft(current);
+
+  return {
+    quoteId: current.id,
+    navigate: {
+      navigator: 'NewJob',
+      screen: 'MaterialsList',
+      params: { autoGenerate: true },
+    },
+  };
+}


### PR DESCRIPTION
Builds on #52 (service reports P1+P2). Five commits, all verified on top of current main.

## What's in it

**Hardening (from live testing with real data):**
- Ghost signatures eliminated: accidental taps captured invisible ink that rendered empty "signed" blocks on the customer PDF. "Signed" now means measured ink length (shared `signatureInk.ts`, one definition across the pad + both PDF renderers). Regression tests include the exact ghost path caught in production.
- Technician signature carries forward to new reports (visible in the pad, one tap to Clear); customer ink is never carried.

**Round 2 features:**
- Talk instead of type: single dictation mic above "Write it up" (mirrors the JobDetailsScreen voice pattern, web + native)
- Compose v2: facts may move between the three narrative fields ("needs replacing" typed into Work carried out lands in Recommended work) but never be invented; same round-trip returns suggested equipment + checklist chips — tap-to-add, always unticked
- "Quote this work": Recommended work spawns a draft quote for the same customer (description verbatim) and opens the materials pipeline
- Actions sheet resumes the job's newest draft report instead of minting duplicates
- Analytics: report created / written-up / signed / shared events in the existing funnel naming
- Share button loading copy fixed ("Preparing PDF...", was the shared button's "Fetching prices..." default)

## Verification
- 1016/1016 vitest passing on this branch rebased onto current main; tsc clean (app + functions)
- Compose v2 verified live against the deployed function: messy single-field note → correctly redistributed three fields + accurate suggestions, zero invention
- Emailed PDF artifact verified by test-send (Puppeteer render, business-name-only branding)
- Deployed to quotemate-staging throughout; `composeServiceReport` + `sendServiceReport` functions already live in prod (additive, auth-gated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)