### PR TITLE
fix(quotes): stale "Continue draft" banner after quote→invoice conversion

### DIFF
--- a/src/store/convertDocumentToInvoice.test.ts
+++ b/src/store/convertDocumentToInvoice.test.ts
@@ -1,0 +1,119 @@
+// @vitest-environment jsdom
+/**
+ * Regression tests for convertDocumentToInvoice's legacy source-quote stamp.
+ *
+ * Jul 2026: the unified convert path flipped the Document to type 'invoice'
+ * but never stamped the legacy quotes row, leaving it status 'draft' with a
+ * wizard draftStep. The dashboard then offered "Continue draft" for a job
+ * that was already invoiced (and paid). The stamp must also run BEFORE the
+ * unified doc flips type, because saveQuote's forward-only type guard
+ * re-routes to saveInvoice once the doc is an invoice — which would swallow
+ * the stamp entirely.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('@react-native-async-storage/async-storage', () => ({
+  default: { getItem: vi.fn(async () => null), setItem: vi.fn(async () => {}), removeItem: vi.fn(async () => {}) },
+}));
+vi.mock('expo-keep-awake', () => ({
+  activateKeepAwakeAsync: vi.fn(async () => {}),
+  deactivateKeepAwake: vi.fn(async () => {}),
+}));
+// The store's import graph reaches most expo-* native modules; none of their
+// behaviour matters for the conversion-stamp logic under test.
+vi.mock('expo-constants', () => ({ default: { expoConfig: {} } }));
+vi.mock('expo-haptics', () => ({ impactAsync: vi.fn(), notificationAsync: vi.fn(), selectionAsync: vi.fn(), ImpactFeedbackStyle: {}, NotificationFeedbackType: {} }));
+vi.mock('expo-file-system', () => ({ documentDirectory: '/tmp/', cacheDirectory: '/tmp/', writeAsStringAsync: vi.fn(), readAsStringAsync: vi.fn(), getInfoAsync: vi.fn(), EncodingType: { UTF8: 'utf8', Base64: 'base64' } }));
+vi.mock('expo-print', () => ({ printToFileAsync: vi.fn() }));
+vi.mock('expo-sharing', () => ({ shareAsync: vi.fn(), isAvailableAsync: vi.fn(async () => false) }));
+vi.mock('expo-store-review', () => ({ requestReview: vi.fn(), hasAction: vi.fn(async () => false), isAvailableAsync: vi.fn(async () => false) }));
+vi.mock('expo-web-browser', () => ({ openBrowserAsync: vi.fn(), openAuthSessionAsync: vi.fn(), maybeCompleteAuthSession: vi.fn() }));
+vi.mock('expo-auth-session', () => ({ makeRedirectUri: vi.fn(() => 'redirect://'), useAuthRequest: vi.fn(), AuthRequest: class {}, ResponseType: {} }));
+vi.mock('expo-crypto', () => ({ digestStringAsync: vi.fn(async () => 'hash'), CryptoDigestAlgorithm: { SHA256: 'SHA-256' }, randomUUID: vi.fn(() => 'uuid') }));
+vi.mock('expo-contacts', () => ({ requestPermissionsAsync: vi.fn(), getContactsAsync: vi.fn() }));
+vi.mock('expo-av', () => ({ Audio: { Sound: class {}, setAudioModeAsync: vi.fn() } }));
+vi.mock('expo-image-manipulator', () => ({ manipulateAsync: vi.fn(), SaveFormat: {} }));
+vi.mock('expo-mail-composer', () => ({ composeAsync: vi.fn(), isAvailableAsync: vi.fn(async () => false) }));
+
+import { useStore } from './useStore';
+import type { Document } from '../types/document';
+import type { Quote } from '../types';
+
+const DOC_ID = 'doc-legacy-1';
+
+function quoteDoc(): Document {
+  return {
+    id: DOC_ID,
+    type: 'quote',
+    stage: 'draft',
+    total: 960,
+    job: { id: 'job-1', name: 'Test job' },
+  } as unknown as Document;
+}
+
+function legacyQuote(overrides: Partial<Quote> = {}): Quote {
+  return {
+    id: DOC_ID,
+    status: 'draft',
+    draftStep: 'JobPreview',
+    total: 960,
+    updatedAt: new Date(),
+    ...overrides,
+  } as Quote;
+}
+
+beforeEach(() => {
+  useStore.setState({
+    documents: [quoteDoc()],
+    quotes: [legacyQuote()],
+    getNextInvoiceNumber: async () => 'INV-9',
+  } as any);
+});
+
+describe('convertDocumentToInvoice legacy stamp', () => {
+  it('stamps invoiceId + invoicedAt on the legacy source quote', async () => {
+    const saveQuote = vi.fn(async () => {});
+    useStore.setState({ saveQuote } as any);
+
+    await useStore.getState().convertDocumentToInvoice(DOC_ID);
+
+    expect(saveQuote).toHaveBeenCalledTimes(1);
+    const stamped = saveQuote.mock.calls[0][0] as Quote;
+    expect(stamped.invoiceId).toBe(DOC_ID);
+    expect(stamped.invoicedAt).toBeInstanceOf(Date);
+    expect(stamped.draftStep).toBeUndefined();
+  });
+
+  it('stamps BEFORE the unified doc flips to invoice (saveQuote type-guard ordering)', async () => {
+    let docTypeAtStampTime: string | undefined;
+    const saveQuote = vi.fn(async () => {
+      docTypeAtStampTime = useStore.getState().documents.find((d) => d.id === DOC_ID)?.type;
+    });
+    useStore.setState({ saveQuote } as any);
+
+    await useStore.getState().convertDocumentToInvoice(DOC_ID);
+
+    expect(docTypeAtStampTime).toBe('quote');
+    expect(useStore.getState().documents.find((d) => d.id === DOC_ID)?.type).toBe('invoice');
+  });
+
+  it('does not re-stamp a quote that already carries an invoiceId', async () => {
+    useStore.setState({ quotes: [legacyQuote({ invoiceId: 'earlier-invoice' })] } as any);
+    const saveQuote = vi.fn(async () => {});
+    useStore.setState({ saveQuote } as any);
+
+    await useStore.getState().convertDocumentToInvoice(DOC_ID);
+
+    expect(saveQuote).not.toHaveBeenCalled();
+  });
+
+  it('still converts the document when the legacy stamp fails', async () => {
+    const saveQuote = vi.fn(async () => { throw new Error('offline'); });
+    useStore.setState({ saveQuote } as any);
+
+    const converted = await useStore.getState().convertDocumentToInvoice(DOC_ID);
+
+    expect(converted.type).toBe('invoice');
+    expect(useStore.getState().documents.find((d) => d.id === DOC_ID)?.type).toBe('invoice');
+  });
+});

--- a/src/store/useStore.ts
+++ b/src/store/useStore.ts
@@ -2433,6 +2433,31 @@ export const useStore = create<AppState>((set, get) => ({
       legacyInvoiceId: existing.id,
       updatedAt: now,
     };
+    // Stamp the legacy source quote BEFORE flipping the unified doc — the
+    // legacy createInvoiceFromQuote path stamps its source quote, but the
+    // unified path used to skip it, leaving the row as status 'draft' with
+    // a wizard draftStep. That zombie fed the dashboard's "Continue draft"
+    // banner for a job that was already invoiced (and possibly paid).
+    // Ordering matters: once the unified doc is type 'invoice', saveQuote's
+    // forward-only type guard re-routes to saveInvoice and the stamp would
+    // never land on the legacy quotes row. (draftStep only clears locally —
+    // firestoreService strips undefined under merge — so pickDashboardDraft
+    // keys off invoiceId/invoicedAt, which do persist.)
+    const sourceQuote = get().quotes.find((q) => q.id === documentId);
+    if (sourceQuote && !sourceQuote.invoiceId) {
+      try {
+        await get().saveQuote({
+          ...sourceQuote,
+          invoiceId: documentId,
+          invoicedAt: new Date(now),
+          draftStep: undefined,
+          updatedAt: new Date(now),
+        });
+      } catch {
+        // Non-fatal — pickDashboardDraft also excludes invoiced quotes, so
+        // the banner stays correct even if this stamp doesn't land.
+      }
+    }
     set((state) => ({
       documents: state.documents.map((d) => (d.id === documentId ? optimistic : d)),
     }));

--- a/src/utils/dashboardDraft.test.ts
+++ b/src/utils/dashboardDraft.test.ts
@@ -65,6 +65,26 @@ describe('pickDashboardDraft', () => {
   it('returns null for an empty quote list', () => {
     expect(pickDashboardDraft([], NOW)).toBeNull();
   });
+
+  // Regression (Jul 2026): converting a wizard draft to an invoice via the
+  // unified convertDocumentToInvoice path left the legacy quote row as
+  // status 'draft' with a draftStep, so the banner offered "Continue draft"
+  // for a job that was already invoiced — and paid.
+  it('ignores a draft that has been converted to an invoice (invoiceId stamped)', () => {
+    const converted = draft({ id: 'converted', invoiceId: 'converted' });
+    expect(pickDashboardDraft([converted], NOW)).toBeNull();
+  });
+
+  it('ignores a draft with invoicedAt stamped even without invoiceId', () => {
+    const invoiced = draft({ id: 'invoiced', invoicedAt: new Date(NOW - 1000) });
+    expect(pickDashboardDraft([invoiced], NOW)).toBeNull();
+  });
+
+  it('an invoiced zombie does not shadow an older genuine draft', () => {
+    const zombie = draft({ id: 'zombie', invoiceId: 'zombie', updatedAt: new Date(NOW - 1000).toISOString() });
+    const genuine = draft({ id: 'genuine', updatedAt: new Date(NOW - 2 * 60 * 60 * 1000).toISOString() });
+    expect(pickDashboardDraft([zombie, genuine], NOW)?.id).toBe('genuine');
+  });
 });
 
 describe('excludeDraftJob', () => {

--- a/src/utils/dashboardDraft.ts
+++ b/src/utils/dashboardDraft.ts
@@ -19,7 +19,11 @@ export const DRAFT_BANNER_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
  */
 export function pickDashboardDraft(quotes: Quote[], now: number = Date.now()): Quote | null {
   const newest = quotes
-    .filter((q) => q.status === 'draft' && q.draftStep)
+    // An invoiced quote is finished work, not an in-progress draft — the
+    // unified convert path used to leave the legacy row as status 'draft',
+    // so the invoiceId/invoicedAt check also heals rows stamped before
+    // convertDocumentToInvoice started clearing them.
+    .filter((q) => q.status === 'draft' && q.draftStep && !q.invoiceId && !q.invoicedAt)
     .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())[0];
   if (!newest) return null;
   const age = now - new Date(newest.updatedAt).getTime();


