### PR TITLE
[Sentry] TypeError: Cannot read properties of undefined (reading 'routes')

### DIFF
--- a/src/hooks/useUnsavedChangesGuard.test.tsx
+++ b/src/hooks/useUnsavedChangesGuard.test.tsx
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+/**
+ * Regression tests for useUnsavedChangesGuard's stale-action guard.
+ *
+ * Production Sentry crash: `TypeError: Cannot read properties of undefined
+ * (reading 'routes')` from React Navigation's getStateForAction, reached via
+ * the imperative navigation.dispatch(...) this hook makes.
+ *
+ * The hook pauses an in-flight `beforeRemove` action, shows a confirm modal,
+ * and — after awaiting onSave/onDiscard — re-dispatches the stored action.
+ * During that async gap the navigator (or the whole root tree in App.tsx) can
+ * be torn down, so the captured action targets state that no longer exists and
+ * dispatch throws synchronously, crashing the app.
+ *
+ * These tests mount the hook with a mocked navigation whose `dispatch` throws
+ * that exact error and assert the discard flow no longer rejects/throws. A
+ * second case guards the existing abort-on-validation-failure behavior.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+// Capture what the hook registers so tests can drive the beforeRemove flow.
+let beforeRemoveCb: ((e: any) => void) | null = null;
+const dispatch = vi.fn();
+const goBack = vi.fn();
+const addListener = vi.fn((event: string, cb: (e: any) => void) => {
+  if (event === 'beforeRemove') beforeRemoveCb = cb;
+  return () => {};
+});
+
+vi.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ addListener, dispatch, goBack }),
+}));
+
+import { useUnsavedChangesGuard } from './useUnsavedChangesGuard';
+
+const fireBeforeRemove = () => {
+  const event = { preventDefault: vi.fn(), data: { action: { type: 'GO_BACK' } } };
+  act(() => {
+    beforeRemoveCb?.(event);
+  });
+  return event;
+};
+
+describe('useUnsavedChangesGuard stale-action guard', () => {
+  beforeEach(() => {
+    beforeRemoveCb = null;
+    dispatch.mockReset();
+    goBack.mockReset();
+    addListener.mockClear();
+  });
+
+  it('does not throw/reject when re-dispatching a stale action crashes', async () => {
+    // Simulate the reported crash: the navigator state moved on during the
+    // await, so dispatch throws synchronously from getStateForAction.
+    dispatch.mockImplementation(() => {
+      throw new TypeError("Cannot read properties of undefined (reading 'routes')");
+    });
+
+    const { result } = renderHook(() =>
+      useUnsavedChangesGuard({ isDirty: true, onSave: async () => true })
+    );
+
+    fireBeforeRemove();
+
+    await expect(
+      result.current.unsavedModalProps.secondaryButtonAction()
+    ).resolves.not.toThrow();
+
+    expect(dispatch).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not dispatch when onSave returns false (validation abort)', async () => {
+    const { result } = renderHook(() =>
+      useUnsavedChangesGuard({ isDirty: true, onSave: async () => false })
+    );
+
+    fireBeforeRemove();
+
+    await act(async () => {
+      await result.current.unsavedModalProps.primaryButtonAction();
+    });
+
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(goBack).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useUnsavedChangesGuard.ts
+++ b/src/hooks/useUnsavedChangesGuard.ts
@@ -55,10 +55,21 @@ export function useUnsavedChangesGuard({ isDirty, onSave, onDiscard }: Options) 
 
   const dispatchPending = (action: NavigationAction | null) => {
     allowExitRef.current = true;
-    if (action) {
-      navigation.dispatch(action);
-    } else {
-      navigation.goBack();
+    try {
+      if (action) {
+        navigation.dispatch(action);
+      } else {
+        navigation.goBack();
+      }
+    } catch {
+      // The captured action was in flight when we paused it; awaiting
+      // onSave/onDiscard opens an async gap in which the navigator (or the
+      // whole root tree in App.tsx) can be torn down, leaving the stored
+      // action pointing at state that no longer exists. React Navigation then
+      // throws synchronously from getStateForAction ("Cannot read properties
+      // of undefined (reading 'routes')"). The user already chose to exit, so
+      // swallow it rather than crash. No fallback goBack() here — the dispatch
+      // may have partially succeeded, and a second nav would double-navigate.
     }
   };
 


### PR DESCRIPTION
<!-- qm-ticket:sentry-7628348725 -->
Closes #63

**Root cause:** `src/hooks/useUnsavedChangesGuard.ts`'s `dispatchPending` re-dispatches a captured navigation action after an async save/discard gap. If the navigator tree changes during that gap (auth/onboarding/main swap), the stale action hits state that no longer exists and React Navigation's `getStateForAction` throws on `undefined.routes` — the exact crash in [REACT-NATIVE-6](https://hansendev-0p.sentry.io/issues/7628348725/).

**Fix:** wrap the re-dispatch in a try/catch so a stale action can't crash the app (no fallback navigation in the catch, to avoid double-navigating if the dispatch partially succeeded).

**Tests:** regression suite in `src/hooks/useUnsavedChangesGuard.test.tsx` (87 lines) reproducing the stale-dispatch crash.

_Agent-produced fix (run [30147396153](https://github.com/Krank3n/QuoteMate/actions/runs/30147396153)); PR opened manually because Actions PR-creation was disabled at the time — that repo setting is now enabled, so future autofix PRs open automatically._

🤖 Generated with [Claude Code](https://claude.com/claude-code)