### PR TITLE
feat(reports): minified service-report rows on the job view screen

### DIFF
--- a/src/screens/ServiceReport/reportDraft.test.ts
+++ b/src/screens/ServiceReport/reportDraft.test.ts
@@ -8,6 +8,7 @@ import {
   formFromReport,
   latestTechnicianSignature,
   pruneSuggestions,
+  reportRowSummary,
   resumableReportId,
   type ReportFormState,
 } from './reportDraft';
@@ -294,5 +295,55 @@ describe('latestTechnicianSignature', () => {
   it('returns null when no report carries technician ink', () => {
     expect(latestTechnicianSignature([])).toBeNull();
     expect(latestTechnicianSignature([report({})])).toBeNull();
+  });
+});
+
+// Minified report rows on the Job screen — the tradie must see at a glance
+// which visits have dockets and whether each went out to the customer.
+describe('reportRowSummary', () => {
+  const NOW = new Date('2026-07-23T06:00:00Z').getTime();
+
+  it('leads with the service type and shows number + sent date for sent reports', () => {
+    const row = reportRowSummary(
+      {
+        number: 'RP-003',
+        serviceType: 'Aircon service',
+        status: 'sent',
+        sentAt: new Date('2026-07-21T02:00:00Z').getTime(),
+        updatedAt: NOW - 1000,
+      },
+      NOW,
+    );
+    expect(row.title).toBe('Aircon service');
+    expect(row.subtitle).toBe('RP-003 · Sent 21 Jul');
+  });
+
+  it('shows Draft with an edited-ago tail for unfinished reports', () => {
+    const row = reportRowSummary(
+      {
+        number: 'RP-004',
+        serviceType: 'Filter replacement',
+        status: 'draft',
+        updatedAt: NOW - 2 * 60 * 60 * 1000,
+      },
+      NOW,
+    );
+    expect(row.subtitle).toBe('RP-004 · Draft · edited about 2 hours ago');
+  });
+
+  it('falls back to a generic title when serviceType is blank', () => {
+    const row = reportRowSummary(
+      { number: 'RP-001', serviceType: '  ', status: 'draft', updatedAt: NOW },
+      NOW,
+    );
+    expect(row.title).toBe('Service report');
+  });
+
+  it('handles a sent report with no sentAt stamp', () => {
+    const row = reportRowSummary(
+      { number: 'RP-002', serviceType: 'Ducted heating', status: 'sent', updatedAt: NOW },
+      NOW,
+    );
+    expect(row.subtitle).toBe('RP-002 · Sent');
   });
 });

--- a/src/screens/ServiceReport/reportDraft.ts
+++ b/src/screens/ServiceReport/reportDraft.ts
@@ -13,6 +13,8 @@
  * customer-facing document.
  */
 
+import { format, formatDistance } from 'date-fns';
+
 import type { Job, JobPhoto } from '../../../shared/job/types';
 import type {
   ReportChecklistItem,
@@ -243,4 +245,31 @@ export function latestTechnicianSignature(
     if (sig && pathHasInk(sig.svgPath)) return sig;
   }
   return null;
+}
+
+/**
+ * Compact one-line summary for a report row on the Job screen: the service
+ * type leads (that's how the tradie thinks of the visit), with the report
+ * number and lifecycle state underneath. `now` is injectable for tests.
+ */
+export function reportRowSummary(
+  report: Pick<ServiceReport, 'number' | 'serviceType' | 'status' | 'sentAt' | 'updatedAt'>,
+  now: number = Date.now(),
+): { title: string; subtitle: string } {
+  const title = report.serviceType?.trim() || 'Service report';
+  const parts: string[] = [];
+  if (report.number) parts.push(report.number);
+  if (report.status === 'sent') {
+    parts.push(
+      report.sentAt ? `Sent ${format(new Date(report.sentAt), 'd MMM')}` : 'Sent',
+    );
+  } else {
+    parts.push('Draft');
+    if (report.updatedAt) {
+      parts.push(
+        `edited ${formatDistance(new Date(report.updatedAt), new Date(now), { addSuffix: true })}`,
+      );
+    }
+  }
+  return { title, subtitle: parts.join(' · ') };
 }

--- a/src/screens/ViewJobScreen.tsx
+++ b/src/screens/ViewJobScreen.tsx
@@ -28,7 +28,8 @@ import { JobActionsSheet, type JobAction } from '../components/JobActionsSheet';
 import { exportDocumentPDF } from '../utils/pdfGenerator';
 import { canUseServiceReports } from '../utils/reportEntitlement';
 import { reportService } from '../services/reportService';
-import { resumableReportId } from './ServiceReport/reportDraft';
+import { resumableReportId, reportRowSummary } from './ServiceReport/reportDraft';
+import type { ServiceReport } from '../../shared/report/types';
 import { StageSheet } from '../components/StageSheet';
 import { JobStageSheet, stageMetaFor } from '../components/JobStageSheet';
 import {
@@ -117,6 +118,24 @@ export function ViewJobScreen() {
       .catch(() => { if (!cancelled) setReeceConnected(false); });
     return () => { cancelled = true; };
   }, []);
