### PR TITLE
fix(payments): manual Record Payment reachable from Take Payment (no Square required)

### DIFF
--- a/src/components/TakePaymentSheet.test.tsx
+++ b/src/components/TakePaymentSheet.test.tsx
@@ -1,0 +1,139 @@
+// @vitest-environment jsdom
+/**
+ * Regression tests for the manual "Record a payment" path in TakePaymentSheet.
+ *
+ * Before Jul 2026 the sheet offered Square methods only, and its entry
+ * points were gated on a Square connection — so a tradie who never
+ * connected Square (or whose customer paid by bank transfer / cash) had no
+ * reachable way to log a payment on an unpaid invoice. The manual row must
+ * render for invoices, route with the right invoice id, and work with zero
+ * Square setup; the Square rows now gate themselves instead.
+ */
+import React from 'react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+
+// Heavy native/expo dependency graphs irrelevant to the sheet's row logic —
+// same approach as StickyJobActionBar.test.tsx / JobCard.ghost.test.tsx.
+vi.mock('@expo/vector-icons/MaterialCommunityIcons', () => ({ default: () => null }));
+vi.mock('react-native-paper', () => ({
+  DefaultTheme: { colors: {} },
+  MD3DarkTheme: { colors: {} },
+  Text: ({ children }: any) => React.createElement('span', null, children),
+  Button: ({ children, onPress }: any) =>
+    React.createElement('button', { onClick: onPress }, children),
+}));
+vi.mock('../services/storeReviewService', () => ({
+  maybeRequestReview: vi.fn(async () => {}),
+}));
+vi.mock('../services/squarePayments', () => ({
+  takeInAppPayment: vi.fn(async () => {}),
+}));
+vi.mock('../services/squareService', () => ({
+  mintInvoicePaymentLink: vi.fn(async () => ({ paymentLinkUrl: 'https://sq.link/x' })),
+  mintQuoteFullPaymentLink: vi.fn(async () => ({ paymentLinkUrl: 'https://sq.link/x' })),
+  mintQuoteDepositPaymentLink: vi.fn(async () => ({ paymentLinkUrl: 'https://sq.link/x' })),
+}));
+vi.mock('../hooks/useTapToPayEnabled', () => ({
+  useTapToPayEnabled: () => ({ enabled: false, reason: 'pending_apple' }),
+}));
+vi.mock('../store/useStore', () => ({
+  useStore: () => ({ businessSettings: null }),
+}));
+
+import { TakePaymentSheet, type TakePaymentTarget } from './TakePaymentSheet';
+import * as squareService from '../services/squareService';
+
+const invoiceTarget: TakePaymentTarget = {
+  kind: 'invoice',
+  invoiceId: 'inv-42',
+  total: 1200,
+  paidAmount: 0,
+  jobName: 'Kitchen cabinets',
+  invoiceNumber: 'INV-0042',
+};
+
+const depositTarget: TakePaymentTarget = {
+  kind: 'quote_deposit',
+  quoteId: 'quote-7',
+  depositAmount: 300,
+  depositPaid: 0,
+  total: 1200,
+  jobName: 'Kitchen cabinets',
+};
+
+function renderSheet(overrides: Partial<React.ComponentProps<typeof TakePaymentSheet>> = {}) {
+  const props = {
+    visible: true,
+    target: invoiceTarget,
+    onDismiss: vi.fn(),
+    onError: vi.fn(),
+    ...overrides,
+  };
+  return { ...render(<TakePaymentSheet {...props} />), props };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('TakePaymentSheet manual "Record a payment" row', () => {
+  it('renders for an invoice target and fires onRecordManualPayment with the invoice id', () => {
+    const onRecordManualPayment = vi.fn();
+    const { getByText, props } = renderSheet({ onRecordManualPayment });
+
+    fireEvent.click(getByText('Record a payment'));
+
+    expect(onRecordManualPayment).toHaveBeenCalledWith('inv-42');
+    expect(props.onDismiss).toHaveBeenCalled();
+  });
+
+  it('does not render for quote deposit targets (no manual deposit path exists)', () => {
+    const { queryByText } = renderSheet({
+      target: depositTarget,
+      onRecordManualPayment: vi.fn(),
+    });
+    expect(queryByText('Record a payment')).toBeNull();
+  });
+
+  it('does not render when no handler is wired', () => {
+    const { queryByText } = renderSheet();
+    expect(queryByText('Record a payment')).toBeNull();
+  });
+
+  it('works without any Square gate — no ensureSquareConnected prop required', () => {
+    const onRecordManualPayment = vi.fn();
+    const { getByText } = renderSheet({
+      onRecordManualPayment,
+      ensureSquareConnected: undefined,
+    });
+    fireEvent.click(getByText('Record a payment'));
+    expect(onRecordManualPayment).toHaveBeenCalledWith('inv-42');
+  });
+});
+
+describe('TakePaymentSheet Square rows gate themselves', () => {
+  it('Share Pay Link aborts (no link minted) when Square is not connected', async () => {
+    const ensureSquareConnected = vi.fn(async () => false);
+    const { getByText, props } = renderSheet({ ensureSquareConnected });
+
+    fireEvent.click(getByText('Share Pay Link'));
+
+    await waitFor(() => expect(ensureSquareConnected).toHaveBeenCalled());
+    expect(squareService.mintInvoicePaymentLink).not.toHaveBeenCalled();
+    // The guard has already routed to Square settings; the sheet must close
+    // so the tradie isn't stranded behind a modal.
+    await waitFor(() => expect(props.onDismiss).toHaveBeenCalled());
+  });
+
+  it('Share Pay Link proceeds to mint a link when Square is connected', async () => {
+    const ensureSquareConnected = vi.fn(async () => true);
+    const { getByText } = renderSheet({ ensureSquareConnected });
+
+    fireEvent.click(getByText('Share Pay Link'));
+
+    await waitFor(() =>
+      expect(squareService.mintInvoicePaymentLink).toHaveBeenCalledWith('inv-42'),
+    );
+  });
+});

--- a/src/components/TakePaymentSheet.test.tsx
+++ b/src/components/TakePaymentSheet.test.tsx
@@ -34,8 +34,13 @@ vi.mock('../services/squareService', () => ({
   mintQuoteFullPaymentLink: vi.fn(async () => ({ paymentLinkUrl: 'https://sq.link/x' })),
   mintQuoteDepositPaymentLink: vi.fn(async () => ({ paymentLinkUrl: 'https://sq.link/x' })),
 }));
+// Mutable so individual tests can flip Tap to Pay on and exercise the
+// card-payment guard; reset to disabled in beforeEach.
+const tapToPay = vi.hoisted(() => ({
+  state: { enabled: false, reason: 'pending_apple' } as any,
+}));
 vi.mock('../hooks/useTapToPayEnabled', () => ({
-  useTapToPayEnabled: () => ({ enabled: false, reason: 'pending_apple' }),
+  useTapToPayEnabled: () => tapToPay.state,
 }));
 vi.mock('../store/useStore', () => ({
   useStore: () => ({ businessSettings: null }),
@@ -43,6 +48,7 @@ vi.mock('../store/useStore', () => ({
 
 import { TakePaymentSheet, type TakePaymentTarget } from './TakePaymentSheet';
 import * as squareService from '../services/squareService';
+import * as squarePayments from '../services/squarePayments';
 
 const invoiceTarget: TakePaymentTarget = {
   kind: 'invoice',
@@ -75,6 +81,7 @@ function renderSheet(overrides: Partial<React.ComponentProps<typeof TakePaymentS
 
 beforeEach(() => {
   vi.clearAllMocks();
+  tapToPay.state = { enabled: false, reason: 'pending_apple' };
 });
 
 describe('TakePaymentSheet manual "Record a payment" row', () => {
@@ -134,6 +141,33 @@ describe('TakePaymentSheet Square rows gate themselves', () => {
 
     await waitFor(() =>
       expect(squareService.mintInvoicePaymentLink).toHaveBeenCalledWith('inv-42'),
+    );
+  });
+
+  it('Tap to Pay aborts (no charge attempted) when Square is not connected', async () => {
+    tapToPay.state = { enabled: true };
+    const ensureSquareConnected = vi.fn(async () => false);
+    const { getByText, props } = renderSheet({ ensureSquareConnected });
+
+    fireEvent.click(getByText('Tap to Pay / Card Entry'));
+
+    await waitFor(() => expect(ensureSquareConnected).toHaveBeenCalled());
+    expect(squarePayments.takeInAppPayment).not.toHaveBeenCalled();
+    await waitFor(() => expect(props.onDismiss).toHaveBeenCalled());
+  });
+
+  it('Tap to Pay proceeds to charge when Square is connected', async () => {
+    tapToPay.state = { enabled: true };
+    const ensureSquareConnected = vi.fn(async () => true);
+    const { getByText } = renderSheet({ ensureSquareConnected });
+
+    fireEvent.click(getByText('Tap to Pay / Card Entry'));
+
+    await waitFor(() => expect(squarePayments.takeInAppPayment).toHaveBeenCalled());
+    expect(squarePayments.takeInAppPayment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        target: { kind: 'invoice', invoiceId: 'inv-42' },
+      }),
     );
   });
 });

--- a/src/components/TakePaymentSheet.tsx
+++ b/src/components/TakePaymentSheet.tsx
@@ -172,14 +172,16 @@ export function TakePaymentSheet({
 
   const handleTakeCardPayment = async () => {
     if (chargingCard || amounts.remaining <= 0) return;
-    // Square-only path: route to settings if not connected. The guard has
-    // already navigated away, so dismiss to avoid a stranded modal over it.
-    if (ensureSquareConnected && !(await ensureSquareConnected())) {
-      onDismiss();
-      return;
-    }
     setChargingCard(true);
     try {
+      // Square-only path: route to settings if not connected. Runs inside
+      // the spinner window (the check is a network round-trip) and the
+      // guard has already navigated away, so dismiss to avoid a stranded
+      // modal over the settings screen.
+      if (ensureSquareConnected && !(await ensureSquareConnected())) {
+        onDismiss();
+        return;
+      }
       // Bake the passthrough surcharge (if opted in) into the charged amount
       // so the customer sees/pays the inflated total. The app fee (our cut)
       // is computed off the CHARGED amount so we also earn on the surcharge.
@@ -226,14 +228,16 @@ export function TakePaymentSheet({
 
   const handleShareLink = async () => {
     if (sharing) return;
-    // Square-only path: route to settings if not connected. The guard has
-    // already navigated away, so dismiss to avoid a stranded modal over it.
-    if (ensureSquareConnected && !(await ensureSquareConnected())) {
-      onDismiss();
-      return;
-    }
     setSharing(true);
     try {
+      // Square-only path: route to settings if not connected. Runs inside
+      // the spinner window (the check is a network round-trip) and the
+      // guard has already navigated away, so dismiss to avoid a stranded
+      // modal over the settings screen.
+      if (ensureSquareConnected && !(await ensureSquareConnected())) {
+        onDismiss();
+        return;
+      }
       const result =
         target.kind === 'invoice'
           ? await squareService.mintInvoicePaymentLink(target.invoiceId)

--- a/src/components/TakePaymentSheet.tsx
+++ b/src/components/TakePaymentSheet.tsx
@@ -70,6 +70,19 @@ interface TakePaymentSheetProps {
   target: TakePaymentTarget | null;
   onDismiss: () => void;
   onError: (message: string) => void;
+  /**
+   * Route to the manual-recording flow (RecordPaymentScreen) for an already-
+   * received bank transfer / cash / cheque. Only wired for invoice targets —
+   * quotes have no manual deposit path. When omitted, the row is hidden.
+   */
+  onRecordManualPayment?: (invoiceId: string) => void;
+  /**
+   * Square connection gate. The sheet always opens (so manual recording works
+   * with zero Square setup); the Square-only rows call this before doing any
+   * Square work and, when it resolves false, it has already routed the tradie
+   * to the Square settings screen. When omitted, the rows proceed unguarded.
+   */
+  ensureSquareConnected?: () => Promise<boolean>;
 }
 
 function describeAmounts(
@@ -111,6 +124,8 @@ export function TakePaymentSheet({
   target,
   onDismiss,
   onError,
+  onRecordManualPayment,
+  ensureSquareConnected,
 }: TakePaymentSheetProps) {
   const [sharing, setSharing] = useState(false);
   const [chargingCard, setChargingCard] = useState(false);
@@ -157,6 +172,12 @@ export function TakePaymentSheet({
 
   const handleTakeCardPayment = async () => {
     if (chargingCard || amounts.remaining <= 0) return;
+    // Square-only path: route to settings if not connected. The guard has
+    // already navigated away, so dismiss to avoid a stranded modal over it.
+    if (ensureSquareConnected && !(await ensureSquareConnected())) {
+      onDismiss();
+      return;
+    }
     setChargingCard(true);
     try {
       // Bake the passthrough surcharge (if opted in) into the charged amount
@@ -205,6 +226,12 @@ export function TakePaymentSheet({
 
   const handleShareLink = async () => {
     if (sharing) return;
+    // Square-only path: route to settings if not connected. The guard has
+    // already navigated away, so dismiss to avoid a stranded modal over it.
+    if (ensureSquareConnected && !(await ensureSquareConnected())) {
+      onDismiss();
+      return;
+    }
     setSharing(true);
     try {
       const result =
@@ -398,6 +425,20 @@ export function TakePaymentSheet({
             onPress={handleShareLink}
             loading={sharing}
           />
+
+          {/* Manual recording — invoice only (quotes have no manual deposit
+              path). No Square guard: works with zero Square setup. */}
+          {target.kind === 'invoice' && onRecordManualPayment && (
+            <MethodRow
+              icon="cash-multiple"
+              title="Record a payment"
+              subtitle="Bank transfer, cash or cheque you've already received."
+              onPress={() => {
+                onDismiss();
+                onRecordManualPayment(target.invoiceId);
+              }}
+            />
+          )}
 
           <Button
             mode="text"

--- a/src/hooks/useJobActionsSheet.tsx
+++ b/src/hooks/useJobActionsSheet.tsx
@@ -151,7 +151,8 @@ export function useJobActionsSheet(
       case 'takePayment': {
         const doc = primaryDocForJob(job);
         if (!doc) return;
-        if (!(await ensureSquareConnectedForPayment(navigation))) break;
+        // No Square gate here — the sheet's manual "Record a payment" row
+        // must work with zero Square setup; the Square rows gate themselves.
         if (doc.type === 'invoice') {
           setTakePaymentTarget({
             kind: 'invoice',
@@ -371,6 +372,10 @@ export function useJobActionsSheet(
         target={takePaymentTarget}
         onDismiss={() => setTakePaymentTarget(null)}
         onError={(message) => Alert.alert('Payment error', message)}
+        onRecordManualPayment={(invoiceId) =>
+          navigation.navigate('RecordPayment', { invoiceId })
+        }
+        ensureSquareConnected={() => ensureSquareConnectedForPayment(navigation)}
       />
 
       {followUpState ? (

--- a/src/screens/NewQuote/JobPreviewScreen.tsx
+++ b/src/screens/NewQuote/JobPreviewScreen.tsx
@@ -749,7 +749,9 @@ export function JobPreviewScreen() {
                       : 'Tap to Pay'
                 }
                 onPress={async () => {
-                  if (!(await ensureSquareConnectedForPayment(navigation))) return;
+                  // No Square gate here — the sheet's manual "Record a
+                  // payment" row must work with zero Square setup; the
+                  // Square rows gate themselves.
                   if (liveDoc.type === 'invoice') {
                     setTakePaymentTarget({
                       kind: 'invoice',
@@ -796,6 +798,10 @@ export function JobPreviewScreen() {
         target={takePaymentTarget}
         onDismiss={() => setTakePaymentTarget(null)}
         onError={(message) => Alert.alert('Payment error', message)}
+        onRecordManualPayment={(invoiceId) =>
+          navigation.navigate('RecordPayment', { invoiceId })
+        }
+        ensureSquareConnected={() => ensureSquareConnectedForPayment(navigation)}
       />
 
       {/* Banner overlay — rendered last so it's on top. Deliberately no

--- a/src/screens/ViewJobScreen.tsx
+++ b/src/screens/ViewJobScreen.tsx
@@ -279,7 +279,8 @@ export function ViewJobScreen() {
   const handlePaymentChipPress = async (doc: Document) => {
     const state = derivePaymentState(doc);
     if (state === 'unpaid' && Number(doc.total) > 0) {
-      if (!(await ensureSquareConnectedForPayment(navigation))) return;
+      // No Square gate here — the sheet's manual "Record a payment" row must
+      // work with zero Square setup; the Square rows gate themselves.
       openTakePaymentForDoc(doc);
       return;
     }
@@ -392,7 +393,6 @@ export function ViewJobScreen() {
           break;
         case 'takeDeposit':
           if (actionableDoc && actionableDoc.type === 'quote') {
-            if (!(await ensureSquareConnectedForPayment(navigation))) break;
             openTakePaymentForDoc(actionableDoc);
           }
           break;
@@ -459,7 +459,6 @@ export function ViewJobScreen() {
           break;
         case 'takeFinalPayment':
           if (actionableDoc && actionableDoc.type === 'invoice') {
-            if (!(await ensureSquareConnectedForPayment(navigation))) break;
             openTakePaymentForDoc(actionableDoc);
           }
           break;
@@ -593,7 +592,6 @@ export function ViewJobScreen() {
     switch (action) {
       case 'takePayment':
         if (primaryDoc) {
-          if (!(await ensureSquareConnectedForPayment(navigation))) break;
           openTakePaymentForDoc(primaryDoc);
         }
         break;
@@ -932,6 +930,10 @@ export function ViewJobScreen() {
         onError={(message) =>
           showAlert({ type: 'error', title: 'Payment error', message })
         }
+        onRecordManualPayment={(invoiceId) =>
+          navigation.navigate('RecordPayment', { invoiceId })
+        }
+        ensureSquareConnected={() => ensureSquareConnectedForPayment(navigation)}
       />
 
 


### PR DESCRIPTION
## Problem

A paying customer (cabinet maker, Android) reported he couldn't work out how to mark an invoice **paid in full** or log a manually-received payment — tapping **Take Payment** showed only Square options. The capability already existed (`RecordPaymentScreen` + the automatic customer paid-receipt email) but was unreachable:

1. `TakePaymentSheet` offered Square methods only (Tap to Pay + Share Pay Link)
2. The manual **Log Payment** action only appeared once an invoice was already `partially_paid`
3. Every entry point to the sheet was gated on `ensureSquareConnectedForPayment`, so a tradie with no Square account couldn't reach any payment surface at all

## Change

- **TakePaymentSheet**: new "Record a payment" method row for invoice targets ("Bank transfer, cash or cheque you've already received.") — dismisses the sheet and routes to the existing `RecordPaymentScreen` via a new optional `onRecordManualPayment` callback. No new screens, no new plumbing.
- **Square self-gating**: the Square-connected check moves from the sheet's entry points onto the Square rows themselves (new optional `ensureSquareConnected` prop). The sheet always opens; tapping a Square row without Square connected routes to Square settings and closes the sheet. Manual recording works with zero Square setup.
- **Entry points un-gated** at all three call sites: `ViewJobScreen` (payment chip, takeDeposit, takeFinalPayment, actions-sheet takePayment), `JobPreviewScreen` footer button, and `useJobActionsSheet`. `tapToPayDraft` deliberately keeps its gate — it flips the quote to accepted before opening the sheet, and accepting a quote you can't collect on is still worth guarding.
- Quote-deposit targets don't get the manual row (no manual deposit path exists; building one is out of scope).

## Tests

New `src/components/TakePaymentSheet.test.tsx` (vitest + react-native-web, full suite green: 84 files / 960 tests, `tsc --noEmit` clean):

- renders for an invoice target and fires `onRecordManualPayment` with the invoice id
- does not render for quote deposit targets (no manual deposit path exists)
- does not render when no handler is wired
- works without any Square gate — no `ensureSquareConnected` prop required
- **regression**: Share Pay Link aborts (no link minted) when Square is not connected, and the sheet closes so the tradie isn't stranded behind a modal
- Share Pay Link proceeds to mint a link when Square is connected

🤖 Generated with [Claude Code](https://claude.com/claude-code)