### PR TITLE
Sentry autofix pipeline: alert → agent PR → deploy on merge

### DIFF
--- a/.github/workflows/deploy-on-merge.yml
+++ b/.github/workflows/deploy-on-merge.yml
@@ -1,0 +1,137 @@
+name: Deploy on autofix merge
+
+# Closes the Sentry autofix loop: when a PR whose linked issue carries the
+# `sentry-autofix` label is MERGED to main, redeploy whatever the fix touched:
+#   - functions/**            -> firebase deploy --only functions
+#   - src/** / App.tsx / assets -> EAS OTA update on the production channel
+#                                 (reaches installed iOS + Android apps)
+#   - native surface (android/, ios/, plugins/, package.json, app.config.js,
+#     patches/) -> OTA is SKIPPED (unsafe over a native mismatch) and a PR
+#     comment asks for a store build via the EAS Pipeline workflow instead.
+#
+# Deliberately does NOT fire for ordinary PRs — normal merges keep the existing
+# manual deploy flow. Human review of the PR remains the only gate; merging IS
+# the deploy approval.
+#
+# Secrets used: FIREBASE_SERVICE_ACCOUNT (needs functions deploy roles, not
+# just Hosting Admin), EXPO_TOKEN.
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  classify:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    outputs:
+      autofix: ${{ steps.check.outputs.autofix }}
+      functions: ${{ steps.check.outputs.functions }}
+      app: ${{ steps.check.outputs.app }}
+      native: ${{ steps.check.outputs.native }}
+    steps:
+      - name: Check autofix label + classify changed files
+        id: check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+
+            // Autofix PRs are identified by the `sentry-autofix` label on the
+            // LINKED ISSUE (the webhook labels it at creation), or on the PR
+            // itself as a manual override.
+            let autofix = pr.labels.some(l => l.name === 'sentry-autofix');
+            if (!autofix) {
+              const m = (pr.body || '').match(/Closes #(\d+)/i);
+              if (m) {
+                try {
+                  const { data: issue } = await github.rest.issues.get({
+                    owner: context.repo.owner, repo: context.repo.repo,
+                    issue_number: Number(m[1]),
+                  });
+                  autofix = issue.labels.some(l => l.name === 'sentry-autofix');
+                } catch (e) {
+                  core.warning(`Could not read linked issue: ${e.message}`);
+                }
+              }
+            }
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner, repo: context.repo.repo,
+              pull_number: pr.number, per_page: 100,
+            });
+            const paths = files.map(f => f.filename);
+            const touches = (re) => paths.some(p => re.test(p));
+
+            const functionsChanged = touches(/^functions\//);
+            const nativeChanged = touches(/^(android\/|ios\/|plugins\/|patches\/|package(-lock)?\.json$|app\.config\.js$|app\.json$)/);
+            const appChanged = touches(/^(src\/|App\.tsx$|assets\/)/);
+
+            core.setOutput('autofix', String(autofix));
+            core.setOutput('functions', String(functionsChanged));
+            core.setOutput('app', String(appChanged));
+            core.setOutput('native', String(nativeChanged));
+            core.info(`autofix=${autofix} functions=${functionsChanged} app=${appChanged} native=${nativeChanged}`);
+
+  deploy-functions:
+    needs: classify
+    if: needs.classify.outputs.autofix == 'true' && needs.classify.outputs.functions == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install functions dependencies
+        run: npm --prefix functions install --no-audit --no-fund
+      - name: Deploy functions
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: ${{ runner.temp }}/firebase-sa.json
+        run: |
+          printf '%s' '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}' > "$GOOGLE_APPLICATION_CREDENTIALS"
+          npx firebase-tools deploy --only functions --project hansendev --force
+
+  ota-update:
+    needs: classify
+    if: >-
+      needs.classify.outputs.autofix == 'true' &&
+      needs.classify.outputs.app == 'true' &&
+      needs.classify.outputs.native != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install dependencies
+        run: npm install --no-audit --no-fund
+      - name: Setup EAS
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+      - name: OTA update (production channel, iOS + Android)
+        run: eas update --branch production --message "Sentry autofix PR #${{ github.event.pull_request.number }}" --non-interactive
+
+  native-build-needed:
+    needs: classify
+    if: >-
+      needs.classify.outputs.autofix == 'true' &&
+      needs.classify.outputs.native == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Comment that a store build is required
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner, repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: [
+                '⚠️ **Autofix merged, but it touches native code — OTA was skipped.**',
+                '',
+                'Shipping this to installed apps needs a store build: run the **EAS Pipeline** workflow (`build`, then `submit`), or the Rebuild button on the Tasks board.',
+              ].join('\n'),
+            });

