### PR TITLE
fix(sentry): ignore benign react-native-web pointer-capture noise

### DIFF
--- a/src/config/sentry.test.ts
+++ b/src/config/sentry.test.ts
@@ -12,7 +12,52 @@ const { init, wrap } = vi.hoisted(() => ({
 }));
 vi.mock('@sentry/react-native', () => ({ init, wrap }));
 
-import { initSentry, wrapRootComponent, shouldEnableSentry, SENTRY_DSN } from './sentry';
+import {
+  initSentry,
+  wrapRootComponent,
+  shouldEnableSentry,
+  SENTRY_DSN,
+  SENTRY_IGNORE_ERRORS,
+} from './sentry';
+
+const matchesIgnoreList = (message: string): boolean =>
+  SENTRY_IGNORE_ERRORS.some((p) =>
+    typeof p === 'string' ? message.includes(p) : p.test(message),
+  );
+
+describe('SENTRY_IGNORE_ERRORS', () => {
+  it('filters the exact react-native-web pointer-capture messages seen in production (REACT-NATIVE-5)', () => {
+    expect(
+      matchesIgnoreList(
+        "Failed to execute 'setPointerCapture' on 'Element': No active pointer with the given id is found.",
+      ),
+    ).toBe(true);
+    expect(
+      matchesIgnoreList(
+        "Failed to execute 'releasePointerCapture' on 'Element': No active pointer with the given id is found.",
+      ),
+    ).toBe(true);
+  });
+
+  it('does not swallow other NotFoundErrors or unrelated crashes', () => {
+    expect(matchesIgnoreList('NotFoundError: The object can not be found here.')).toBe(false);
+    expect(
+      matchesIgnoreList("TypeError: Cannot read properties of undefined (reading 'routes')"),
+    ).toBe(false);
+  });
+
+  it('is passed to Sentry.init in enabled builds', () => {
+    init.mockClear();
+    initSentry();
+    if (SENTRY_DSN !== '') {
+      expect(init).toHaveBeenCalledWith(
+        expect.objectContaining({ ignoreErrors: SENTRY_IGNORE_ERRORS }),
+      );
+    } else {
+      expect(init).not.toHaveBeenCalled();
+    }
+  });
+});
 
 describe('shouldEnableSentry', () => {
   it('is off with no DSN', () => {

--- a/src/config/sentry.ts
+++ b/src/config/sentry.ts
@@ -22,6 +22,19 @@ export function shouldEnableSentry(dsn: string, isDev: boolean): boolean {
   return dsn.length > 0 && !isDev;
 }
 
+/**
+ * Known-benign errors we deliberately don't report.
+ *
+ * Pointer capture (REACT-NATIVE-5): thrown by react-native-web's internal
+ * ResponderEventPlugin on web when a pointer is already gone by the time it
+ * calls set/releasePointerCapture (fast flick, touch cancel, unmount
+ * mid-gesture). No first-party frame, the browser auto-releases capture,
+ * and the drag/slider interaction still completes — pure noise.
+ */
+export const SENTRY_IGNORE_ERRORS: (string | RegExp)[] = [
+  /Failed to execute '(set|release)PointerCapture' on 'Element'/,
+];
+
 export function initSentry(): void {
   if (!shouldEnableSentry(SENTRY_DSN, __DEV__)) return;
   Sentry.init({
@@ -30,6 +43,7 @@ export function initSentry(): void {
     // no PII. Keep the payload to stack traces + device context.
     sendDefaultPii: false,
     tracesSampleRate: 0,
+    ignoreErrors: SENTRY_IGNORE_ERRORS,
   });
 }
 


### PR DESCRIPTION
Closes #68 (Sentry REACT-NATIVE-5).

The `setPointerCapture`/`releasePointerCapture` NotFoundErrors are thrown inside react-native-web's ResponderEventPlugin on web when the pointer is already released/cancelled by the time capture is taken — fast flicks, touch cancels, unmounts mid-gesture. No first-party frame exists to guard, the browser auto-releases capture regardless, and the interaction completes normally. Per the autofix agent's analysis on #68, this filters the noise client-side rather than carrying a version-pinned `patch-package` patch on react-native-web forever.

Exported `SENTRY_IGNORE_ERRORS` so the filter is unit-tested: matches both production message variants, proven not to swallow other NotFoundErrors or unrelated crashes, and asserted to be wired into `Sentry.init`.

Tests: 8/8 passing in `src/config/sentry.test.ts` (3 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)