### PR TITLE
fix(android): initialize Square SDK before first Activity (issue #66)

### DIFF
--- a/plugins/withSquareSDK.js
+++ b/plugins/withSquareSDK.js
@@ -264,6 +264,14 @@ function injectSquareMainApplication(src, applicationId) {
     /\n\s*android\.os\.Looper\.myQueue\(\)\.addIdleHandler \{\n\s*MobilePaymentsSdk\.initialize\([^)]*\)\n\s*false\n\s*\}/,
     ''
   );
+  // If an idle-handler init survives the whitespace-exact strip above, the
+  // marker check below would silently keep the broken timing on this machine.
+  if (src.includes('addIdleHandler') && src.includes('MobilePaymentsSdk.initialize')) {
+    console.warn(
+      'withSquareSDK: unrecognized idle-handler MobilePaymentsSdk.initialize block — ' +
+        'migrate MainApplication.kt manually or the #66 crash timing ships again.'
+    );
+  }
 
   if (!src.includes('MobilePaymentsSdk.initialize')) {
     // Square's initialize() must (a) run on the main thread — it throws

--- a/plugins/withSquareSDK.js
+++ b/plugins/withSquareSDK.js
@@ -20,9 +20,10 @@
  *   • android/build.gradle — Square maven repo + squareSdkVersion ext prop
  *   • android/app/build.gradle — Square SDK dependency + disable Proguard
  *     for release (per Square's docs)
- *   • MainApplication.kt — initialize MobilePaymentsSdk at first main-thread
- *     idle after onCreate (init is main-thread-mandatory but blocking it
- *     inline caused cold-start ANRs — Sentry REACT-NATIVE-1)
+ *   • MainApplication.kt — initialize MobilePaymentsSdk in
+ *     onActivityPreCreated (API 29+): before the first Activity so Square's
+ *     ActivityListener sees it (issue #66), but off the blocking
+ *     process-start path (ANR — Sentry REACT-NATIVE-1); inline on API 28
  *   • AndroidManifest.xml — NFC + location permissions
  *
  * iOS Tap to Pay entitlement (proximity-reader.payment.acceptance) is added
@@ -255,18 +256,45 @@ function injectSquareMainApplication(src, applicationId) {
     );
   }
 
+  // Migrate the 1.46+155-era idle-handler deferral (issue #66): idle fires
+  // after MainActivity is created, so Square's ActivityListener missed the
+  // activity and createdActivity stayed null. Strip it so the block below
+  // re-injects the correct timing.
+  src = src.replace(
+    /\n\s*android\.os\.Looper\.myQueue\(\)\.addIdleHandler \{\n\s*MobilePaymentsSdk\.initialize\([^)]*\)\n\s*false\n\s*\}/,
+    ''
+  );
+
   if (!src.includes('MobilePaymentsSdk.initialize')) {
-    // Square's initialize() must run on the main thread (it throws
-    // otherwise) and blocks for the whole SDK bootstrap. Inline in
-    // onCreate() that stall sat inside the process-start ANR window
-    // (Sentry REACT-NATIVE-1); at first main-thread idle it runs after
-    // startup settles, still long before the user-triggered payment flow.
+    // Square's initialize() must (a) run on the main thread — it throws
+    // off-main, (b) finish before the first Activity is created — its
+    // ActivityListener only tracks activities created after init, and a
+    // missed first activity is a fatal IllegalStateException in the payment
+    // flow (issue #66) — and (c) stay off the blocking process-start path
+    // (ANR, Sentry REACT-NATIVE-1). onActivityPreCreated runs synchronously
+    // just before the first Activity's onCreate, after process start, and
+    // never for background broadcast/service starts — the only hook that
+    // satisfies all three. It requires API 29; on API 28 (minSdk) init runs
+    // inline as the lesser risk.
     src = src.replace(
       /super\.onCreate\(\)/,
       `super.onCreate()\n` +
-        `    android.os.Looper.myQueue().addIdleHandler {\n` +
+        `    if (android.os.Build.VERSION.SDK_INT >= 29) {\n` +
+        `      registerActivityLifecycleCallbacks(object : android.app.Application.ActivityLifecycleCallbacks {\n` +
+        `        override fun onActivityPreCreated(activity: android.app.Activity, savedInstanceState: android.os.Bundle?) {\n` +
+        `          unregisterActivityLifecycleCallbacks(this)\n` +
+        `          MobilePaymentsSdk.initialize("${applicationId}", this@MainApplication)\n` +
+        `        }\n` +
+        `        override fun onActivityCreated(activity: android.app.Activity, savedInstanceState: android.os.Bundle?) {}\n` +
+        `        override fun onActivityStarted(activity: android.app.Activity) {}\n` +
+        `        override fun onActivityResumed(activity: android.app.Activity) {}\n` +
+        `        override fun onActivityPaused(activity: android.app.Activity) {}\n` +
+        `        override fun onActivityStopped(activity: android.app.Activity) {}\n` +
+        `        override fun onActivitySaveInstanceState(activity: android.app.Activity, outState: android.os.Bundle) {}\n` +
+        `        override fun onActivityDestroyed(activity: android.app.Activity) {}\n` +
+        `      })\n` +
+        `    } else {\n` +
         `      MobilePaymentsSdk.initialize("${applicationId}", this)\n` +
-        `      false\n` +
         `    }`
     );
   }

--- a/plugins/withSquareSDK.test.ts
+++ b/plugins/withSquareSDK.test.ts
@@ -115,6 +115,22 @@ describe('injectSquareMainApplication', () => {
     expect(out).not.toContain('addIdleHandler');
     expect(out).toContain('onActivityPreCreated');
     expect(out.match(/MobilePaymentsSdk\.initialize/g)).toHaveLength(2); // pre-created + <29 fallback
+
+    // Convergence: a migrated legacy checkout must end up byte-identical to a
+    // fresh injection — the transform's output can't depend on prior state.
+    const legacyTemplate = LEGACY_IDLE_HANDLER.replace(
+      /\n    android\.os\.Looper\.myQueue\(\)\.addIdleHandler \{\n      MobilePaymentsSdk\.initialize\([^)]*\)\n      false\n    \}/,
+      ''
+    ).replace(/import com\.squareup\.sdk\.mobilepayments\.MobilePaymentsSdk\n/, '');
+    expect(out).toBe(
+      injectSquareMainApplication(
+        injectSquareMainApplication(legacyTemplate, APP_ID),
+        APP_ID
+      )
+    );
+
+    // Migration is idempotent too.
+    expect(injectSquareMainApplication(out, APP_ID)).toBe(out);
   });
 
   it('injects after super.onCreate() and keeps the rest of onCreate intact', () => {

--- a/plugins/withSquareSDK.test.ts
+++ b/plugins/withSquareSDK.test.ts
@@ -1,9 +1,21 @@
 /**
  * Regression tests for the MainApplication.kt injection in withSquareSDK.
  *
- * Background: injecting MobilePaymentsSdk.initialize() inline in onCreate()
- * blocked the main thread during the process-start ANR window (Sentry
- * REACT-NATIVE-1). The plugin now defers init to the first main-thread idle.
+ * Background — two production incidents pull this injection in opposite
+ * directions:
+ *   • Sentry REACT-NATIVE-1: initialize() inline in onCreate() blocked the
+ *     main thread inside the process-start ANR window.
+ *   • Sentry issue #66 (7632325790): deferring initialize() to the first
+ *     main-thread idle ran it AFTER MainActivity was created — Square's
+ *     ActivityListener only tracks activities created after init, so
+ *     `createdActivity` stayed null and the payments path threw
+ *     IllegalStateException.
+ *
+ * The contract now: on API 29+ initialize() runs in onActivityPreCreated —
+ * after process start (so background broadcast/service starts never pay the
+ * init cost) but synchronously before any Activity's onCreate (so the SDK
+ * never misses the first activity). Below API 29 that hook doesn't exist and
+ * init runs inline in onCreate() as the lesser risk.
  */
 import { describe, it, expect } from 'vitest';
 
@@ -32,6 +44,28 @@ class MainApplication : Application(), ReactApplication {
 }
 `;
 
+// What the plugin injected between the ANR fix (1.46+155) and the #66 fix —
+// found in already-prebuilt android/ checkouts, must be migrated on re-run.
+const LEGACY_IDLE_HANDLER = `package com.quotemate.app
+
+import com.squareup.sdk.mobilepayments.MobilePaymentsSdk
+import android.app.Application
+import android.content.res.Configuration
+
+class MainApplication : Application(), ReactApplication {
+
+  override fun onCreate() {
+    super.onCreate()
+    android.os.Looper.myQueue().addIdleHandler {
+      MobilePaymentsSdk.initialize("${APP_ID}", this)
+      false
+    }
+    SoLoader.init(this, OpenSourceMergedSoMapping)
+    ApplicationLifecycleDispatcher.onApplicationCreate(this)
+  }
+}
+`;
+
 describe('injectSquareMainApplication', () => {
   it('adds the MobilePaymentsSdk import after the package line', () => {
     const out = injectSquareMainApplication(TEMPLATE, APP_ID);
@@ -40,27 +74,57 @@ describe('injectSquareMainApplication', () => {
     );
   });
 
-  it('defers initialize to a one-shot main-thread idle handler, not inline in onCreate', () => {
+  it('initializes inside onActivityPreCreated so init beats the first Activity (issue #66)', () => {
     const out = injectSquareMainApplication(TEMPLATE, APP_ID);
 
-    const idleBlock = out.match(
-      /android\.os\.Looper\.myQueue\(\)\.addIdleHandler \{\n\s*MobilePaymentsSdk\.initialize\("sq0idp-test-app-id", this\)\n\s*false\n\s*\}/
-    );
-    expect(idleBlock).not.toBeNull();
+    // Callbacks must be registered before any Activity can exist…
+    const registerIdx = out.indexOf('registerActivityLifecycleCallbacks');
+    const superIdx = out.indexOf('super.onCreate()');
+    expect(registerIdx).toBeGreaterThan(superIdx);
 
-    // The init must not run as a direct statement of onCreate() — that put
-    // the SDK bootstrap inside the cold-start ANR window.
-    expect(out).not.toMatch(/super\.onCreate\(\)\n\s*MobilePaymentsSdk\.initialize/);
+    // …and initialize() must live inside onActivityPreCreated, scoped to the
+    // Application (`this@MainApplication`, not the callback object).
+    const preCreated = out.match(
+      /override fun onActivityPreCreated\([^)]*\)\s*\{([\s\S]*?)\n\s*\}/
+    );
+    expect(preCreated).not.toBeNull();
+    expect(preCreated![1]).toContain(
+      `MobilePaymentsSdk.initialize("${APP_ID}", this@MainApplication)`
+    );
+    // One-shot: unregister before init so a second activity can't re-init.
+    expect(preCreated![1].indexOf('unregisterActivityLifecycleCallbacks')).toBeLessThan(
+      preCreated![1].indexOf('MobilePaymentsSdk.initialize')
+    );
+  });
+
+  it('falls back to inline init below API 29, where onActivityPreCreated does not exist', () => {
+    const out = injectSquareMainApplication(TEMPLATE, APP_ID);
+    const guarded = out.match(
+      /if \(android\.os\.Build\.VERSION\.SDK_INT >= 29\) \{[\s\S]*?\} else \{\s*\n\s*MobilePaymentsSdk\.initialize\("sq0idp-test-app-id", this\)\s*\n\s*\}/
+    );
+    expect(guarded).not.toBeNull();
+  });
+
+  it('never defers init to an idle handler — that ran after Activity creation (issue #66)', () => {
+    const out = injectSquareMainApplication(TEMPLATE, APP_ID);
+    expect(out).not.toContain('addIdleHandler');
+  });
+
+  it('migrates the legacy idle-handler injection from an already-prebuilt checkout', () => {
+    const out = injectSquareMainApplication(LEGACY_IDLE_HANDLER, APP_ID);
+    expect(out).not.toContain('addIdleHandler');
+    expect(out).toContain('onActivityPreCreated');
+    expect(out.match(/MobilePaymentsSdk\.initialize/g)).toHaveLength(2); // pre-created + <29 fallback
   });
 
   it('injects after super.onCreate() and keeps the rest of onCreate intact', () => {
     const out = injectSquareMainApplication(TEMPLATE, APP_ID);
     const superIdx = out.indexOf('super.onCreate()');
-    const idleIdx = out.indexOf('addIdleHandler');
+    const initIdx = out.indexOf('onActivityPreCreated');
     const soLoaderIdx = out.indexOf('SoLoader.init');
     expect(superIdx).toBeGreaterThan(-1);
-    expect(idleIdx).toBeGreaterThan(superIdx);
-    expect(soLoaderIdx).toBeGreaterThan(idleIdx);
+    expect(initIdx).toBeGreaterThan(superIdx);
+    expect(soLoaderIdx).toBeGreaterThan(initIdx);
     expect(out).toContain('ApplicationLifecycleDispatcher.onApplicationCreate(this)');
   });
 
@@ -70,15 +134,6 @@ describe('injectSquareMainApplication', () => {
     expect(twice).toBe(once);
   });
 
-  it('never registers the idle handler twice (single initialize call survives)', () => {
-    const out = injectSquareMainApplication(
-      injectSquareMainApplication(TEMPLATE, APP_ID),
-      APP_ID
-    );
-    expect(out.match(/MobilePaymentsSdk\.initialize/g)).toHaveLength(1);
-    expect(out.match(/addIdleHandler/g)).toHaveLength(1);
-  });
-
   it('does not re-inject over a legacy inline initialize (marker respected)', () => {
     const legacy = TEMPLATE.replace(
       'super.onCreate()',
@@ -86,6 +141,6 @@ describe('injectSquareMainApplication', () => {
     );
     const out = injectSquareMainApplication(legacy, APP_ID);
     expect(out.match(/MobilePaymentsSdk\.initialize/g)).toHaveLength(1);
-    expect(out).not.toContain('addIdleHandler');
+    expect(out).not.toContain('registerActivityLifecycleCallbacks');
   });
 });


### PR DESCRIPTION
Fixes #66 (Sentry [7632325790](https://sentry.io/organizations/hansendev-0p/issues/7632325790/) — fatal `IllegalStateException: Expected the last created activity not to be null` in `com.squareup.android.activity.ActivityListener`, release 1.47+156).

## Root cause
The cold-start ANR fix (`44ccefc`, REACT-NATIVE-1) deferred `MobilePaymentsSdk.initialize()` to the first main-thread idle — which fires **after** `MainActivity` is created. Square's `ActivityListener` (registered during `initialize()`) only tracks activities created after init, so it missed the one-and-only activity and `createdActivity` stayed null; the payments path then throws fatally.

## Fix
Init now runs in `onActivityPreCreated` (API 29+), registered in `Application.onCreate`:

- **Guaranteed before the first Activity** — `Activity.performCreate` dispatches `onActivityPreCreated` synchronously before `onCreate`; no message-queue-ordering gamble. Square's own lifecycle callback, registered during our pre-create hook, still receives the same activity's `onActivityCreated` because each dispatch takes a fresh callback snapshot (verified against AOSP `Application.java:351/363/583` and SDK 2.4.0 bytecode).
- **Still off the blocking process-start path** — background broadcast/service starts never create an activity, so they now skip Square init entirely (the class of start where `Application.onCreate` blocking actually times out).
- **API 28** (minSdk): the hook doesn't exist; init runs inline in `onCreate` as the lesser risk. Note the original ANR's single observed event was a synthetic sideloaded-AOSP-emulator device, not a real user.
- The transform migrates the 1.46+155-era idle-handler block in already-prebuilt `android/` checkouts (gitignored, so every build machine has one), warns if it finds an idle-handler init it can't migrate, and double-init is impossible (one-shot unregister-before-init; Square throws on second init).

## Tests
`plugins/withSquareSDK.test.ts` rewritten to pin the new contract — 8 named cases: init inside `onActivityPreCreated` with unregister-before-init, API<29 inline fallback, no idle handler anywhere (the #66 regression case), legacy-checkout migration + convergence + idempotency, import placement, marker respected. Full suite: 92 files / 1058 tests green.

## Verification
- `:app:compileDebugKotlin` and `:app:assembleDebug` pass on the generated code.
- API 36 emulator cold start: Square init logged at `11:52:54.670`, activity-creation machinery at `11:52:55.033`, first frame `11:52:56.5` — init beats the activity; no `IllegalStateException`, no ANR, process healthy.
- Adversarial audit (AOSP source + SDK bytecode) confirmed the dispatch-snapshot semantics, no double/zero-init path, and byte-identical migration output.

## Shipping notes
- **Native change — OTA won't carry it.** Needs new store builds (Android: sync versionCode with Play first; iOS: local build recipe).
- Before release, run one real `authorize()`/`startPayment()` on a device — the crash's symptom site is the payment flow, which an emulator cold start can't exercise.
- If a cold-start ANR ever recurs it would appear under a **new** fingerprint (at `MainActivity.performCreate`), not as a REACT-NATIVE-1 reopen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)