### PR TITLE
fix(functions): allow staging web origin in CORS allowlist

### DIFF
--- a/functions/src/corsOrigins.test.ts
+++ b/functions/src/corsOrigins.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Regression tests for the HTTP-function CORS allowlist.
+ *
+ * Jul 2026: the staging hosting site (quotemate-staging.web.app) was missing
+ * from allowedOrigins, so every fetch from the staging web build failed as an
+ * opaque "TypeError: Failed to fetch" — presenting as silently-disabled send
+ * buttons (empty generated email body → disabled Send Invoice) and a dead
+ * Mate/Square/price-search surface for staging testers.
+ *
+ * index.ts pulls in the whole functions graph, so assert against the source
+ * text instead of importing it — keeps this test dependency-free and fast.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+function extractAllowedOrigins(): string[] {
+  const src = readFileSync(join(__dirname, 'index.ts'), 'utf8');
+  const match = src.match(/export const allowedOrigins = \[([\s\S]*?)\];/);
+  if (!match) throw new Error('allowedOrigins array not found in index.ts');
+  return [...match[1].matchAll(/'([^']+)'/g)].map((m) => m[1]);
+}
+
+describe('functions CORS allowlist', () => {
+  it('includes the staging hosting origins (regression: silent staging-web fetch failures)', () => {
+    const origins = extractAllowedOrigins();
+    expect(origins).toContain('https://quotemate-staging.web.app');
+    expect(origins).toContain('https://quotemate-staging.firebaseapp.com');
+  });
+
+  it('still includes every production origin', () => {
+    const origins = extractAllowedOrigins();
+    expect(origins).toContain('https://hansendev.web.app');
+    expect(origins).toContain('https://hansendev.firebaseapp.com');
+    expect(origins).toContain('https://quotemateapp.au');
+    expect(origins).toContain('https://www.quotemateapp.au');
+  });
+
+  it('contains only https origins with no trailing slashes', () => {
+    for (const o of extractAllowedOrigins()) {
+      expect(o).toMatch(/^https:\/\/[^/]+$/);
+    }
+  });
+});

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -336,12 +336,19 @@ async function recordAffiliateEarning(
 }
 
 // CORS configuration - whitelist allowed origins
-const allowedOrigins = [
+// Exported for tests: web builds silently lose every HTTP function when
+// their hosting origin is missing from this list (see fix/staging-web-cors).
+export const allowedOrigins = [
   'https://us-central1-hansendev.cloudfunctions.net',
   'https://hansendev.web.app',
   'https://hansendev.firebaseapp.com',
   'https://quotemateapp.au',
   'https://www.quotemateapp.au',
+  // Staging hosting site (deploy:staging) — without these, every HTTP
+  // function call from the staging web build dies as an opaque
+  // "Failed to fetch", which presents as silently-disabled send buttons.
+  'https://quotemate-staging.web.app',
+  'https://quotemate-staging.firebaseapp.com',
 ];
 
 const corsHandler = cors({


### PR DESCRIPTION
## Problem

`https://quotemate-staging.web.app` (the `deploy:staging` hosting site) is not in the functions CORS allowlist, so **every** HTTP function call from the staging web build dies as an opaque `TypeError: Failed to fetch`:

- **Send Invoice/Quote silently does nothing** — email body generation fails, body stays empty, and the Send button is disabled by `!emailBody.trim()` with no error shown (found while verifying #56 on staging)
- Mate (`assistantChat`/`assistantToken`), Square connection checks, price search, supplier import, and `composeServiceReport` are equally dead for staging testers

Verified live from the staging origin: `fetch(...) → FETCH FAILED (CORS)`.

## Change

- Add `https://quotemate-staging.web.app` + `https://quotemate-staging.firebaseapp.com` to `allowedOrigins`
- Export the list and add `corsOrigins.test.ts` (staging origins present, production origins intact, https-only shape)

## Tests

`functions` build clean; vitest suite green (427 tests) including the 3 new named cases.

## Deploy note

Functions must be redeployed for this to take effect: `npx firebase deploy --only functions --project hansendev`. Note this ships everything currently on main (incl. #55 service-report functions if not yet deployed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)