+
+  // Service reports attached to this job — reloaded on focus so a report
+  // saved/sent on the ServiceReport screen shows up when the tradie backs
+  // out to the job. Errors leave the list as-is (rows just don't appear).
+  const [jobReports, setJobReports] = useState<ServiceReport[]>([]);
+  useEffect(() => {
+    if (!jobId) return;
+    let cancelled = false;
+    const load = () => {
+      reportService
+        .listReports(jobId)
+        .then((reports) => { if (!cancelled) setJobReports(reports); })
+        .catch(() => {});
+    };
+    load();
+    const unsubscribe = navigation.addListener('focus', load);
+    return () => { cancelled = true; unsubscribe(); };
+  }, [jobId, navigation]);
   const [notesDirty, setNotesDirty] = useState(false);
   const [notesEditing, setNotesEditing] = useState(false);
 
@@ -186,6 +205,41 @@ export function ViewJobScreen() {
   // "Order from Reece" entry — only when Reece is connected and the doc has
   // at least one Reece-priced material with order identifiers. Slots into
   // the ScopeBlock right under the JobScopeCard via the `extra` prop.
+  // Minified service-report rows for the scope card. Reuses the Reece entry's
+  // row styling so the "extras" under the scope card read as one family.
+  // Tap → reopen that report (draft resumes, sent reports open read-back).
+  const serviceReportRows = jobReports.length > 0 ? (
+    <>
+      {jobReports.map((report) => {
+        const row = reportRowSummary(report);
+        return (
+          <TouchableOpacity
+            key={report.id}
+            style={styles.reeceOrderButton}
+            onPress={() =>
+              navigation.navigate('ServiceReport', {
+                jobId: job.id,
+                reportId: report.id,
+              })
+            }
+            activeOpacity={0.7}
+          >
+            <MaterialCommunityIcons
+              name="clipboard-check-outline"
+              size={20}
+              color={colors.primary}
+            />
+            <View style={{ flex: 1, marginLeft: 12 }}>
+              <Text style={styles.reeceOrderButtonTitle}>{row.title}</Text>
+              <Text style={styles.reeceOrderButtonSubtitle}>{row.subtitle}</Text>
+            </View>
+            <MaterialCommunityIcons name="chevron-right" size={22} color={colors.textMuted} />
+          </TouchableOpacity>
+        );
+      })}
+    </>
+  ) : null;
+
   const reeceOrderEntry =
     reeceConnected === true &&
     primaryDoc?.materials?.some((m) => !!m.reeceItemNumber && !!m.reeceUnitOfMeasure) ? (
@@ -835,7 +889,7 @@ export function ViewJobScreen() {
             onStagePress={setDocStageSheetDoc}
             onPaymentPress={handlePaymentChipPress}
             onConvertToInvoice={handleConvertToInvoice}
-            extra={reeceOrderEntry}
+            extra={<>{serviceReportRows}{reeceOrderEntry}</>}
           />
         ) : null}
 
@@ -856,7 +910,7 @@ export function ViewJobScreen() {
             onStagePress={setDocStageSheetDoc}
             onPaymentPress={handlePaymentChipPress}
             onConvertToInvoice={handleConvertToInvoice}
-            extra={reeceOrderEntry}
+            extra={<>{serviceReportRows}{reeceOrderEntry}</>}
           />
         ) : null}
 
@@ -1012,7 +1066,9 @@ function ScopeBlock({
 }: ScopeBlockProps) {
   if (!primaryDoc) {
     // No doc yet — the sticky bar already offers "Create Quote". Render
-    // an empty-state stub so the section doesn't just vanish.
+    // an empty-state stub so the section doesn't just vanish. `extra`
+    // still renders: a service-visit job can carry reports without ever
+    // having a quote, and those must stay reachable from the job.
     return (
       <WebContainer>
         <Card style={styles.emptyDocsCard}>
@@ -1027,6 +1083,7 @@ function ScopeBlock({
             </Text>
           </View>
         </Card>
+        {extra}
       </WebContainer>
     );
   }


### PR DESCRIPTION
## Problem

Service reports don't appear anywhere on ViewJob. The kebab's "Service Report" action resumes or creates one, but an existing report — draft or sent — is invisible from the job it belongs to. A tradie can't tell at a glance whether a visit has a docket or whether it went to the customer.

## Change

- **Minified report rows** under the scope card, one per report for the job: service type as the title, `RP-00X · Draft · edited 2 hours ago` or `RP-00X · Sent 21 Jul` underneath, chevron to reopen that exact report. Reuses the existing Reece-entry row styling (same `extra` slot) — no new components or patterns.
- **Report-only jobs work too:** the scope card's no-quote empty state now renders the `extra` slot, so a service-visit job with reports but no quote still shows them.
- **Focus reload:** the list refreshes when the screen regains focus, so a report saved or sent on the ServiceReport screen appears immediately on back-out.
- Zero reports → nothing renders (no added clutter).

## Tests (suite green: 1,020, tsc clean)

`reportDraft.test.ts` — new `reportRowSummary` cases:
- leads with the service type and shows number + sent date for sent reports
- shows Draft with an edited-ago tail for unfinished reports
- falls back to a generic title when serviceType is blank
- handles a sent report with no sentAt stamp

🤖 Generated with [Claude Code](https://claude.com/claude-code)