### PR DESCRIPTION
## Problem

Found while verifying #56 on staging: convert a wizard-draft quote to an invoice (JobPreview's Quote/Invoice toggle, ViewJob convert, or Mate flows), and the dashboard keeps showing a **"Continue draft"** banner for that job — even after the invoice is paid. Root cause: the unified `convertDocumentToInvoice` path flips the unified Document but never stamps the legacy `quotes` row (only the legacy `createInvoiceFromQuote` fallback stamps its source quote), so the row stays `status: 'draft'` with a wizard `draftStep` — exactly what `pickDashboardDraft` looks for. The zombie banner persists across reloads (it's in Firestore) and its only escape is a destructive delete.

## Change

- **`convertDocumentToInvoice`**: stamp `invoiceId`/`invoicedAt` on the legacy source quote, mirroring the legacy path. The stamp runs **before** the unified doc flips type — after the flip, `saveQuote`'s forward-only type guard re-routes to `saveInvoice` and the stamp would be silently swallowed. Non-fatal on failure; idempotent (skips already-stamped quotes).
- **`pickDashboardDraft`**: exclude quotes carrying `invoiceId` or `invoicedAt` — an invoiced quote is finished work, not an in-progress draft. This also heals accounts already polluted by the old behaviour.

## Tests (all green: 1,023 total, tsc clean)

`src/utils/dashboardDraft.test.ts`:
- ignores a draft that has been converted to an invoice (invoiceId stamped)
- ignores a draft with invoicedAt stamped even without invoiceId
- an invoiced zombie does not shadow an older genuine draft

`src/store/convertDocumentToInvoice.test.ts` (new):
- stamps invoiceId + invoicedAt on the legacy source quote
- stamps BEFORE the unified doc flips to invoice (saveQuote type-guard ordering)
- does not re-stamp a quote that already carries an invoiceId
- still converts the document when the legacy stamp fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)