### PR TITLE
fix(ci): accept all GitHub closing keywords in autofix classify

### DIFF
--- a/.github/workflows/deploy-on-merge.yml
+++ b/.github/workflows/deploy-on-merge.yml
@@ -42,7 +42,9 @@ jobs:
             // itself as a manual override.
             let autofix = pr.labels.some(l => l.name === 'sentry-autofix');
             if (!autofix) {
-              const m = (pr.body || '').match(/Closes #(\d+)/i);
+              // Any GitHub closing keyword counts (a "Fixes #66" PR missed
+              // this check when it only matched "Closes").
+              const m = (pr.body || '').match(/(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?) #(\d+)/i);
               if (m) {
                 try {
                   const { data: issue } = await github.rest.issues.get({


### PR DESCRIPTION
PR #73 ("Fixes #66") was classified `autofix=false` because the classify step only matches `Closes #N` when looking up the linked issue's `sentry-autofix` label. Match GitHub's full closing-keyword set instead (close/closes/closed, fix/fixes/fixed, resolve/resolves/resolved).

Regex verified against all nine keywords plus a non-keyword control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)