### PR TITLE
fix(trial): server-side trial bootstrap on first quote

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -73,6 +73,7 @@ export {
   leadUnsubscribe,
 } from './leadOutreach';
 export { onQuoteWritten, onInvoiceWritten, mirrorAllDocuments } from './documentMirror';
+export { onQuoteCreatedBootstrapTrial } from './trialBootstrap';
 export { assistantToken } from './assistantToken';
 export { assistantChat } from './assistantChat';
 export { composeServiceReport } from './composeServiceReport';

--- a/functions/src/trialBootstrap.helpers.test.ts
+++ b/functions/src/trialBootstrap.helpers.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { deriveTrialBootstrapWrite, toMillis } from './trialBootstrap.helpers';
+
+const NOW = new Date('2026-07-24T10:00:00.000Z').getTime();
+const QUOTE_AT = new Date('2026-07-24T09:30:00.000Z').getTime();
+
+describe('deriveTrialBootstrapWrite', () => {
+  it('seeds a full subscription doc when none exists (pre-1.47 client)', () => {
+    const write = deriveTrialBootstrapWrite(undefined, QUOTE_AT, NOW);
+    expect(write).not.toBeNull();
+    expect(write!.payload).toMatchObject({
+      isPro: false,
+      quotesThisMonth: 1,
+      freeQuotesLimit: 5,
+      trialStartedAt: '2026-07-24T09:30:00.000Z',
+      trialExpired: false,
+    });
+  });
+
+  it('never writes entitlement keys (PAY-02 deny-list)', () => {
+    const write = deriveTrialBootstrapWrite(undefined, QUOTE_AT, NOW);
+    const denied = ['plan', 'platform', 'productId', 'platformFeeBps', 'subscriptionId'];
+    for (const key of denied) expect(write!.payload).not.toHaveProperty(key);
+  });
+
+  it('stamps only trialStartedAt when the doc exists without one (1.47 client seed)', () => {
+    const write = deriveTrialBootstrapWrite(
+      { isPro: false, quotesThisMonth: 0, trialStartedAt: null },
+      QUOTE_AT,
+      NOW,
+    );
+    expect(Object.keys(write!.payload).sort()).toEqual(['syncedAt', 'trialStartedAt']);
+    expect(write!.payload.trialStartedAt).toBe('2026-07-24T09:30:00.000Z');
+  });
+
+  it('is a no-op when a trial has already started (idempotent on re-fire)', () => {
+    expect(
+      deriveTrialBootstrapWrite({ trialStartedAt: '2026-07-01T00:00:00.000Z' }, QUOTE_AT, NOW),
+    ).toBeNull();
+  });
+
+  it('is a no-op for expired trials (second quote must not restart the clock)', () => {
+    expect(
+      deriveTrialBootstrapWrite(
+        { trialStartedAt: '2026-01-01T00:00:00.000Z', trialExpired: true },
+        QUOTE_AT,
+        NOW,
+      ),
+    ).toBeNull();
+  });
+
+  it('is a no-op for Pro users', () => {
+    expect(deriveTrialBootstrapWrite({ isPro: true }, QUOTE_AT, NOW)).toBeNull();
+  });
+
+  it('falls back to now when the quote createdAt is missing or invalid', () => {
+    const write = deriveTrialBootstrapWrite(undefined, NaN, NOW);
+    expect(write!.payload.trialStartedAt).toBe('2026-07-24T10:00:00.000Z');
+  });
+});
+
+describe('toMillis', () => {
+  it('handles Firestore Timestamp-like objects', () => {
+    expect(toMillis({ toMillis: () => 123 })).toBe(123);
+    expect(toMillis({ toDate: () => new Date(456) })).toBe(456);
+  });
+  it('handles ISO strings, Dates, numbers, and garbage', () => {
+    expect(toMillis('2026-07-24T09:30:00.000Z')).toBe(QUOTE_AT);
+    expect(toMillis(new Date(QUOTE_AT))).toBe(QUOTE_AT);
+    expect(toMillis(QUOTE_AT)).toBe(QUOTE_AT);
+    expect(Number.isNaN(toMillis(null))).toBe(true);
+    expect(Number.isNaN(toMillis('nonsense'))).toBe(true);
+  });
+});

