### PR TITLE
fix(ci): deploy-on-merge OTA command truncated by YAML comment

### DIFF
--- a/.github/workflows/deploy-on-merge.yml
+++ b/.github/workflows/deploy-on-merge.yml
@@ -111,7 +111,10 @@ jobs:
           eas-version: latest
           token: ${{ secrets.EXPO_TOKEN }}
       - name: OTA update (production channel, iOS + Android)
-        run: eas update --branch production --message "Sentry autofix PR #${{ github.event.pull_request.number }}" --non-interactive
+        # Block scalar: a plain "run:" scalar would treat the # in the message
+        # as a YAML comment and truncate the command mid-string.
+        run: |
+          eas update --branch production --message "Sentry autofix PR #${{ github.event.pull_request.number }}" --non-interactive
 
   native-build-needed:
     needs: classify


### PR DESCRIPTION
The `#` in `--message "Sentry autofix PR #N"` started a YAML comment in the plain scalar, truncating the shell command mid-string (`unexpected EOF while looking for matching '\"'`) — seen in run 30149698110 after merging PR #64. Block scalar keeps the `#` literal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)