--- a/docs/SENTRY_AUTOFIX.md
+++ b/docs/SENTRY_AUTOFIX.md
@@ -1,0 +1,65 @@
+# Sentry → autofix → PR → deploy pipeline
+
+A new production error in Sentry automatically becomes a fixed, tested PR; merging that PR automatically redeploys what it touched.
+
+```
+Sentry issue alert (new issue, production)
+  └─▶ sentryAutofix function (verify sig, dedupe, daily cap)
+        └─▶ GitHub issue [sentry-autofix, agent-working] + dispatch agent.yml
+              └─▶ Claude pipeline: explore → implement (+regression test) → 3 audits → QA → PR
+                    └─▶ HUMAN reviews & merges  ◀── the only gate
+                          └─▶ deploy-on-merge.yml:
+                                functions/** → firebase deploy --only functions
+                                src/**       → eas update (production channel, iOS+Android OTA)
+                                native touch → PR comment: run EAS Pipeline build+submit
+```
+
+## One-time setup
+
+### 1. GitHub
+
+- Create the `sentry-autofix` label on Krank3n/QuoteMate (any colour).
+- Create a **fine-grained PAT** scoped to Krank3n/QuoteMate with **Issues: Read/write** and **Actions: Read/write** (Contents: Read). This is `GITHUB_AGENT_TOKEN` below.
+- Repo secrets already in place from the existing pipelines: `ANTHROPIC_API_KEY`, `EXPO_TOKEN`, `FIREBASE_SERVICE_ACCOUNT`.
+- `FIREBASE_SERVICE_ACCOUNT` was provisioned for Hosting previews — functions deploys additionally need **Cloud Functions Admin**, **Cloud Run Admin**, **Artifact Registry Writer**, **Service Account User**, and **Firebase Extensions Viewer** on `hansendev` (or just grant it Editor).
+
+### 2. Sentry (org `hansendev-0p`, project `react-native`)
+
+1. **Settings → Developer Settings → New Internal Integration**
+   - Name: `QuoteMate Autofix`
+   - Webhook URL: `https://us-central1-hansendev.cloudfunctions.net/sentryAutofix`
+   - Enable **Alert Rule Action**. Permissions: Issue & Event = Read.
+   - Save, then copy the **Client Secret** — this is `SENTRY_WEBHOOK_SECRET`.
+2. **Alerts → Create Alert → Issues** on the `react-native` project:
+   - When: **A new issue is created**
+   - Filter: environment = `production` (skip dev noise)
+   - Action: **Send a notification via QuoteMate Autofix**
+
+### 3. Functions env (`functions/.env`, never committed)
+
+```
+SENTRY_AUTOFIX_ENABLED=true
+SENTRY_WEBHOOK_SECRET=<internal integration client secret>
+GITHUB_AGENT_TOKEN=<fine-grained PAT>
+# optional overrides
+# SENTRY_AUTOFIX_DAILY_CAP=3
+# SENTRY_ORG_SLUG=hansendev-0p
+# GITHUB_AUTOFIX_REPO=Krank3n/QuoteMate
+```
+
+Then `cd functions && npm run deploy`.
+
+## Guard rails
+
+- **Human merge is mandatory** — the agent never merges, never pushes to main, never deploys (agent-task.md hard rules). Merging the PR is the deploy approval.
+- **Dedupe forever**: one dispatch per Sentry issue id (`sentryAutofixDispatches` collection). A regression alert on the same issue won't re-dispatch; delete the doc to force a re-run.
+- **Daily cap** (default 3): an alert storm can't queue dozens of agent runs. Over-cap alerts are logged in the function logs.
+- **Kill switch**: set `SENTRY_AUTOFIX_ENABLED=false` and redeploy functions.
+- **Native-safe OTA**: if the fix touches `android/`, `ios/`, `plugins/`, `patches/`, `package.json`, or `app.config.js`, the OTA is skipped and the PR gets a comment asking for a store build — a JS bundle mismatched against old native code is how you crash everyone.
+- Ordinary (non-autofix) merges to main are untouched — no deploy behaviour changes outside this flow.
+
+## Ops notes
+
+- Dispatch audit trail: `sentryAutofixDispatches/{sentryIssueId}` docs (status: `dispatching` → `dispatched` / `skipped-daily-cap`; failed dispatches delete the doc so Sentry's retry works).
+- If the agent can't confidently root-cause (native crash, third-party dep), it comments on the GitHub issue and stops — check open `sentry-autofix` issues without linked PRs.
+- Store-build releases (native changes) still go through the existing EAS Pipeline workflow / Tasks board buttons.

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -46,6 +46,7 @@ export { trialLifecycleDaily } from './lifecycleEmails';
 import { sentConversionEmailWithin } from './lifecycleEmails.helpers';
 export { subscriptionAuditDaily, adminSubscriptionAudit } from './subscriptionAudit';
 export { dailyTrackingCheck } from './trackingAlarm';
+export { sentryAutofix } from './sentryAutofix';
 export { storeFunnelDaily } from './storeFunnel';
 export { websiteContact, websiteSubscribe } from './websiteForms';
 export {

--- a/functions/src/sentryAutofix.helpers.ts
+++ b/functions/src/sentryAutofix.helpers.ts
@@ -1,0 +1,141 @@
+/**
+ * Pure helpers for the Sentry → autofix-agent webhook (sentryAutofix.ts).
+ *
+ * Flow: a Sentry issue alert (internal integration webhook) posts here; we
+ * verify the signature, normalise the payload, and the caller opens a GitHub
+ * issue + dispatches the agent.yml pipeline which fixes the bug and opens a PR.
+ */
+import * as crypto from 'crypto';
+
+/** Normalised view of a Sentry alert payload, whatever shape it arrived in. */
+export interface SentryBug {
+  /** Sentry issue id — the dedupe key (one autofix dispatch per issue, ever). */
+  issueId: string;
+  title: string;
+  culprit: string;
+  permalink: string;
+  environment: string;
+  release: string;
+  platform: string;
+  /** "file:function:line" strings for the most relevant in-app frames. */
+  topFrames: string[];
+}
+
+/**
+ * Verify Sentry's `sentry-hook-signature` header: hex HMAC-SHA256 of the raw
+ * request body keyed with the internal integration's client secret.
+ */
+export function verifySentrySignature(
+  rawBody: string | Buffer,
+  signature: string | undefined,
+  secret: string,
+): boolean {
+  if (!signature || !secret) return false;
+  const expected = crypto.createHmac('sha256', secret).update(rawBody).digest('hex');
+  const a = Buffer.from(expected, 'utf8');
+  const b = Buffer.from(signature, 'utf8');
+  return a.length === b.length && crypto.timingSafeEqual(a, b);
+}
+
+/** Extract "file:function:line" for the last (= most relevant) in-app frames. */
+function framesFromEvent(event: Record<string, any>, max = 5): string[] {
+  const values = event?.exception?.values;
+  const frames: Array<Record<string, any>> =
+    (Array.isArray(values) && values[0]?.stacktrace?.frames) || [];
+  const inApp = frames.filter((f) => f && f.in_app !== false);
+  return (inApp.length ? inApp : frames)
+    .slice(-max)
+    .map((f) => `${f.filename || f.abs_path || '?'} : ${f.function || '?'} : line ${f.lineno ?? '?'}`);
+}
+
+/**
+ * Normalise the webhook payload. Supports the two shapes Sentry sends to an
+ * internal integration:
+ *  - resource `event_alert` (issue alert "send a notification via …" action):
+ *    `{ action: 'triggered', data: { event: {...} } }`
+ *  - resource `issue` (Issue & Event webhooks, action `created`):
+ *    `{ action: 'created', data: { issue: {...} } }`
+ * Returns null for anything else (resolved/ignored actions, comments, pings).
+ */
+export function parseSentryAlert(payload: any, orgSlug: string): SentryBug | null {
+  if (!payload || typeof payload !== 'object') return null;
+
+  const event = payload.data?.event;
+  if (payload.action === 'triggered' && event) {
+    const issueId = String(event.issue_id ?? event.issue?.id ?? '');
+    if (!issueId) return null;
+    return {
+      issueId,
+      title: String(event.title || event.message || 'Unknown error'),
+      culprit: String(event.culprit || ''),
+      permalink: String(event.web_url || `https://${orgSlug}.sentry.io/issues/${issueId}/`),
+      environment: String(event.environment || ''),
+      release: String(event.release || ''),
+      platform: String(event.platform || ''),
+      topFrames: framesFromEvent(event),
+    };
+  }
+
+  const issue = payload.data?.issue;
+  if (payload.action === 'created' && issue) {
+    const issueId = String(issue.id ?? '');
+    if (!issueId) return null;
+    return {
+      issueId,
+      title: String(issue.title || 'Unknown error'),
+      culprit: String(issue.culprit || ''),
+      permalink: String(issue.permalink || `https://${orgSlug}.sentry.io/issues/${issueId}/`),
+      environment: '',
+      release: '',
+      platform: String(issue.platform || ''),
+      topFrames: [],
+    };
+  }
+
+  return null;
+}
+
+/** GitHub issue title for the agent queue. */
+export function buildIssueTitle(bug: SentryBug): string {
+  const title = bug.title.length > 100 ? `${bug.title.slice(0, 97)}...` : bug.title;
+  return `[Sentry] ${title}`;
+}
+
+/**
+ * GitHub issue body in the agent pipeline's expected format: the task spec
+ * above the `---` divider, with a `qm-ticket` marker the agent copies into
+ * the PR body verbatim (that is how the PR is traced back to this alert).
+ */
+export function buildIssueBody(bug: SentryBug): string {
+  const facts = [
+    `**Error:** ${bug.title}`,
+    bug.culprit && `**Where:** \`${bug.culprit}\``,
+    bug.platform && `**Platform:** ${bug.platform}`,
+    bug.environment && `**Environment:** ${bug.environment}`,
+    bug.release && `**Release:** ${bug.release}`,
+    `**Sentry:** ${bug.permalink}`,
+  ].filter(Boolean);
+
+  const frames = bug.topFrames.length
+    ? `\nMost relevant stack frames (innermost last):\n\`\`\`\n${bug.topFrames.join('\n')}\n\`\`\`\n`
+    : '';
+
+  return `Fix the production error reported by Sentry below. Diagnose the root cause from the stack trace and the surrounding code — do not just guard the symptom.
+
+${facts.join('\n')}
+${frames}
+Requirements:
+- Write a failing regression test that reproduces the error FIRST, then fix it. The fix is not done without that test passing.
+- Keep the diff minimal and focused on this one error.
+- If the root cause is in native code, a third-party dependency, or cannot be determined with confidence from the stack trace, comment on this issue explaining what you found and STOP — do not guess.
+
+<!-- qm-ticket:sentry-${bug.issueId} -->
+
+---
+Auto-created by the \`sentryAutofix\` webhook from a Sentry issue alert.`;
+}
+
+/** UTC day bucket for the daily dispatch cap, e.g. "2026-07-24". */
+export function dailyKey(now: Date): string {
+  return now.toISOString().slice(0, 10);
+}

--- a/functions/src/sentryAutofix.test.ts
+++ b/functions/src/sentryAutofix.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect } from 'vitest';
+import * as crypto from 'crypto';
+import {
+  verifySentrySignature,
+  parseSentryAlert,
+  buildIssueTitle,
+  buildIssueBody,
+  dailyKey,
+  SentryBug,
+} from './sentryAutofix.helpers';
+
+const SECRET = 'test-client-secret';
+const sign = (body: string) => crypto.createHmac('sha256', SECRET).update(body).digest('hex');
+
+describe('verifySentrySignature', () => {
+  it('accepts a valid HMAC-SHA256 hex signature of the raw body', () => {
+    const body = JSON.stringify({ action: 'triggered' });
+    expect(verifySentrySignature(body, sign(body), SECRET)).toBe(true);
+  });
+
+  it('accepts a Buffer raw body (the type functions gives us)', () => {
+    const body = Buffer.from('{"a":1}');
+    expect(verifySentrySignature(body, sign('{"a":1}'), SECRET)).toBe(true);
+  });
+
+  it('rejects a signature computed with the wrong secret', () => {
+    const body = '{"a":1}';
+    const wrong = crypto.createHmac('sha256', 'other-secret').update(body).digest('hex');
+    expect(verifySentrySignature(body, wrong, SECRET)).toBe(false);
+  });
+
+  it('rejects a signature for a different body (tampered payload)', () => {
+    expect(verifySentrySignature('{"a":2}', sign('{"a":1}'), SECRET)).toBe(false);
+  });
+
+  it('rejects a missing signature header', () => {
+    expect(verifySentrySignature('{"a":1}', undefined, SECRET)).toBe(false);
+  });
+
+  it('rejects everything when no secret is configured', () => {
+    const body = '{"a":1}';
+    expect(verifySentrySignature(body, sign(body), '')).toBe(false);
+  });
+
+  it('rejects a malformed (wrong-length) signature without throwing', () => {
+    expect(verifySentrySignature('{"a":1}', 'deadbeef', SECRET)).toBe(false);
+  });
+});
+
+describe('parseSentryAlert', () => {
+  const ORG = 'hansendev-0p';
+
+  it('parses an issue-alert (event_alert) payload including in-app stack frames', () => {
+    const payload = {
+      action: 'triggered',
+      data: {
+        event: {
+          issue_id: '987654',
+          title: "TypeError: Cannot read property 'total' of undefined",
+          culprit: 'src/screens/JobPreview.tsx in renderTotals',
+          web_url: 'https://hansendev-0p.sentry.io/issues/987654/events/abc/',
+          environment: 'production',
+          release: '1.47.0',
+          platform: 'javascript',
+          exception: {
+            values: [
+              {
+                stacktrace: {
+                  frames: [
+                    { filename: 'node_modules/react/index.js', function: 'render', lineno: 1, in_app: false },
+                    { filename: 'src/screens/JobPreview.tsx', function: 'renderTotals', lineno: 214, in_app: true },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      },
+    };
+    const bug = parseSentryAlert(payload, ORG);
+    expect(bug).not.toBeNull();
+    expect(bug!.issueId).toBe('987654');
+    expect(bug!.title).toContain('TypeError');
+    expect(bug!.environment).toBe('production');
+    expect(bug!.topFrames).toEqual(['src/screens/JobPreview.tsx : renderTotals : line 214']);
+  });
+
+  it('falls back to a constructed permalink when the event has no web_url', () => {
+    const bug = parseSentryAlert(
+      { action: 'triggered', data: { event: { issue_id: '42', title: 'Boom' } } },
+      ORG,
+    );
+    expect(bug!.permalink).toBe('https://hansendev-0p.sentry.io/issues/42/');
+  });
+
+  it('parses an issue-created webhook payload', () => {
+    const bug = parseSentryAlert(
+      {
+        action: 'created',
+        data: {
+          issue: {
+            id: '111',
+            title: 'ReferenceError: x is not defined',
+            culprit: 'src/utils/foo.ts',
+            permalink: 'https://hansendev-0p.sentry.io/issues/111/',
+            platform: 'javascript',
+          },
+        },
+      },
+      ORG,
+    );
+    expect(bug).toEqual(
+      expect.objectContaining({ issueId: '111', permalink: 'https://hansendev-0p.sentry.io/issues/111/' }),
+    );
+  });
+
+  it('returns null for installation pings and non-alert actions', () => {
+    expect(parseSentryAlert({ action: 'created', data: { installation: {} } }, ORG)).toBeNull();
+    expect(parseSentryAlert({ action: 'resolved', data: { issue: { id: '9' } } }, ORG)).toBeNull();
+    expect(parseSentryAlert({ action: 'triggered', data: {} }, ORG)).toBeNull();
+    expect(parseSentryAlert(null, ORG)).toBeNull();
+    expect(parseSentryAlert('junk', ORG)).toBeNull();
+  });
+
+  it('returns null when the event has no issue id (nothing to dedupe on)', () => {
+    expect(parseSentryAlert({ action: 'triggered', data: { event: { title: 'x' } } }, ORG)).toBeNull();
+  });
+});
+
+describe('buildIssueTitle / buildIssueBody', () => {
+  const bug: SentryBug = {
+    issueId: '987654',
+    title: "TypeError: Cannot read property 'total' of undefined",
+    culprit: 'src/screens/JobPreview.tsx in renderTotals',
+    permalink: 'https://hansendev-0p.sentry.io/issues/987654/',
+    environment: 'production',
+    release: '1.47.0',
+    platform: 'javascript',
+    topFrames: ['src/screens/JobPreview.tsx : renderTotals : line 214'],
+  };
+
+  it('prefixes the title with [Sentry] and truncates very long titles', () => {
+    expect(buildIssueTitle(bug)).toBe(
+      "[Sentry] TypeError: Cannot read property 'total' of undefined",
+    );
+    const long = buildIssueTitle({ ...bug, title: 'x'.repeat(300) });
+    expect(long.length).toBeLessThanOrEqual('[Sentry] '.length + 100);
+    expect(long.endsWith('...')).toBe(true);
+  });
+
+  it('includes the qm-ticket marker the agent must copy into the PR body', () => {
+    expect(buildIssueBody(bug)).toContain('<!-- qm-ticket:sentry-987654 -->');
+  });
+
+  it('puts the task spec above the --- divider (agent-task.md contract)', () => {
+    const body = buildIssueBody(bug);
+    const [spec] = body.split('\n---\n');
+    expect(spec).toContain('regression test');
+    expect(spec).toContain(bug.permalink);
+    expect(spec).toContain('src/screens/JobPreview.tsx : renderTotals : line 214');
+  });
+
+  it('omits empty metadata lines and the frames block when there are none', () => {
+    const sparse = buildIssueBody({
+      ...bug,
+      culprit: '',
+      environment: '',
+      release: '',
+      platform: '',
+      topFrames: [],
+    });
+    expect(sparse).not.toContain('**Where:**');
+    expect(sparse).not.toContain('**Release:**');
+    expect(sparse).not.toContain('stack frames');
+  });
+
+  it('tells the agent to stop rather than guess on native/dependency crashes', () => {
+    expect(buildIssueBody(bug)).toContain('STOP');
+  });
+});
+
+describe('dailyKey', () => {
+  it('buckets by UTC calendar day', () => {
+    expect(dailyKey(new Date('2026-07-24T23:59:59Z'))).toBe('2026-07-24');
+    expect(dailyKey(new Date('2026-07-25T00:00:01Z'))).toBe('2026-07-25');
+  });
+});

--- a/functions/src/sentryAutofix.ts
+++ b/functions/src/sentryAutofix.ts
@@ -1,0 +1,169 @@
+/**
+ * Sentry → autofix pipeline webhook.
+ *
+ * A Sentry issue alert (internal integration "QuoteMate Autofix") POSTs here
+ * when a NEW issue appears in production. We then:
+ *  1. verify the webhook signature and normalise the payload,
+ *  2. dedupe (one dispatch per Sentry issue, ever) + enforce a daily cap so an
+ *     alert storm can't open dozens of agent runs,
+ *  3. open a GitHub issue in the agent-task format (labels: sentry-autofix,
+ *     agent-working) and dispatch .github/workflows/agent.yml on it.
+ * The agent pipeline fixes the bug with a regression test and opens a PR; a
+ * human still reviews and merges. deploy-on-merge.yml handles the redeploy.
+ *
+ * Env (functions/.env):
+ *  - SENTRY_AUTOFIX_ENABLED  kill switch, must be exactly "true"
+ *  - SENTRY_WEBHOOK_SECRET   internal integration client secret
+ *  - GITHUB_AGENT_TOKEN      fine-grained PAT: Issues RW + Actions RW on the repo
+ *  - SENTRY_AUTOFIX_DAILY_CAP optional, default 3
+ */
+import * as functions from 'firebase-functions';
+import * as admin from 'firebase-admin';
+import {
+  verifySentrySignature,
+  parseSentryAlert,
+  buildIssueTitle,
+  buildIssueBody,
+  dailyKey,
+} from './sentryAutofix.helpers';
+
+const SENTRY_ORG_SLUG = process.env.SENTRY_ORG_SLUG || 'hansendev-0p';
+const GITHUB_REPO = process.env.GITHUB_AUTOFIX_REPO || 'Krank3n/QuoteMate';
+const AGENT_WORKFLOW = 'agent.yml';
+const DISPATCHES = 'sentryAutofixDispatches';
+const META = 'sentryAutofixMeta';
+
+async function github(
+  token: string,
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<Response> {
+  return fetch(`https://api.github.com${path}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+      'Content-Type': 'application/json',
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+export const sentryAutofix = functions.https.onRequest(async (req, res) => {
+  if (req.method !== 'POST') {
+    res.status(405).send('POST only');
+    return;
+  }
+
+  // Kill switch: flip SENTRY_AUTOFIX_ENABLED off and redeploy to pause the
+  // whole flow without touching Sentry or GitHub.
+  if (process.env.SENTRY_AUTOFIX_ENABLED !== 'true') {
+    res.status(200).json({ skipped: 'autofix disabled' });
+    return;
+  }
+
+  const secret = process.env.SENTRY_WEBHOOK_SECRET || '';
+  const token = process.env.GITHUB_AGENT_TOKEN || '';
+  if (!secret || !token) {
+    functions.logger.error('sentryAutofix: missing SENTRY_WEBHOOK_SECRET or GITHUB_AGENT_TOKEN');
+    res.status(503).json({ error: 'not configured' });
+    return;
+  }
+
+  const signature = req.get('sentry-hook-signature');
+  if (!verifySentrySignature(req.rawBody, signature, secret)) {
+    functions.logger.warn('sentryAutofix: bad signature');
+    res.status(401).json({ error: 'bad signature' });
+    return;
+  }
+
+  // Sentry pings installations with `{ action: "created", data: { installation... } }`
+  // and sends non-alert resources too — anything unparseable is a clean no-op.
+  const bug = parseSentryAlert(req.body, SENTRY_ORG_SLUG);
+  if (!bug) {
+    res.status(200).json({ skipped: 'not an issue alert' });
+    return;
+  }
+
+  const db = admin.firestore();
+
+  // Dedupe: .create() is atomic — a second alert for the same Sentry issue
+  // (regression alerts, re-notifications) fails here and never re-dispatches.
+  const dispatchRef = db.collection(DISPATCHES).doc(bug.issueId);
+  try {
+    await dispatchRef.create({
+      sentryIssueId: bug.issueId,
+      title: bug.title,
+      permalink: bug.permalink,
+      createdAt: admin.firestore.FieldValue.serverTimestamp(),
+      status: 'dispatching',
+    });
+  } catch {
+    res.status(200).json({ skipped: 'already dispatched for this Sentry issue' });
+    return;
+  }
+
+  // Daily cap: an alert storm (bad release, flaky infra) must not queue an
+  // unbounded pile of agent runs. Over-cap issues are logged, not fixed.
+  const cap = Number(process.env.SENTRY_AUTOFIX_DAILY_CAP || '3');
+  const capRef = db.collection(META).doc(dailyKey(new Date()));
+  const underCap = await db.runTransaction(async (tx) => {
+    const snap = await tx.get(capRef);
+    const count = (snap.data()?.count as number | undefined) ?? 0;
+    if (count >= cap) return false;
+    tx.set(capRef, { count: count + 1 }, { merge: true });
+    return true;
+  });
+  if (!underCap) {
+    functions.logger.warn(`sentryAutofix: daily cap (${cap}) reached, skipping`, {
+      sentryIssue: bug.permalink,
+    });
+    await dispatchRef.update({ status: 'skipped-daily-cap' });
+    res.status(200).json({ skipped: 'daily cap reached' });
+    return;
+  }
+
+  try {
+    // The agent-working label keeps the hourly queue routine from also
+    // grabbing the issue — same convention the Tasks board uses.
+    const issueRes = await github(token, 'POST', `/repos/${GITHUB_REPO}/issues`, {
+      title: buildIssueTitle(bug),
+      body: buildIssueBody(bug),
+      labels: ['sentry-autofix', 'agent-working'],
+    });
+    if (!issueRes.ok) {
+      throw new Error(`GitHub issue create failed: ${issueRes.status} ${await issueRes.text()}`);
+    }
+    const issue = (await issueRes.json()) as { number: number; html_url: string };
+
+    const dispatchRes = await github(
+      token,
+      'POST',
+      `/repos/${GITHUB_REPO}/actions/workflows/${AGENT_WORKFLOW}/dispatches`,
+      { ref: 'main', inputs: { issue: String(issue.number) } },
+    );
+    if (dispatchRes.status !== 204) {
+      throw new Error(
+        `agent.yml dispatch failed: ${dispatchRes.status} ${await dispatchRes.text()}`,
+      );
+    }
+
+    await dispatchRef.update({
+      status: 'dispatched',
+      githubIssue: issue.number,
+      githubIssueUrl: issue.html_url,
+    });
+    functions.logger.info(`sentryAutofix: dispatched agent for ${bug.permalink}`, {
+      githubIssue: issue.html_url,
+    });
+    res.status(200).json({ dispatched: issue.html_url });
+  } catch (err) {
+    // Release the dedupe slot so Sentry's retry (or a manual re-send) can
+    // try again — otherwise a transient GitHub failure permanently eats the bug.
+    await dispatchRef.delete().catch(() => undefined);
+    functions.logger.error('sentryAutofix: dispatch failed', err);
+    res.status(500).json({ error: 'dispatch failed' });
+  }
+});


### PR DESCRIPTION
Closes the loop from a production Sentry error to a deployed fix:

1. **`sentryAutofix` function** — Sentry issue-alert webhook: HMAC signature check, per-issue dedupe (Firestore `create()` lock), daily cap (default 3), kill switch (`SENTRY_AUTOFIX_ENABLED`). Opens a GitHub issue in the agent-task format (labels `sentry-autofix` + `agent-working`) and dispatches `agent.yml`.
2. **`deploy-on-merge.yml`** — when a merged PR traces to a `sentry-autofix` issue: deploys functions if `functions/` changed, EAS OTA (production channel) if app JS changed, and skips OTA + comments for a store build when native surface changed. Ordinary merges are untouched.
3. **`docs/SENTRY_AUTOFIX.md`** — one-time setup (Sentry internal integration + alert rule, PAT, env, SA roles) and guard rails.

Tests: 18 named cases in `functions/src/sentryAutofix.test.ts` (signature verify incl. tamper/length cases, both webhook payload shapes, issue body contract with agent-task.md, daily key). `vitest` green, `tsc` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)