--- a/functions/src/trialBootstrap.helpers.ts
+++ b/functions/src/trialBootstrap.helpers.ts
@@ -1,0 +1,72 @@
+/**
+ * Server-side trial bootstrap (pure helpers).
+ *
+ * The 14-day trial starts on a user's first quote. Historically the CLIENT
+ * stamped trialStartedAt (startTrialIfNeeded → saveSubscriptionStatus), but
+ * the PAY-02 rules deploy (22 Jul 2026) rejects the pre-1.47 client payload
+ * (it includes the server-owned `plan`/`platformFeeBps` keys), so old builds
+ * silently fail to seed users/{uid}/profile/subscription and the trial clock
+ * never starts. onQuoteCreatedBootstrapTrial (trialBootstrap.ts) closes that
+ * gap server-side — and long-term makes trial start server-owned, closing the
+ * "trialStartedAt stays client-writable" weakness noted in firestore.rules.
+ */
+
+export interface TrialBootstrapWrite {
+  /** merge-set payload for users/{uid}/profile/subscription */
+  payload: Record<string, unknown>;
+}
+
+/**
+ * Given the current subscription doc (or undefined when missing) and the
+ * quote's creation time, decide what — if anything — to write.
+ *
+ * Idempotent: returns null whenever a trial is already running/ran (any
+ * trialStartedAt present) or the user is Pro. Never touches entitlement keys.
+ */
+export function deriveTrialBootstrapWrite(
+  subData: Record<string, any> | undefined | null,
+  quoteCreatedAtMs: number,
+  nowMs: number,
+): TrialBootstrapWrite | null {
+  if (subData?.isPro === true) return null;
+  if (subData?.trialStartedAt) return null;
+
+  const startMs = Number.isFinite(quoteCreatedAtMs) ? quoteCreatedAtMs : nowMs;
+  const trialStartedAt = new Date(startMs).toISOString();
+
+  if (subData) {
+    // Doc exists (e.g. seeded by a 1.47+ client with trialStartedAt: null):
+    // just stamp the trial start.
+    return { payload: { trialStartedAt, syncedAt: new Date(nowMs).toISOString() } };
+  }
+
+  // Doc missing entirely (pre-1.47 client whose seed write was denied):
+  // create the same shape the client quota code seeds, minus entitlement keys.
+  const now = new Date(nowMs);
+  const monthStart = new Date(now.getFullYear(), now.getMonth(), 1);
+  const monthEnd = new Date(now.getFullYear(), now.getMonth() + 1, 0, 23, 59, 59);
+  return {
+    payload: {
+      isPro: false,
+      quotesThisMonth: 1,
+      currentPeriodStart: monthStart.toISOString(),
+      currentPeriodEnd: monthEnd.toISOString(),
+      freeQuotesLimit: 5,
+      trialStartedAt,
+      trialExpired: false,
+      dismissedUpgradeBanner: false,
+      syncedAt: now.toISOString(),
+      trialBootstrappedBy: 'onQuoteCreatedBootstrapTrial',
+    },
+  };
+}
+
+/** Best-effort ms-epoch from a Firestore Timestamp | ISO string | Date | ms. */
+export function toMillis(value: any): number {
+  if (value == null) return NaN;
+  if (typeof value === 'number') return value;
+  if (typeof value?.toMillis === 'function') return value.toMillis();
+  if (typeof value?.toDate === 'function') return value.toDate().getTime();
+  const t = new Date(value).getTime();
+  return t;
+}

--- a/functions/src/trialBootstrap.ts
+++ b/functions/src/trialBootstrap.ts
@@ -1,0 +1,34 @@
+/**
+ * Server-side trial bootstrap trigger — see trialBootstrap.helpers.ts for the
+ * full rationale. Stamps trialStartedAt on the user's first quote when the
+ * client couldn't (pre-1.47 builds blocked by the PAY-02 rules) or didn't.
+ *
+ * Runs in a transaction so a concurrent client quota write can't be clobbered:
+ * we re-read the sub doc and merge only the missing fields.
+ */
+
+import * as functions from 'firebase-functions';
+import * as admin from 'firebase-admin';
+
+import { deriveTrialBootstrapWrite, toMillis } from './trialBootstrap.helpers';
+
+const db = () => admin.firestore();
+
+export const onQuoteCreatedBootstrapTrial = functions.firestore
+  .document('users/{userId}/quotes/{quoteId}')
+  .onCreate(async (snap, context) => {
+    const { userId } = context.params as { userId: string };
+    const quoteCreatedAtMs = toMillis(snap.data()?.createdAt);
+    const subRef = db().doc(`users/${userId}/profile/subscription`);
+
+    await db().runTransaction(async (tx) => {
+      const subSnap = await tx.get(subRef);
+      const write = deriveTrialBootstrapWrite(
+        subSnap.exists ? subSnap.data() : undefined,
+        quoteCreatedAtMs,
+        Date.now(),
+      );
+      if (!write) return;
+      tx.set(subRef, write.payload, { merge: true });
+    });
+  });


### PR DESCRIPTION
## Problem
The PAY-02 rules deploy (22 Jul 07:25 UTC) denies any client write to `users/{uid}/profile/subscription` touching `plan`/`platformFeeBps` — which the pre-1.47 client's `saveSubscriptionStatus` payload includes. Old builds (iOS/Android ≤1.46 + current web bundle) silently fail to seed the subscription doc, so `trialStartedAt` is never stamped: every account created since the deploy showed as **free** in the admin CRM while getting an indefinite server-side trial (`resolveServerPlan` treats a missing doc as 'trial').

The quota transaction never rescues it because wizard/Mate quotes go through `saveDraft` first, so `saveQuote` never sees `isNewQuote` and `checkAndIncrementQuota` never runs. Verified against the deployed ruleset in the rules emulator: old payload DENIED, quota seed ALLOWED, 1.47 payload ALLOWED.

## Fix
New `onQuoteCreatedBootstrapTrial` trigger: on first quote create, stamp `trialStartedAt` (transaction, merge-only, never writes entitlement keys). Seeds the full doc when missing (pre-1.47 clients), stamps only `trialStartedAt` when a 1.47 seed exists without one. Idempotent — no-op for Pro users or any existing `trialStartedAt` (expired trials can't restart the clock).

Long-term this makes trial start server-owned, closing the "trialStartedAt stays client-writable — known weakness" note in firestore.rules.

## Tests
`trialBootstrap.helpers.test.ts` — 9 passing cases: missing-doc seed shape, PAY-02 deny-list exclusion, stamp-only on existing doc, idempotency on re-fire, expired-trial no-restart, Pro no-op, createdAt fallback, timestamp coercion.

## Ops (already done)
- Trigger deployed to prod (`onQuoteCreatedBootstrapTrial`, us-central1).
- Affected cohort backfilled: 7 users created 22–24 Jul got docs with `trialStartedAt` = first quote createdAt (or null for 0-quote users).

🤖 Generated with [Claude Code](https://claude.com/claude-code)