### PR TITLE
feat(send): strip friction from the send flow

### DIFF
--- a/src/components/DocumentEmailPreviewModal.test.tsx
+++ b/src/components/DocumentEmailPreviewModal.test.tsx
@@ -1,0 +1,364 @@
+// @vitest-environment jsdom
+/**
+ * The email preview's posture, post Jul 2026 audit.
+ *
+ * 40 tradies stalled here holding a finished, priced quote with the
+ * customer's address on file and no gate in their way. The screen answered
+ * "send this" with a writing task: a scripted generating checklist, an
+ * editable body with a markdown toolbar, a Test Send button of equal weight
+ * to Send (and a dead end — it never records a send), and a $0 warning whose
+ * default button was retreat. These tests pin the shape that replaced it.
+ *
+ * Heavy native/expo dependency graphs are mocked out — same approach as
+ * TakePaymentSheet.test.tsx / AuthScreen.forgotPassword.test.tsx.
+ */
+import React from 'react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, fireEvent, screen, waitFor } from '@testing-library/react';
+
+vi.mock('@expo/vector-icons/MaterialCommunityIcons', () => ({ default: () => null }));
+vi.mock('expo-linear-gradient', () => ({
+  LinearGradient: ({ children }: any) => React.createElement('div', null, children),
+}));
+vi.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+  initialWindowMetrics: { insets: { top: 0, bottom: 0, left: 0, right: 0 } },
+}));
+vi.mock('react-native-paper', () => {
+  const TextInput: any = ({ value, onChangeText, multiline, placeholder }: any) =>
+    React.createElement(multiline ? 'textarea' : 'input', {
+      'data-multiline': multiline ? 'true' : undefined,
+      placeholder,
+      value: value ?? '',
+      onChange: (e: any) => onChangeText?.(e.target.value),
+    });
+  TextInput.Icon = () => null;
+  return {
+    // src/theme.ts spreads these at import time.
+    DefaultTheme: { colors: {} },
+    MD3DarkTheme: { colors: {} },
+    Text: ({ children }: any) => React.createElement('span', null, children),
+    TextInput,
+    Button: ({ children, onPress, disabled }: any) =>
+      React.createElement('button', { onClick: onPress, disabled }, children),
+    Portal: { Host: ({ children }: any) => React.createElement('div', null, children) },
+    Switch: ({ value, onValueChange }: any) =>
+      React.createElement('input', {
+        type: 'checkbox',
+        checked: !!value,
+        onChange: (e: any) => onValueChange?.(e.target.checked),
+      }),
+    ActivityIndicator: () => null,
+  };
+});
+// Renders the two buttons with their hierarchy visible to assertions.
+vi.mock('./AlertModal', () => ({
+  AlertModal: ({ visible, title, primaryButtonText, primaryButtonAction, secondaryButtonText, secondaryButtonAction }: any) =>
+    visible
+      ? React.createElement(
+          'div',
+          { 'data-testid': 'alert' },
+          React.createElement('span', null, title),
+          React.createElement('button', { 'data-role': 'primary', onClick: primaryButtonAction }, primaryButtonText),
+          secondaryButtonText
+            ? React.createElement('button', { 'data-role': 'secondary', onClick: secondaryButtonAction }, secondaryButtonText)
+            : null,
+        )
+      : null,
+}));
+vi.mock('../store/useStore', () => ({ useStore: () => ({ quotes: [] }) }));
+vi.mock('../services/analyticsService', () => ({ trackEvent: vi.fn() }));
+
+import { DocumentEmailPreviewModal } from './DocumentEmailPreviewModal';
+import { trackEvent } from '../services/analyticsService';
+// Resolves to src/test/stubs/firebase.ts via the vitest alias.
+import { auth } from '../config/firebase';
+import type { Document } from '../types/document';
+
+const tracked = vi.mocked(trackEvent);
+const fetchMock = vi.fn();
+const OWNER_EMAIL = 'jo@trade.com.au';
+
+function doc(overrides: Partial<Document> = {}): Document {
+  return {
+    id: 'q1',
+    type: 'quote',
+    stage: 'draft',
+    number: 'Q-001',
+    createdAt: 0,
+    updatedAt: 0,
+    customerName: 'Sam',
+    customerEmail: 'sam@example.com',
+    job: { name: 'Deck restain' },
+    payments: [],
+    materials: [{ id: 'm1', name: 'Decking oil', quantity: 2, unit: 'each', price: 60, totalPrice: 120 } as any],
+    laborRate: 80,
+    laborHours: 6,
+    laborTotal: 480,
+    materialsSubtotal: 120,
+    markup: 10,
+    markupAmount: 12,
+    subtotal: 612,
+    gst: 61,
+    total: 673,
+    ...overrides,
+  } as Document;
+}
+
+const EMAIL_BODY = 'Hi Sam,\n\nHere is the quote for the deck restain. Give us a bell if anything needs a tweak.';
+
+function renderModal(overrides: Partial<React.ComponentProps<typeof DocumentEmailPreviewModal>> = {}) {
+  const props = {
+    visible: true,
+    onDismiss: vi.fn(),
+    doc: doc(),
+    businessSettings: { businessName: 'Hansen Decks' } as any,
+    emailBody: EMAIL_BODY,
+    onEmailBodyChange: vi.fn(),
+    subject: 'Quotation from Hansen Decks - Deck restain',
+    onSubjectChange: vi.fn(),
+    onRegenerate: vi.fn(),
+    onSent: vi.fn(),
+    onMoreWaysToSend: vi.fn(),
+    isPro: true,
+    isRegenerating: false,
+    ...overrides,
+  };
+  return { ...render(<DocumentEmailPreviewModal {...props} />), props };
+}
+
+function eventProps(name: string) {
+  return tracked.mock.calls.find(([event]) => event === name)?.[1] as any;
+}
+
+const bodyEditor = () => document.querySelector('textarea');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  fetchMock.mockResolvedValue({ ok: true, json: async () => ({}) });
+  vi.stubGlobal('fetch', fetchMock);
+  (auth as any).currentUser = {
+    uid: 'test-uid',
+    email: OWNER_EMAIL,
+    getIdToken: vi.fn(async () => 'test-token'),
+  };
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('default posture', () => {
+  it('shows the email as a read-only preview, not an editor', () => {
+    renderModal();
+
+    expect(screen.getByText(/Here is the quote for the deck restain/)).toBeTruthy();
+    expect(bodyEditor()).toBeNull();
+  });
+
+  it('keeps the markdown toolbar out of the default view', () => {
+    renderModal();
+
+    expect(screen.queryByText(/\*\*bold\*\*/)).toBeNull();
+    expect(screen.queryByLabelText('Bold')).toBeNull();
+  });
+
+  it('leads with one prominent Send', () => {
+    renderModal();
+
+    const send = screen.getByText('Send Quote');
+    expect(send.tagName).toBe('BUTTON');
+  });
+});
+
+describe('editing the body', () => {
+  it('opens the editor and the formatting toolbar behind "Edit email"', () => {
+    renderModal();
+
+    fireEvent.click(screen.getByText('Edit email'));
+
+    expect(bodyEditor()).toBeTruthy();
+    expect(screen.getByText(/\*\*bold\*\*/)).toBeTruthy();
+  });
+
+  it('still edits the body for real', () => {
+    const { props } = renderModal();
+    fireEvent.click(screen.getByText('Edit email'));
+
+    fireEvent.change(bodyEditor()!, { target: { value: 'Rewritten by hand' } });
+
+    expect(props.onEmailBodyChange).toHaveBeenCalledWith('Rewritten by hand');
+  });
+
+  it('Done returns to the read-only posture', () => {
+    renderModal();
+    fireEvent.click(screen.getByText('Edit email'));
+
+    fireEvent.click(screen.getByText('Done'));
+
+    expect(bodyEditor()).toBeNull();
+    expect(screen.getByText('Send Quote')).toBeTruthy();
+  });
+
+  it('offers Regenerate inside edit mode only', () => {
+    renderModal();
+    expect(screen.queryByText('Regenerate')).toBeNull();
+
+    fireEvent.click(screen.getByText('Edit email'));
+
+    expect(screen.getByText('Regenerate')).toBeTruthy();
+  });
+});
+
+describe('waiting for a body', () => {
+  it('shows an honest indeterminate state, never a scripted checklist', () => {
+    renderModal({ isRegenerating: true });
+
+    expect(screen.getByText('Writing your email…')).toBeTruthy();
+    expect(screen.queryByText(/Reading quote details/)).toBeNull();
+    expect(screen.queryByText(/Crafting email tone/)).toBeNull();
+    expect(screen.queryByText(/Finalizing/)).toBeNull();
+  });
+});
+
+describe('Test Send', () => {
+  it('is a link, not a button competing with Send', () => {
+    renderModal();
+
+    const testSend = screen.getByText('Send a test to myself');
+    expect(testSend.closest('button')).toBeNull();
+    // Send remains the only real button in the footer.
+    expect(screen.getByText('Send Quote').tagName).toBe('BUTTON');
+  });
+
+  it('still sends a test to the account email', async () => {
+    renderModal();
+
+    fireEvent.click(screen.getByText('Send a test to myself'));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.isTestSend).toBe(true);
+    expect(body.recipientEmail).toBe(OWNER_EMAIL);
+    // A test is not a send: it must never be counted as one.
+    expect(tracked.mock.calls.map(([e]) => e)).not.toContain('quote_send_succeeded');
+  });
+});
+
+describe('the $0 line-item guard', () => {
+  const unpricedDoc = () =>
+    doc({
+      materials: [
+        { id: 'm1', name: 'Handrail supply', quantity: 1, unit: 'each', price: 0, totalPrice: 0 } as any,
+      ],
+    });
+
+  it('still warns before sending', async () => {
+    renderModal({ doc: unpricedDoc() });
+
+    fireEvent.click(screen.getByText('Send Quote'));
+
+    await waitFor(() => expect(screen.getByTestId('alert')).toBeTruthy());
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('leads with "Send anyway" and demotes "Go back and fix"', async () => {
+    renderModal({ doc: unpricedDoc() });
+
+    fireEvent.click(screen.getByText('Send Quote'));
+
+    await waitFor(() => expect(screen.getByText('Send anyway')).toBeTruthy());
+    expect(screen.getByText('Send anyway').getAttribute('data-role')).toBe('primary');
+    expect(screen.getByText('Go back and fix').getAttribute('data-role')).toBe('secondary');
+  });
+
+  it('sends when the warning is accepted', async () => {
+    renderModal({ doc: unpricedDoc() });
+    fireEvent.click(screen.getByText('Send Quote'));
+    await waitFor(() => expect(screen.getByText('Send anyway')).toBeTruthy());
+
+    fireEvent.click(screen.getByText('Send anyway'));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body).isTestSend).toBeUndefined();
+  });
+});
+
+describe('a successful send', () => {
+  it('reports the send and tells the host', async () => {
+    const { props } = renderModal();
+
+    fireEvent.click(screen.getByText('Send Quote'));
+
+    await waitFor(() => expect(props.onSent).toHaveBeenCalledTimes(1));
+    expect(eventProps('quote_send_succeeded')).toEqual({
+      doc_type: 'quote',
+      method: 'email',
+      to_self: false,
+    });
+  });
+
+  it('flags a send to the tradie’s own inbox as a self-send', async () => {
+    renderModal({ doc: doc({ customerEmail: OWNER_EMAIL }) });
+
+    fireEvent.click(screen.getByText('Send Quote'));
+
+    await waitFor(() => expect(eventProps('quote_send_succeeded')).toBeTruthy());
+    expect(eventProps('quote_send_succeeded').to_self).toBe(true);
+  });
+
+  it('does not count as an abandonment when the confirmation is closed', async () => {
+    renderModal();
+    fireEvent.click(screen.getByText('Send Quote'));
+    await waitFor(() => expect(screen.getByText('Quote Sent!')).toBeTruthy());
+
+    fireEvent.click(screen.getByText('Done'));
+
+    expect(tracked.mock.calls.map(([e]) => e)).not.toContain('email_preview_abandoned');
+  });
+});
+
+describe('abandonment', () => {
+  it('reports a close with nothing sent', () => {
+    renderModal();
+
+    fireEvent.click(screen.getByText('Back'));
+
+    expect(eventProps('email_preview_abandoned')).toEqual({
+      doc_type: 'quote',
+      had_recipient: true,
+      edited_body: false,
+    });
+  });
+
+  it('records whether they had an address and touched the body', () => {
+    renderModal({ doc: doc({ customerEmail: undefined }) });
+    fireEvent.click(screen.getByText('Edit email'));
+    fireEvent.change(bodyEditor()!, { target: { value: 'Reworded' } });
+    fireEvent.click(screen.getByText('Done'));
+
+    fireEvent.click(screen.getByText('Back'));
+
+    expect(eventProps('email_preview_abandoned')).toEqual({
+      doc_type: 'quote',
+      had_recipient: false,
+      edited_body: true,
+    });
+  });
+});
+
+describe('More ways to send', () => {
+  it('hands SMS / Share / Export PDF back to the host', () => {
+    const { props } = renderModal();
+
+    fireEvent.click(screen.getByText('More ways to send'));
+
+    expect(props.onMoreWaysToSend).toHaveBeenCalledTimes(1);
+  });
+
+  it('is absent when the host offers no other channels', () => {
+    renderModal({ onMoreWaysToSend: undefined });
+
+    expect(screen.queryByText('More ways to send')).toBeNull();
+  });
+});

--- a/src/components/DocumentEmailPreviewModal.tsx
+++ b/src/components/DocumentEmailPreviewModal.tsx
@@ -3,8 +3,14 @@
  *
  * Unified modal for previewing/sending the client-facing email for either a
  * quote or an invoice. Branches on `doc.type` for type-specific copy
- * (subject default, header title, AI generating step labels, send-button
- * label, sent-confirmation message) and the underlying Brevo endpoint.
+ * (subject default, header title, send-button label, sent-confirmation
+ * message) and the underlying Brevo endpoint.
+ *
+ * Jul 2026 send audit: this screen used to open as a writing task — a
+ * scripted "generating" checklist, an editable body with a markdown toolbar,
+ * and a Test Send button with the same weight as Send. The default posture
+ * is now READ-ONLY: a short preview of the email and one prominent Send.
+ * Editing is a deliberate step behind "Edit email", and Test Send is a link.
  *
  * Replaces the per-type `EmailPreviewModal` (quotes) and
  * `InvoiceEmailPreviewModal` (invoices).
@@ -20,7 +26,6 @@ import {
   Platform,
   KeyboardAvoidingView,
   Keyboard,
-  Animated,
 } from 'react-native';
 import {
   Text,
@@ -28,6 +33,7 @@ import {
   Button,
   Portal,
   Switch,
+  ActivityIndicator,
 } from 'react-native-paper';
 import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
 import { useSafeAreaInsets, initialWindowMetrics } from 'react-native-safe-area-context';
@@ -42,121 +48,20 @@ import { reviewQuoteMaterials, buildPresendWarning, type PresendWarning } from '
 import { auth } from '../config/firebase';
 import { AlertModal } from './AlertModal';
 import { useStore } from '../store/useStore';
+import { trackEvent } from '../services/analyticsService';
+import { isEmailAddress, isSelfSend } from '../utils/sendFlow';
 
-const STEP_HEIGHT = 32;
-const VISIBLE_STEPS = 3;
-const STEP_INTERVAL = 1800;
-
-const QUOTE_EMAIL_STEPS = [
-  { icon: 'file-document-outline', text: 'Reading quote details...' },
-  { icon: 'head-cog-outline', text: 'Crafting email tone...' },
-  { icon: 'text-box-outline', text: 'Writing email body...' },
-  { icon: 'check-circle-outline', text: 'Finalizing...' },
-];
-
-const INVOICE_EMAIL_STEPS = [
-  { icon: 'file-document-outline', text: 'Reading invoice details...' },
-  { icon: 'head-cog-outline', text: 'Crafting email tone...' },
-  { icon: 'text-box-outline', text: 'Writing email body...' },
-  { icon: 'check-circle-outline', text: 'Finalizing...' },
-];
-
-function EmailGeneratingState({ steps }: { steps: typeof QUOTE_EMAIL_STEPS }) {
-  const [currentStep, setCurrentStep] = useState(0);
-  const scrollAnim = useRef(new Animated.Value(0)).current;
-  const stepOpacities = useRef(steps.map((_, i) => new Animated.Value(i === 0 ? 1 : 0))).current;
-  const pulseAnim = useRef(new Animated.Value(0.3)).current;
-
-  useEffect(() => {
-    const pulse = Animated.loop(
-      Animated.sequence([
-        Animated.timing(pulseAnim, { toValue: 1, duration: 1000, useNativeDriver: true }),
-        Animated.timing(pulseAnim, { toValue: 0.3, duration: 1000, useNativeDriver: true }),
-      ])
-    );
-    pulse.start();
-    return () => pulse.stop();
-  }, []);
-
-  useEffect(() => {
-    const timers: ReturnType<typeof setTimeout>[] = [];
-
-    steps.forEach((_, index) => {
-      if (index === 0) return;
-      const timer = setTimeout(() => {
-        setCurrentStep(index);
-
-        Animated.timing(stepOpacities[index], {
-          toValue: 1,
-          duration: 350,
-          useNativeDriver: true,
-        }).start();
-
-        if (index >= VISIBLE_STEPS) {
-          Animated.timing(scrollAnim, {
-            toValue: (index - VISIBLE_STEPS + 1) * STEP_HEIGHT,
-            duration: 400,
-            useNativeDriver: true,
-          }).start();
-
-          const fadeOutIndex = index - VISIBLE_STEPS;
-          if (fadeOutIndex >= 0) {
-            Animated.timing(stepOpacities[fadeOutIndex], {
-              toValue: 0,
-              duration: 300,
-              useNativeDriver: true,
-            }).start();
-          }
-        }
-      }, index * STEP_INTERVAL);
-      timers.push(timer);
-    });
-
-    return () => timers.forEach(clearTimeout);
-  }, []);
-
+/**
+ * Honest indeterminate wait. The old version ran a four-step checklist on a
+ * fixed 1.8s-per-step timer — ~5.4s of scripted progress unrelated to the
+ * actual request, which then parked on "Finalizing...". With the body warmed
+ * on JobPreview this state usually never renders at all.
+ */
+function EmailGeneratingState() {
   return (
     <View style={styles.generatingContainer}>
-      <Animated.View style={[styles.generatingIconWrapper, { opacity: pulseAnim }]}>
-        <MaterialCommunityIcons name="email-edit-outline" size={48} color={colors.primary} />
-      </Animated.View>
-
-      <Text style={styles.generatingTitle}>Generating your email...</Text>
-
-      <View style={styles.stepsWindow}>
-        <Animated.View
-          style={[
-            styles.stepsTrack,
-            { transform: [{ translateY: Animated.multiply(scrollAnim, -1) }] },
-          ]}
-        >
-          {steps.map((step, index) => (
-            <Animated.View
-              key={index}
-              style={[
-                styles.stepRow,
-                { opacity: stepOpacities[index] },
-              ]}
-            >
-              <MaterialCommunityIcons
-                name={index < currentStep ? 'check-circle' as any : step.icon as any}
-                size={16}
-                color={index < currentStep ? colors.success : index === currentStep ? colors.primary : colors.textMuted}
-              />
-              <Text
-                style={[
-                  styles.stepText,
-                  index < currentStep && styles.stepTextDone,
-                  index === currentStep && styles.stepTextActive,
-                ]}
-                numberOfLines={1}
-              >
-                {step.text}
-              </Text>
-            </Animated.View>
-          ))}
-        </Animated.View>
-      </View>
+      <ActivityIndicator size="small" color={colors.primary} />
+      <Text style={styles.generatingTitle}>Writing your email…</Text>
     </View>
   );
 }
@@ -176,6 +81,13 @@ interface Props {
   subject: string;
   onSubjectChange: (subject: string) => void;
   onRegenerate: () => void;
+  /**
+   * Fired once the email is actually away. The host uses it to decide what
+   * happens after the preview closes (e.g. the post-send pay-link ask).
+   */
+  onSent?: () => void;
+  /** Opens the full send sheet — SMS / Share / Export PDF. */
+  onMoreWaysToSend?: () => void;
   isPro: boolean;
   isRegenerating: boolean;
 }
@@ -190,6 +102,8 @@ export function DocumentEmailPreviewModal({
   subject,
   onSubjectChange,
   onRegenerate,
+  onSent,
+  onMoreWaysToSend,
   isPro,
   isRegenerating,
 }: Props) {
@@ -220,10 +134,10 @@ export function DocumentEmailPreviewModal({
       })()
     : (documentToQuote(doc).photos || []);
 
+  const docType = isInvoice ? 'invoice' : 'quote';
   const headerTitle = isInvoice ? 'Invoice Email' : 'Email Preview';
-  const sendButtonLabel = isInvoice ? 'Send Invoice' : 'Send Email';
+  const sendButtonLabel = isInvoice ? 'Send Invoice' : 'Send Quote';
   const sentTitle = isInvoice ? 'Invoice Sent!' : 'Quote Sent!';
-  const generatingSteps = isInvoice ? INVOICE_EMAIL_STEPS : QUOTE_EMAIL_STEPS;
   const sendEndpoint = isInvoice
     ? `${FIREBASE_FUNCTIONS_URL}/sendInvoiceEmail`
     : `${FIREBASE_FUNCTIONS_URL}/sendQuoteEmail`;
@@ -247,10 +161,15 @@ export function DocumentEmailPreviewModal({
 
   // Keyboard UX state
   const scrollViewRef = useRef<ScrollView>(null);
-  const [isBodyFocused, setIsBodyFocused] = useState(false);
   const [isKeyboardVisible, setIsKeyboardVisible] = useState(false);
   const [keyboardHeight, setKeyboardHeight] = useState(0);
-  const isEditingBody = isBodyFocused && isKeyboardVisible;
+  // Editing is an explicit mode, not the default posture. Off = read-only
+  // preview + prominent Send; on = full-height editor with the formatting
+  // toolbar, the recipient/subject cards collapsed to a single bar.
+  const [isEditingBody, setIsEditingBody] = useState(false);
+  // Did the tradie actually touch the body? Distinguishes an edited email
+  // from one that merely arrived after the preview opened.
+  const [bodyEdited, setBodyEdited] = useState(false);
 
   // Body formatting toolbar. We track the last known caret/selection in a
   // ref (cheap, no re-renders) and only set the controlled `selection`
@@ -266,6 +185,13 @@ export function DocumentEmailPreviewModal({
     return () => clearTimeout(id);
   }, [pendingBodySelection]);
 
+  // Every user-driven body change funnels through here so `edited_body` on
+  // the abandonment event stays honest.
+  const handleBodyChange = (next: string) => {
+    setBodyEdited(true);
+    onEmailBodyChange(next);
+  };
+
   const applyBold = () => {
     const { start, end } = bodySelectionRef.current;
     const safeStart = Math.min(start, emailBody.length);
@@ -274,11 +200,11 @@ export function DocumentEmailPreviewModal({
     const selected = emailBody.slice(safeStart, safeEnd);
     const after = emailBody.slice(safeEnd);
     if (selected.length > 0) {
-      onEmailBodyChange(`${before}**${selected}**${after}`);
+      handleBodyChange(`${before}**${selected}**${after}`);
       setPendingBodySelection({ start: safeStart + 2, end: safeEnd + 2 });
     } else {
       const placeholder = 'bold text';
-      onEmailBodyChange(`${before}**${placeholder}**${after}`);
+      handleBodyChange(`${before}**${placeholder}**${after}`);
       const cursor = safeStart + 2;
       setPendingBodySelection({ start: cursor, end: cursor + placeholder.length });
     }
@@ -302,7 +228,7 @@ export function DocumentEmailPreviewModal({
       })
       .join('\n');
     const next = `${emailBody.slice(0, lineStart)}${transformed}${emailBody.slice(lineEnd)}`;
-    onEmailBodyChange(next);
+    handleBodyChange(next);
     const cursor = lineStart + transformed.length;
     setPendingBodySelection({ start: cursor, end: cursor });
   };
@@ -325,19 +251,16 @@ export function DocumentEmailPreviewModal({
     return () => { showSub.remove(); hideSub.remove(); };
   }, []);
 
-  const handleBodyFocus = () => {
-    setIsBodyFocused(true);
+  const startEditingBody = () => {
+    setIsEditingBody(true);
     setTimeout(() => {
       scrollViewRef.current?.scrollTo({ y: 0, animated: true });
     }, 150);
   };
 
-  const handleBodyBlur = () => {
-    setIsBodyFocused(false);
-  };
-
-  const handleCollapsedBarPress = () => {
+  const stopEditingBody = () => {
     Keyboard.dismiss();
+    setIsEditingBody(false);
     setTimeout(() => {
       scrollViewRef.current?.scrollTo({ y: 0, animated: true });
     }, 100);
@@ -359,7 +282,7 @@ export function DocumentEmailPreviewModal({
   const validateEmail = (email: string): string => {
     const trimmed = email.trim();
     if (!trimmed) return 'Email address is required';
-    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmed)) return 'Please enter a valid email address';
+    if (!isEmailAddress(trimmed)) return 'Please enter a valid email address';
     return '';
   };
 
@@ -374,8 +297,26 @@ export function DocumentEmailPreviewModal({
       setEmailTouched(false);
       setEmailError('');
       setSendCopyToSelf(false);
+      setIsEditingBody(false);
+      setBodyEdited(false);
     }
   }, [visible, doc.customerEmail]);
+
+  /**
+   * Close the preview. Anything other than a completed send is a drop-off —
+   * the exact one the Jul 2026 audit couldn't see, since 40 tradies stalled
+   * here holding a finished, priced quote.
+   */
+  const handleDismiss = () => {
+    if (!sent) {
+      trackEvent('email_preview_abandoned', {
+        doc_type: docType,
+        had_recipient: !!recipientEmail.trim(),
+        edited_body: bodyEdited,
+      });
+    }
+    onDismiss();
+  };
 
   const handleEmailChange = (text: string) => {
     setRecipientEmail(text);
@@ -468,6 +409,12 @@ export function DocumentEmailPreviewModal({
       }
 
       setSent(true);
+      trackEvent('quote_send_succeeded', {
+        doc_type: docType,
+        method: 'email',
+        to_self: isSelfSend(recipientEmail, ownerEmail),
+      });
+      onSent?.();
     } catch (error: any) {
       showAlert('error', 'Send Failed', error.message || 'Could not send the email. Please try again.');
     } finally {
@@ -475,6 +422,9 @@ export function DocumentEmailPreviewModal({
     }
   };
 
+  // Deliberately does NOT record a send: a test lands in the tradie's own
+  // inbox and the doc stays a draft. Demoted to a link for the same reason —
+  // two of the Jul 2026 audit's users test-sent and never sent for real.
   const handleTestSend = async () => {
     if (!ownerEmail) {
       showAlert('error', 'No Email', 'Could not find your account email.');
@@ -498,7 +448,11 @@ export function DocumentEmailPreviewModal({
         throw new Error(err.error || 'Failed to send test email');
       }
 
-      showAlert('success', 'Test Sent', `A test email has been sent to ${ownerEmail}`);
+      showAlert(
+        'success',
+        'Test Sent',
+        `A test email has been sent to ${ownerEmail}. Have a look, then send it to your customer.`,
+      );
     } catch (error: any) {
       showAlert('error', 'Test Failed', error.message || 'Could not send test email.');
     } finally {
@@ -522,7 +476,7 @@ export function DocumentEmailPreviewModal({
         end={{ x: 1, y: 0 }}
         style={[styles.header, { paddingTop: insets.top + 12 }]}
       >
-        <TouchableOpacity onPress={onDismiss} style={styles.headerButton}>
+        <TouchableOpacity onPress={handleDismiss} style={styles.headerButton}>
           <MaterialCommunityIcons name="chevron-left" size={26} color={colors.white} />
           <Text style={styles.backText}>Back</Text>
         </TouchableOpacity>
@@ -544,7 +498,7 @@ export function DocumentEmailPreviewModal({
           /* Collapsed Recipient + Subject bar */
           <TouchableOpacity
             style={styles.collapsedBar}
-            onPress={handleCollapsedBarPress}
+            onPress={stopEditingBody}
             activeOpacity={0.7}
           >
             <View style={styles.collapsedBarContent}>
@@ -612,7 +566,9 @@ export function DocumentEmailPreviewModal({
               <MaterialCommunityIcons name="email-edit-outline" size={18} color={colors.primary} />
             </View>
             <Text style={[styles.sectionTitle, { flex: 1 }]}>Email Body</Text>
-            {isPro && !isRegenerating && (
+            {/* Regenerate belongs to authoring, so it lives inside edit mode
+                — the default view offers one decision: send it. */}
+            {isEditingBody && isPro && !isRegenerating && (
               <TouchableOpacity
                 onPress={onRegenerate}
                 style={styles.regenerateButton}
@@ -621,12 +577,18 @@ export function DocumentEmailPreviewModal({
                 <Text style={styles.regenerateText}>Regenerate</Text>
               </TouchableOpacity>
             )}
+            {!isEditingBody && !isRegenerating && (
+              <TouchableOpacity onPress={startEditingBody} style={styles.regenerateButton}>
+                <MaterialCommunityIcons name="pencil-outline" size={16} color={colors.primary} />
+                <Text style={styles.regenerateText}>Edit email</Text>
+              </TouchableOpacity>
+            )}
           </View>
 
           {isRegenerating ? (
-            <EmailGeneratingState steps={generatingSteps} />
-          ) : (
-            <View style={[styles.bodyCard, isEditingBody && styles.bodyCardEditing]}>
+            <EmailGeneratingState />
+          ) : isEditingBody ? (
+            <View style={[styles.bodyCard, styles.bodyCardEditing]}>
               <View style={styles.formatToolbar}>
                 <TouchableOpacity onPress={applyBold} style={styles.formatButton} accessibilityLabel="Bold">
                   <Text style={styles.formatButtonBold}>B</Text>
@@ -638,21 +600,33 @@ export function DocumentEmailPreviewModal({
               </View>
               <TextInput
                 value={emailBody}
-                onChangeText={onEmailBodyChange}
-                onFocus={handleBodyFocus}
-                onBlur={handleBodyBlur}
+                onChangeText={handleBodyChange}
                 onSelectionChange={(e) => {
                   bodySelectionRef.current = e.nativeEvent.selection;
                 }}
                 selection={pendingBodySelection}
                 mode="flat"
-                style={[styles.bodyInput, isEditingBody && styles.bodyInputEditing]}
+                style={[styles.bodyInput, styles.bodyInputEditing]}
                 multiline
                 numberOfLines={12}
+                autoFocus
                 underlineColor="transparent"
                 activeUnderlineColor="transparent"
               />
             </View>
+          ) : (
+            /* Read-only preview — this is what the customer gets. Tapping it
+               is the same door as the "Edit email" link above. */
+            <TouchableOpacity
+              style={styles.bodyPreview}
+              onPress={startEditingBody}
+              activeOpacity={0.7}
+              accessibilityLabel="Edit email"
+            >
+              <Text style={styles.bodyPreviewText} numberOfLines={8}>
+                {emailBody}
+              </Text>
+            </TouchableOpacity>
           )}
         </View>
 
@@ -711,44 +685,46 @@ export function DocumentEmailPreviewModal({
         )}
       </ScrollView>
 
-      {/* Footer: Done bar when editing body, send buttons otherwise */}
+      {/* Footer: Done bar while editing, otherwise one prominent Send with
+          the secondary paths as plain links beneath it. Test Send used to be
+          a half-width button beside Send — same weight as the action that
+          actually activates the account, and a dead end (it never records a
+          send). */}
       {isEditingBody ? (
         <View style={styles.doneBar}>
-          <TouchableOpacity onPress={() => Keyboard.dismiss()} style={styles.doneButton}>
+          <TouchableOpacity onPress={stopEditingBody} style={styles.doneButton}>
             <Text style={styles.doneButtonText}>Done</Text>
           </TouchableOpacity>
         </View>
       ) : !isKeyboardVisible ? (
         <View style={[styles.footer, { paddingBottom: bottomInset }]}>
-          <View style={styles.footerButtons}>
+          <Button
+            mode="contained"
+            onPress={handleSend}
+            loading={sending}
+            disabled={sending || sendingTest || !emailBody.trim() || !!validateEmail(recipientEmail) || isRegenerating}
+            style={styles.sendButton}
+            contentStyle={styles.sendButtonContent}
+            icon="send"
+          >
+            {sending ? 'Sending...' : sendButtonLabel}
+          </Button>
+          <View style={styles.footerLinks}>
             {ownerEmail ? (
-              <View style={styles.footerButtonHalfWrapper}>
-                <Button
-                  mode="outlined"
-                  onPress={handleTestSend}
-                  loading={sendingTest}
-                  disabled={sendingTest || sending || !emailBody.trim() || isRegenerating}
-                  style={styles.footerButtonFlex}
-                  contentStyle={styles.sendButtonContent}
-                  icon="email-check-outline"
-                >
-                  {sendingTest ? 'Sending...' : 'Test Send'}
-                </Button>
-              </View>
-            ) : null}
-            <View style={styles.footerButtonHalfWrapper}>
-              <Button
-                mode="contained"
-                onPress={handleSend}
-                loading={sending}
-                disabled={sending || sendingTest || !emailBody.trim() || !!validateEmail(recipientEmail) || isRegenerating}
-                style={styles.footerButtonFlex}
-                contentStyle={styles.sendButtonContent}
-                icon="send"
+              <TouchableOpacity
+                onPress={handleTestSend}
+                disabled={sendingTest || sending || !emailBody.trim() || isRegenerating}
               >
-                {sending ? 'Sending...' : sendButtonLabel}
-              </Button>
-            </View>
+                <Text style={styles.footerLinkText}>
+                  {sendingTest ? 'Sending test…' : 'Send a test to myself'}
+                </Text>
+              </TouchableOpacity>
+            ) : null}
+            {onMoreWaysToSend ? (
+              <TouchableOpacity onPress={onMoreWaysToSend} disabled={sending || sendingTest}>
+                <Text style={styles.footerLinkText}>More ways to send</Text>
+              </TouchableOpacity>
+            ) : null}
           </View>
         </View>
       ) : null}
@@ -786,6 +762,9 @@ export function DocumentEmailPreviewModal({
           primaryButtonAction={() => setAlertVisible(false)}
           showConfetti={alertType === 'success'}
         />
+        {/* $0-row guard. The warning stays — it catches real mistakes — but
+            retreat is no longer the default button: these tradies do not
+            come back, and an unpriced row is often deliberate. */}
         <AlertModal
           visible={presendWarning !== null}
           onDismiss={() => setPresendWarning(null)}
@@ -793,15 +772,15 @@ export function DocumentEmailPreviewModal({
           icon="currency-usd-off"
           title={presendWarning?.title || ''}
           message={presendWarning?.message || ''}
-          primaryButtonText="Go back and fix"
+          primaryButtonText="Send anyway"
           primaryButtonAction={() => {
             setPresendWarning(null);
-            onDismiss();
+            doSend();
           }}
-          secondaryButtonText="Send anyway"
+          secondaryButtonText="Go back and fix"
           secondaryButtonAction={() => {
             setPresendWarning(null);
-            doSend();
+            handleDismiss();
           }}
         />
       </Portal.Host>
@@ -954,50 +933,32 @@ const styles = StyleSheet.create({
     flex: 1,
     minHeight: undefined,
   },
+  bodyPreview: {
+    backgroundColor: colors.background,
+    borderRadius: 10,
+    paddingHorizontal: 12,
+    paddingVertical: 12,
+  },
+  bodyPreviewText: {
+    fontSize: 15,
+    lineHeight: 24,
+    color: colors.text,
+  },
   generatingContainer: {
     alignItems: 'center',
     justifyContent: 'center',
+    gap: 12,
     paddingVertical: 40,
     paddingHorizontal: 20,
     backgroundColor: colors.background,
     borderRadius: 10,
-    minHeight: 200,
-  },
-  generatingIconWrapper: {
-    marginBottom: 16,
+    minHeight: 140,
   },
   generatingTitle: {
-    fontSize: 17,
+    fontSize: 15,
     fontWeight: '600',
     color: colors.text,
-    marginBottom: 16,
     textAlign: 'center',
-  },
-  stepsWindow: {
-    height: STEP_HEIGHT * VISIBLE_STEPS,
-    overflow: 'hidden',
-    alignItems: 'center',
-  },
-  stepsTrack: {
-    alignItems: 'center',
-  },
-  stepRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    height: STEP_HEIGHT,
-    gap: 10,
-  },
-  stepText: {
-    fontSize: 14,
-    color: colors.textMuted,
-  },
-  stepTextActive: {
-    color: colors.primary,
-    fontWeight: '600',
-  },
-  stepTextDone: {
-    color: colors.success,
   },
   toggleRow: {
     flexDirection: 'row',
@@ -1052,21 +1013,25 @@ const styles = StyleSheet.create({
       android: { elevation: 8 },
     }),
   },
-  footerButtons: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    width: '100%',
-    gap: 12,
-  },
-  footerButtonHalfWrapper: {
-    flex: 1,
-  },
-  footerButtonFlex: {
+  sendButton: {
     width: '100%',
     margin: 0,
   },
   sendButtonContent: {
     paddingVertical: 8,
+  },
+  footerLinks: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexWrap: 'wrap',
+    gap: 24,
+    paddingTop: 12,
+  },
+  footerLinkText: {
+    fontSize: 13,
+    color: colors.textMuted,
+    fontWeight: '600',
   },
   collapsedBar: {
     flexDirection: 'row',

--- a/src/components/SendDocumentDialog.test.tsx
+++ b/src/components/SendDocumentDialog.test.tsx
@@ -1,0 +1,372 @@
+// @vitest-environment jsdom
+/**
+ * The send flow's shape, post Jul 2026 audit.
+ *
+ * Sending is the activation event — 4 of the 25 tradies who sent a quote to a
+ * real customer pay, and none of the 113 who never sent do. Two things stood
+ * between a finished quote and a send: a five-row sheet asking how to deliver
+ * a doc we already had an address for, and a pay-link upsell sitting ABOVE
+ * Email that dropped the whole send flow when Square wasn't connected.
+ *
+ * Heavy native/expo dependency graphs are mocked out — same approach as
+ * TakePaymentSheet.test.tsx / StickyJobActionBar.test.tsx.
+ */
+import React from 'react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, fireEvent, screen, waitFor } from '@testing-library/react';
+
+vi.mock('react-native', () => ({
+  Alert: { alert: vi.fn() },
+  Share: { share: vi.fn(async () => ({ action: 'sharedAction' })), sharedAction: 'sharedAction' },
+  Linking: { openURL: vi.fn(async () => {}) },
+  Platform: { OS: 'android', select: (o: any) => o.android ?? o.default },
+}));
+vi.mock('@react-navigation/native', () => ({ useNavigation: () => ({ navigate: vi.fn() }) }));
+
+vi.mock('./ActionSheet', () => ({
+  ActionSheet: ({ visible, title, options }: any) =>
+    visible
+      ? React.createElement(
+          'div',
+          { 'data-testid': 'sheet' },
+          React.createElement('span', null, title),
+          options.map((o: any, i: number) =>
+            React.createElement('button', { key: i, onClick: o.onPress }, o.label),
+          ),
+        )
+      : null,
+}));
+vi.mock('./AlertModal', () => ({
+  AlertModal: ({ visible, title, primaryButtonText, primaryButtonAction, secondaryButtonText, secondaryButtonAction }: any) =>
+    visible
+      ? React.createElement(
+          'div',
+          { 'data-testid': 'alert' },
+          React.createElement('span', null, title),
+          React.createElement('button', { onClick: primaryButtonAction }, primaryButtonText),
+          secondaryButtonText
+            ? React.createElement('button', { onClick: secondaryButtonAction }, secondaryButtonText)
+            : null,
+        )
+      : null,
+}));
+vi.mock('./SendGateModal', () => ({ SendGateModal: () => null }));
+// Stub preview: exposes the callbacks the dialog wires into it so the tests
+// can drive "sent", "closed" and "more ways to send" without the real modal.
+vi.mock('./DocumentEmailPreviewModal', () => ({
+  DocumentEmailPreviewModal: ({ visible, onDismiss, onSent, onMoreWaysToSend, isRegenerating }: any) =>
+    visible
+      ? React.createElement(
+          'div',
+          { 'data-testid': 'preview' },
+          React.createElement('span', null, isRegenerating ? 'generating' : 'ready'),
+          React.createElement('button', { onClick: onSent }, 'stub-sent'),
+          React.createElement('button', { onClick: onDismiss }, 'stub-close'),
+          React.createElement('button', { onClick: onMoreWaysToSend }, 'stub-more'),
+        )
+      : null,
+}));
+
+vi.mock('../utils/pdfGenerator', () => ({ exportDocumentPDF: vi.fn(async () => {}) }));
+vi.mock('../utils/applyStageChange', () => ({ markDocumentSent: vi.fn(async () => {}) }));
+vi.mock('../services/analyticsService', () => ({ trackEvent: vi.fn() }));
+
+const llm = vi.hoisted(() => ({
+  generateQuoteEmail: vi.fn(async () => 'Written quote email'),
+  generateInvoiceEmail: vi.fn(async () => 'Written invoice email'),
+  getDefaultEmailBody: vi.fn(() => 'Template quote email'),
+  getDefaultInvoiceEmailBody: vi.fn(() => 'Template invoice email'),
+}));
+vi.mock('../services/llmService', () => llm);
+
+const guard = vi.hoisted(() => ({
+  ensureCanDeliver: vi.fn(async () => ({ ok: true })),
+  attachTrialPayLink: vi.fn(async () => ({ status: 'connect_required' })),
+}));
+vi.mock('../utils/quoteDeliveryGuard', () => ({
+  ...guard,
+  // Real rule, kept in sync by quoteDeliveryGuard.test.ts.
+  shouldOfferTrialPayLink: (plan: string, doc: any) => plan === 'trial' && !doc.squarePaymentLinkUrl,
+}));
+
+const store = vi.hoisted(() => ({
+  state: {
+    subscriptionStatus: { trialStartedAt: 1, trialExpired: false, isPro: false },
+    quotes: [] as any[],
+    invoices: [] as any[],
+    saveDraft: vi.fn(async () => {}),
+    saveQuote: vi.fn(async () => {}),
+    saveInvoice: vi.fn(async () => {}),
+    createInvoiceFromQuote: vi.fn(async () => {}),
+    getEffectivePlan: () => 'trial',
+  } as any,
+}));
+vi.mock('../store/useStore', () => {
+  const useStore: any = () => store.state;
+  useStore.getState = () => store.state;
+  return { useStore };
+});
+
+import { SendDocumentDialog } from './SendDocumentDialog';
+import { trackEvent } from '../services/analyticsService';
+import type { Document } from '../types/document';
+
+const tracked = vi.mocked(trackEvent);
+
+function doc(overrides: Partial<Document> = {}): Document {
+  return {
+    id: 'q1',
+    type: 'quote',
+    stage: 'draft',
+    number: 'Q-001',
+    createdAt: 0,
+    updatedAt: 0,
+    customerName: 'Sam',
+    customerEmail: 'sam@example.com',
+    job: { name: 'Deck restain', description: 'Sand and restain' },
+    payments: [],
+    materials: [],
+    laborRate: 80,
+    laborHours: 6,
+    laborTotal: 480,
+    materialsSubtotal: 200,
+    markup: 10,
+    markupAmount: 20,
+    subtotal: 700,
+    gst: 70,
+    total: 770,
+    draftEmailBody: 'Warmed on JobPreview',
+    ...overrides,
+  } as Document;
+}
+
+function renderDialog(overrides: Partial<React.ComponentProps<typeof SendDocumentDialog>> = {}) {
+  const props = {
+    visible: true,
+    onDismiss: vi.fn(),
+    doc: doc(),
+    businessSettings: { businessName: 'Hansen Decks' } as any,
+    ...overrides,
+  };
+  return { ...render(<SendDocumentDialog {...props} />), props };
+}
+
+/** Props of the first matching tracked event. */
+function eventProps(name: string) {
+  return tracked.mock.calls.find(([event]) => event === name)?.[1] as any;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  guard.ensureCanDeliver.mockResolvedValue({ ok: true } as any);
+  guard.attachTrialPayLink.mockResolvedValue({ status: 'connect_required' } as any);
+  store.state.getEffectivePlan = () => 'trial';
+});
+
+describe('opening the send flow', () => {
+  it('skips the sheet and opens the email preview when we have the address', async () => {
+    renderDialog();
+
+    await waitFor(() => expect(screen.getByTestId('preview')).toBeTruthy());
+    expect(screen.queryByTestId('sheet')).toBeNull();
+  });
+
+  it('shows the sheet when there is no address on file', async () => {
+    renderDialog({ doc: doc({ customerEmail: undefined }) });
+
+    await waitFor(() => expect(screen.getByTestId('sheet')).toBeTruthy());
+    expect(screen.queryByTestId('preview')).toBeNull();
+  });
+
+  it('treats an unusable address as no address', async () => {
+    renderDialog({ doc: doc({ customerEmail: 'not-an-email' }) });
+
+    await waitFor(() => expect(screen.getByTestId('sheet')).toBeTruthy());
+  });
+
+  it('keeps the sheet for free-plan users, whose gate does a Square round-trip first', async () => {
+    store.state.getEffectivePlan = () => 'free';
+
+    renderDialog();
+
+    await waitFor(() => expect(screen.getByTestId('sheet')).toBeTruthy());
+    expect(screen.queryByTestId('preview')).toBeNull();
+    expect(eventProps('send_sheet_opened')).toEqual({
+      doc_type: 'quote',
+      has_customer_email: true,
+      plan: 'free',
+    });
+  });
+
+  it('reports the open with doc type, address and plan', async () => {
+    renderDialog();
+
+    await waitFor(() => expect(eventProps('send_sheet_opened')).toBeTruthy());
+    expect(eventProps('send_sheet_opened')).toEqual({
+      doc_type: 'quote',
+      has_customer_email: true,
+      plan: 'trial',
+    });
+  });
+});
+
+describe('the sheet itself', () => {
+  it('offers exactly the four delivery channels, Email first', async () => {
+    renderDialog({ doc: doc({ customerEmail: undefined }) });
+
+    await waitFor(() => expect(screen.getByTestId('sheet')).toBeTruthy());
+    const labels = Array.from(screen.getByTestId('sheet').querySelectorAll('button')).map((b) => b.textContent);
+    expect(labels).toEqual(['Email', 'SMS', 'Share', 'Export PDF']);
+  });
+
+  it('no longer puts the pay-link upsell in front of the send', async () => {
+    // Trial user with no pay link — the exact case that used to show it.
+    renderDialog({ doc: doc({ customerEmail: undefined, squarePaymentLinkUrl: undefined }) });
+
+    await waitFor(() => expect(screen.getByTestId('sheet')).toBeTruthy());
+    expect(screen.queryByText(/Get paid on this/i)).toBeNull();
+    expect(tracked.mock.calls.map(([e]) => e)).not.toContain('pay_link_optin_shown');
+  });
+
+  it('records the channel chosen from the sheet', async () => {
+    renderDialog({ doc: doc({ customerEmail: undefined }) });
+    await waitFor(() => expect(screen.getByTestId('sheet')).toBeTruthy());
+
+    fireEvent.click(screen.getByText('Email'));
+
+    await waitFor(() => expect(eventProps('send_method_chosen')).toEqual({ method: 'email', doc_type: 'quote' }));
+  });
+});
+
+describe('the warmed email body', () => {
+  it('opens on a warm body with no generation and no wait', async () => {
+    renderDialog();
+
+    await waitFor(() => expect(eventProps('email_preview_opened')).toBeTruthy());
+    expect(eventProps('email_preview_opened')).toEqual({ doc_type: 'quote', prefilled: true, wait_ms: 0 });
+    expect(llm.generateQuoteEmail).not.toHaveBeenCalled();
+    expect(screen.getByText('ready')).toBeTruthy();
+  });
+
+  it('generates on the spot when nothing was warmed, and reports the real wait', async () => {
+    renderDialog({ doc: doc({ draftEmailBody: undefined }) });
+
+    await waitFor(() => expect(llm.generateQuoteEmail).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(eventProps('email_preview_opened')).toBeTruthy());
+    const props = eventProps('email_preview_opened');
+    expect(props.prefilled).toBe(false);
+    expect(typeof props.wait_ms).toBe('number');
+    expect(store.state.saveDraft).toHaveBeenCalledWith(
+      expect.objectContaining({ draftEmailBody: 'Written quote email' }),
+    );
+  });
+
+  it('falls back to the local template for free users', async () => {
+    store.state.subscriptionStatus = { trialStartedAt: null, trialExpired: true, isPro: false };
+    store.state.getEffectivePlan = () => 'free';
+    renderDialog({ doc: doc({ draftEmailBody: undefined }) });
+    await waitFor(() => expect(screen.getByTestId('sheet')).toBeTruthy());
+
+    fireEvent.click(screen.getByText('Email'));
+
+    await waitFor(() => expect(llm.getDefaultEmailBody).toHaveBeenCalled());
+    expect(llm.generateQuoteEmail).not.toHaveBeenCalled();
+    store.state.subscriptionStatus = { trialStartedAt: 1, trialExpired: false, isPro: false };
+  });
+});
+
+describe('More ways to send', () => {
+  it('swaps the preview for the full sheet', async () => {
+    renderDialog();
+    await waitFor(() => expect(screen.getByTestId('preview')).toBeTruthy());
+
+    fireEvent.click(screen.getByText('stub-more'));
+
+    expect(screen.getByTestId('sheet')).toBeTruthy();
+    expect(screen.queryByTestId('preview')).toBeNull();
+  });
+});
+
+describe('the pay-link ask, now after the send', () => {
+  it('asks once the doc is away, not before', async () => {
+    const { props } = renderDialog();
+    await waitFor(() => expect(screen.getByTestId('preview')).toBeTruthy());
+
+    fireEvent.click(screen.getByText('stub-sent'));
+    fireEvent.click(screen.getByText('stub-close'));
+
+    expect(screen.getByText('Want a Pay Now button?')).toBeTruthy();
+    expect(eventProps('pay_link_optin_shown')).toEqual({ doc_type: 'quote' });
+    // The flow stays open for the ask instead of closing out from under it.
+    expect(props.onDismiss).not.toHaveBeenCalled();
+  });
+
+  it('stays out of the way when the preview is abandoned', async () => {
+    const { props } = renderDialog();
+    await waitFor(() => expect(screen.getByTestId('preview')).toBeTruthy());
+
+    fireEvent.click(screen.getByText('stub-close'));
+
+    expect(screen.queryByText('Want a Pay Now button?')).toBeNull();
+    expect(tracked.mock.calls.map(([e]) => e)).not.toContain('pay_link_optin_shown');
+    expect(props.onDismiss).toHaveBeenCalled();
+  });
+
+  it('is not offered to a doc that already carries a pay link', async () => {
+    renderDialog({ doc: doc({ squarePaymentLinkUrl: 'https://sq.link/x' }) });
+    await waitFor(() => expect(screen.getByTestId('preview')).toBeTruthy());
+
+    fireEvent.click(screen.getByText('stub-sent'));
+    fireEvent.click(screen.getByText('stub-close'));
+
+    expect(screen.queryByText('Want a Pay Now button?')).toBeNull();
+  });
+
+  it('records the opt-in outcome when taken', async () => {
+    renderDialog();
+    await waitFor(() => expect(screen.getByTestId('preview')).toBeTruthy());
+    fireEvent.click(screen.getByText('stub-sent'));
+    fireEvent.click(screen.getByText('stub-close'));
+
+    fireEvent.click(screen.getByText('Set it up'));
+
+    await waitFor(() => expect(guard.attachTrialPayLink).toHaveBeenCalledTimes(1));
+    expect(eventProps('pay_link_optin_tapped')).toEqual({ doc_type: 'quote', outcome: 'connect_required' });
+  });
+
+  it('"Not now" closes the flow without attaching anything', async () => {
+    const { props } = renderDialog();
+    await waitFor(() => expect(screen.getByTestId('preview')).toBeTruthy());
+    fireEvent.click(screen.getByText('stub-sent'));
+    fireEvent.click(screen.getByText('stub-close'));
+
+    fireEvent.click(screen.getByText('Not now'));
+
+    expect(guard.attachTrialPayLink).not.toHaveBeenCalled();
+    expect(props.onDismiss).toHaveBeenCalled();
+  });
+});
+
+describe('non-email channels', () => {
+  it('records the method and the send for SMS', async () => {
+    renderDialog({ doc: doc({ customerEmail: undefined, customerPhone: '0412345678' }) });
+    await waitFor(() => expect(screen.getByTestId('sheet')).toBeTruthy());
+
+    fireEvent.click(screen.getByText('SMS'));
+
+    await waitFor(() => expect(eventProps('quote_send_succeeded')).toBeTruthy());
+    expect(eventProps('send_method_chosen')).toEqual({ method: 'sms', doc_type: 'quote' });
+    expect(eventProps('quote_send_succeeded')).toEqual({ doc_type: 'quote', method: 'sms', to_self: false });
+  });
+});
+
+describe('the free-tier send gate', () => {
+  it('still opens instead of the preview, and keeps its event', async () => {
+    guard.ensureCanDeliver.mockResolvedValue({ ok: false, reason: 'connect_square', message: 'Connect Square' } as any);
+
+    renderDialog();
+
+    await waitFor(() => expect(eventProps('send_gate_shown')).toEqual({ doc_type: 'quote' }));
+    expect(screen.queryByTestId('preview')).toBeNull();
+  });
+});

--- a/src/components/SendDocumentDialog.test.tsx
+++ b/src/components/SendDocumentDialog.test.tsx
@@ -54,15 +54,17 @@ vi.mock('./SendGateModal', () => ({ SendGateModal: () => null }));
 // Stub preview: exposes the callbacks the dialog wires into it so the tests
 // can drive "sent", "closed" and "more ways to send" without the real modal.
 vi.mock('./DocumentEmailPreviewModal', () => ({
-  DocumentEmailPreviewModal: ({ visible, onDismiss, onSent, onMoreWaysToSend, isRegenerating }: any) =>
+  DocumentEmailPreviewModal: ({ visible, onDismiss, onSent, onMoreWaysToSend, onEmailBodyChange, emailBody, isRegenerating }: any) =>
     visible
       ? React.createElement(
           'div',
           { 'data-testid': 'preview' },
           React.createElement('span', null, isRegenerating ? 'generating' : 'ready'),
+          React.createElement('span', { 'data-testid': 'preview-body' }, emailBody),
           React.createElement('button', { onClick: onSent }, 'stub-sent'),
           React.createElement('button', { onClick: onDismiss }, 'stub-close'),
           React.createElement('button', { onClick: onMoreWaysToSend }, 'stub-more'),
+          React.createElement('button', { onClick: () => onEmailBodyChange('MY HAND EDITS') }, 'stub-edit'),
         )
       : null,
 }));
@@ -108,6 +110,7 @@ vi.mock('../store/useStore', () => {
 });
 
 import { SendDocumentDialog } from './SendDocumentDialog';
+import { resetWarmedEmailDrafts, warmEmailDraft } from '../utils/emailDraft';
 import { trackEvent } from '../services/analyticsService';
 import type { Document } from '../types/document';
 
@@ -158,6 +161,7 @@ function eventProps(name: string) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  resetWarmedEmailDrafts();
   guard.ensureCanDeliver.mockResolvedValue({ ok: true } as any);
   guard.attachTrialPayLink.mockResolvedValue({ status: 'connect_required' } as any);
   store.state.getEffectivePlan = () => 'trial';
@@ -261,6 +265,43 @@ describe('the warmed email body', () => {
     );
   });
 
+  // The warm body lives in memory, not on the doc: draftEmailBody only
+  // reaches the unified Document after a Firestore round-trip through the
+  // server-side mirror, which routinely hasn't landed by the time a tradie
+  // taps Send off JobPreview.
+  it('uses a body warmed on JobPreview even though the doc has not caught up', async () => {
+    await warmEmailDraft(doc({ draftEmailBody: undefined }), { businessName: 'Hansen Decks' } as any, { isPro: true });
+    llm.generateQuoteEmail.mockClear();
+
+    renderDialog({ doc: doc({ draftEmailBody: undefined }) });
+
+    await waitFor(() => expect(screen.getByTestId('preview')).toBeTruthy());
+    expect(screen.getByTestId('preview-body').textContent).toBe('Written quote email');
+    expect(llm.generateQuoteEmail).not.toHaveBeenCalled();
+    expect(eventProps('email_preview_opened')).toEqual({ doc_type: 'quote', prefilled: true, wait_ms: 0 });
+    // Persisted on the tradie's own tap, so the next session opens warm too.
+    expect(store.state.saveDraft).toHaveBeenCalledWith(
+      expect.objectContaining({ draftEmailBody: 'Written quote email' }),
+    );
+  });
+
+  it('waits on an in-flight warm-up instead of paying for a second generation', async () => {
+    let release: (body: string) => void = () => {};
+    llm.generateQuoteEmail.mockImplementationOnce(
+      () => new Promise<string>((resolve) => { release = resolve; }),
+    );
+    const warming = warmEmailDraft(doc({ draftEmailBody: undefined }), { businessName: 'Hansen Decks' } as any, { isPro: true });
+
+    renderDialog({ doc: doc({ draftEmailBody: undefined }) });
+    await waitFor(() => expect(screen.getByText('generating')).toBeTruthy());
+    release('Written quote email');
+    await warming;
+
+    await waitFor(() => expect(screen.getByText('ready')).toBeTruthy());
+    expect(llm.generateQuoteEmail).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('preview-body').textContent).toBe('Written quote email');
+  });
+
   it('falls back to the local template for free users', async () => {
     store.state.subscriptionStatus = { trialStartedAt: null, trialExpired: true, isPro: false };
     store.state.getEffectivePlan = () => 'free';
@@ -285,6 +326,34 @@ describe('More ways to send', () => {
     expect(screen.getByTestId('sheet')).toBeTruthy();
     expect(screen.queryByTestId('preview')).toBeNull();
   });
+
+  // The host holds `doc` in state, so the prop never refreshes mid-session:
+  // reseeding the body on the way back would revert the tradie's own words —
+  // and send the pre-edit copy, since the save then sees "no change".
+  it('keeps hand edits when coming back to Email', async () => {
+    renderDialog();
+    await waitFor(() => expect(screen.getByTestId('preview')).toBeTruthy());
+    fireEvent.click(screen.getByText('stub-edit'));
+    fireEvent.click(screen.getByText('stub-more'));
+
+    fireEvent.click(screen.getByText('Email'));
+
+    await waitFor(() => expect(screen.getByTestId('preview')).toBeTruthy());
+    expect(screen.getByTestId('preview-body').textContent).toBe('MY HAND EDITS');
+  });
+
+  it('does not re-generate a cold body on the way back', async () => {
+    renderDialog({ doc: doc({ draftEmailBody: undefined }) });
+    await waitFor(() => expect(llm.generateQuoteEmail).toHaveBeenCalledTimes(1));
+    fireEvent.click(screen.getByText('stub-edit'));
+    fireEvent.click(screen.getByText('stub-more'));
+
+    fireEvent.click(screen.getByText('Email'));
+
+    await waitFor(() => expect(screen.getByTestId('preview')).toBeTruthy());
+    expect(llm.generateQuoteEmail).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('preview-body').textContent).toBe('MY HAND EDITS');
+  });
 });
 
 describe('the pay-link ask, now after the send', () => {
@@ -299,6 +368,20 @@ describe('the pay-link ask, now after the send', () => {
     expect(eventProps('pay_link_optin_shown')).toEqual({ doc_type: 'quote' });
     // The flow stays open for the ask instead of closing out from under it.
     expect(props.onDismiss).not.toHaveBeenCalled();
+  });
+
+  // The doc snapshot this dialog holds is stamped `draft`; re-writing the
+  // legacy quote from it after a send merges that status straight back over
+  // the server's sent stamp.
+  it('does not re-write the doc once it has gone out', async () => {
+    renderDialog();
+    await waitFor(() => expect(screen.getByTestId('preview')).toBeTruthy());
+    store.state.saveDraft.mockClear();
+
+    fireEvent.click(screen.getByText('stub-sent'));
+    fireEvent.click(screen.getByText('stub-close'));
+
+    expect(store.state.saveDraft).not.toHaveBeenCalled();
   });
 
   it('stays out of the way when the preview is abandoned', async () => {

--- a/src/components/SendDocumentDialog.tsx
+++ b/src/components/SendDocumentDialog.tsx
@@ -2,15 +2,23 @@
  * SendDocumentDialog — purely controlled version of the send-flow UI.
  *
  * Extracted from SendDocumentButton so non-button surfaces (e.g. the
- * StickyJobActionBar on ViewJob) can drive the exact same UX: Action
- * Sheet with Email / SMS / Share / Export PDF, plus the AI email
- * preview modal once they pick Email.
+ * StickyJobActionBar on ViewJob) can drive the exact same UX, plus the
+ * email preview modal.
  *
- * SendDocumentButton itself now wraps this dialog — nothing changes
- * visually for existing callers.
+ * Jul 2026 send audit — sending is the activation event, and the tap-to-send
+ * path was where finished quotes died. Two shape changes came out of it:
+ *   1. A doc we already have an email address for goes STRAIGHT to the email
+ *      preview. The sheet (SMS / Share / Export PDF) stays one tap away
+ *      behind "More ways to send", and is still the entry point when there's
+ *      no address on file.
+ *   2. The Path B pay-link opt-in no longer sits above Email in the sheet —
+ *      tapping it without Square connected abandoned the send entirely. It
+ *      now asks AFTER the doc is out the door, aimed at the next one.
+ *
+ * SendDocumentButton itself wraps this dialog — nothing changes for callers.
  */
 
-import React, { useMemo, useState, useEffect } from 'react';
+import React, { useMemo, useRef, useState, useEffect } from 'react';
 import { Alert, Share, Linking, Platform } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { format } from 'date-fns';
@@ -28,15 +36,12 @@ import {
   shouldOfferTrialPayLink,
 } from '../utils/quoteDeliveryGuard';
 import { ActionSheet, ActionSheetOption } from './ActionSheet';
+import { AlertModal } from './AlertModal';
 import { DocumentEmailPreviewModal } from './DocumentEmailPreviewModal';
 import { SendGateModal } from './SendGateModal';
 import { trackEvent } from '../services/analyticsService';
-import {
-  generateQuoteEmail,
-  getDefaultEmailBody,
-  generateInvoiceEmail,
-  getDefaultInvoiceEmailBody,
-} from '../services/llmService';
+import { buildEmailBodySource } from '../utils/emailDraft';
+import { hasCustomerEmail } from '../utils/sendFlow';
 
 interface SendDocumentDialogProps {
   visible: boolean;
@@ -78,10 +83,16 @@ export function SendDocumentDialog({
   const [isGeneratingEmail, setIsGeneratingEmail] = useState(false);
   const [payLinkAttached, setPayLinkAttached] = useState(false);
   const [isAttachingPayLink, setIsAttachingPayLink] = useState(false);
+  const [payLinkOfferVisible, setPayLinkOfferVisible] = useState(false);
+  // Set by the preview modal on a successful send; gates the post-send
+  // pay-link ask so we only pitch payments to someone who just delivered.
+  const emailSentRef = useRef(false);
 
-  // Path B opt-in: offer trial users a Pay Now link at the moment they're
-  // sending real work — connection happens while they're engaged, not at the
-  // post-trial gate. Free users are gated instead; Pro/linked docs need nothing.
+  const docType = isInvoice ? 'invoice' : 'quote';
+
+  // Path B opt-in: offer trial users a Pay Now link once this doc has gone
+  // out, so the next one can carry a card button. Free users are gated
+  // instead; Pro/linked docs need nothing.
   const offerPayLink =
     shouldOfferTrialPayLink(getEffectivePlan(), doc) && !payLinkAttached;
 
@@ -93,26 +104,6 @@ export function SendDocumentDialog({
       : `Quotation from ${businessName} - ${jobName}`;
   })();
 
-  // Mirror external `visible` → internal ActionSheet open. Tapping a
-  // row in the sheet (Email) may swap us over to the email preview,
-  // which is why we keep two sub-states instead of trusting `visible`
-  // alone.
-  useEffect(() => {
-    if (visible) setActionSheetVisible(true);
-    else {
-      setActionSheetVisible(false);
-      setEmailPreviewVisible(false);
-    }
-  }, [visible]);
-
-  // One impression per sheet open — the attach-rate denominator.
-  useEffect(() => {
-    if (actionSheetVisible && offerPayLink) {
-      trackEvent('pay_link_optin_shown', { doc_type: isInvoice ? 'invoice' : 'quote' });
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [actionSheetVisible]);
-
   type EmailHandler = {
     draftBody: string | undefined;
     draftSubject: string | undefined;
@@ -122,53 +113,22 @@ export function SendDocumentDialog({
     persistSubject: (subject: string) => void;
   };
 
+  // generate/fallback come from the shared source so a body warmed on
+  // JobPreview is exactly what this flow would have produced on tap.
+  const bodySource = buildEmailBodySource(doc, businessSettings);
+
   const emailHandler: EmailHandler = isInvoice
     ? {
         draftBody: invoice.draftEmailBody,
         draftSubject: invoice.draftEmailSubject,
-        generate: () => generateInvoiceEmail({
-          jobName: invoice.job.name,
-          jobDescription: invoice.job.description || '',
-          materials: invoice.materials.map((m) => ({ name: m.name, quantity: m.quantity, unit: m.unit })),
-          laborHours: invoice.laborHours,
-          total: invoice.total,
-          businessName: businessSettings?.businessName || '',
-          customerName: invoice.customerName,
-          dueDate: new Date(invoice.dueDate).toISOString(),
-          invoiceNumber: invoice.invoiceNumber,
-          gstRegistered: invoice.gstRegistered,
-        }),
-        fallback: () => getDefaultInvoiceEmailBody(
-          invoice.customerName,
-          invoice.job.name,
-          invoice.total,
-          businessSettings?.businessName || 'Your Business',
-          new Date(invoice.dueDate).toISOString(),
-          invoice.gstRegistered,
-        ),
+        ...bodySource,
         persistBody: (body) => { saveInvoice({ ...invoice, draftEmailBody: body }); },
         persistSubject: (subject) => { saveInvoice({ ...invoice, draftEmailSubject: subject }); },
       }
     : {
         draftBody: quote.draftEmailBody,
         draftSubject: quote.draftEmailSubject,
-        generate: () => generateQuoteEmail({
-          jobName: quote.job.name,
-          jobDescription: quote.job.description || '',
-          materials: quote.materials.map((m) => ({ name: m.name, quantity: m.quantity, unit: m.unit })),
-          laborHours: quote.laborHours,
-          total: quote.total,
-          businessName: businessSettings?.businessName || '',
-          customerName: quote.customerName,
-          gstRegistered: quote.gstRegistered,
-        }),
-        fallback: () => getDefaultEmailBody(
-          quote.customerName,
-          quote.job.name,
-          quote.total,
-          businessSettings?.businessName || 'Your Business',
-          quote.gstRegistered,
-        ),
+        ...bodySource,
         persistBody: (body) => { saveDraft({ ...quote, draftEmailBody: body }); },
         persistSubject: (subject) => { saveDraft({ ...quote, draftEmailSubject: subject }); },
       };
@@ -207,12 +167,17 @@ export function SendDocumentDialog({
   const handleEmailOption = async () => {
     if (!(await passesDeliveryGate())) return;
     setActionSheetVisible(false);
+    trackEvent('send_method_chosen', { method: 'email', doc_type: docType });
     setEmailSubject(emailHandler.draftSubject || defaultSubject);
+    // Warm body (pre-generated on JobPreview, or written on a previous open):
+    // straight into the preview, no wait at all.
     if (emailHandler.draftBody) {
       setEmailBody(emailHandler.draftBody);
       setEmailPreviewVisible(true);
+      trackEvent('email_preview_opened', { doc_type: docType, prefilled: true, wait_ms: 0 });
       return;
     }
+    const startedAt = Date.now();
     setIsGeneratingEmail(true);
     setEmailPreviewVisible(true);
     try {
@@ -225,8 +190,41 @@ export function SendDocumentDialog({
       emailHandler.persistBody(fallback);
     } finally {
       setIsGeneratingEmail(false);
+      // Logged once the body actually lands, so wait_ms is the wait the
+      // tradie sat through rather than a scripted animation.
+      trackEvent('email_preview_opened', {
+        doc_type: docType,
+        prefilled: false,
+        wait_ms: Date.now() - startedAt,
+      });
     }
   };
+
+  // Mirror external `visible` → the send flow. A doc with an address on file
+  // skips the sheet entirely (email is the dominant path); without one, the
+  // sheet is still the right place to start.
+  useEffect(() => {
+    if (!visible) {
+      setActionSheetVisible(false);
+      setEmailPreviewVisible(false);
+      setPayLinkOfferVisible(false);
+      emailSentRef.current = false;
+      return;
+    }
+    const plan = getEffectivePlan();
+    trackEvent('send_sheet_opened', {
+      doc_type: docType,
+      has_customer_email: hasCustomerEmail(doc),
+      plan,
+    });
+    // Free plan keeps the sheet: its delivery gate does a Square round-trip
+    // (and may mint a payment link) before anything can go out, so routing
+    // straight through would leave the tradie tapping Send and watching an
+    // unchanged screen. On the sheet, that wait happens with the UI already up.
+    if (plan !== 'free' && hasCustomerEmail(doc)) void handleEmailOption();
+    else setActionSheetVisible(true);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [visible]);
 
   const handleRegenerateEmail = async () => {
     setIsGeneratingEmail(true);
@@ -243,6 +241,25 @@ export function SendDocumentDialog({
 
   const handleEmailPreviewDismiss = () => {
     setEmailPreviewVisible(false);
+    persistEmailEdits();
+    // Ask about payments only once the doc is actually out the door — the
+    // ask used to sit in front of the send and cost us the send itself.
+    if (emailSentRef.current && offerPayLink) {
+      trackEvent('pay_link_optin_shown', { doc_type: docType });
+      setPayLinkOfferVisible(true);
+      return;
+    }
+    onDismiss();
+  };
+
+  /** Swap the email preview for the full sheet (SMS / Share / Export PDF). */
+  const handleMoreWaysToSend = () => {
+    persistEmailEdits();
+    setEmailPreviewVisible(false);
+    setActionSheetVisible(true);
+  };
+
+  const persistEmailEdits = () => {
     // Persist body + subject together so a single write covers both edits
     // and they stay in sync on reopen.
     const trimmedSubject = emailSubject.trim();
@@ -266,7 +283,6 @@ export function SendDocumentDialog({
         });
       }
     }
-    onDismiss();
   };
 
   // Record a non-email delivery (SMS / Share / Export) against the doc so its
@@ -283,12 +299,15 @@ export function SendDocumentDialog({
       // Best-effort audit; ignore.
       return;
     }
+    // No recipient on these channels, so they can never be a self-send.
+    trackEvent('quote_send_succeeded', { doc_type: docType, method, to_self: false });
     if (wasDraft) onMarkedSent?.(doc, method);
   };
 
   const handleSendSMS = async () => {
     if (!(await passesDeliveryGate())) return;
     setActionSheetVisible(false);
+    trackEvent('send_method_chosen', { method: 'sms', doc_type: docType });
     const message = isInvoice
       ? `Hi ${invoice.customerName}, your invoice from ${businessSettings?.businessName || 'us'} for ${invoice.job.name} is ready. Total: ${formatCurrency(invoice.total)}. Payment due: ${format(new Date(invoice.dueDate), 'dd MMM yyyy')}. Thank you!`
       : `Hi ${quote.customerName}, your quote from ${businessSettings?.businessName || 'us'} for ${quote.job.name} is ready. Total: ${formatCurrency(quote.total)}. Thank you for your business!`;
@@ -308,6 +327,7 @@ export function SendDocumentDialog({
   const handleShareFromDialog = async () => {
     if (!(await passesDeliveryGate())) return;
     setActionSheetVisible(false);
+    trackEvent('send_method_chosen', { method: 'share', doc_type: docType });
     try {
       const message = isInvoice
         ? `Invoice for ${invoice.customerName}\n${invoice.job.name}\nTotal: ${formatCurrency(invoice.total)}\nDue: ${format(new Date(invoice.dueDate), 'dd MMM yyyy')}`
@@ -325,6 +345,7 @@ export function SendDocumentDialog({
   const handleExportFromDialog = async () => {
     if (!(await passesDeliveryGate())) return;
     setActionSheetVisible(false);
+    trackEvent('send_method_chosen', { method: 'export_pdf', doc_type: docType });
     try {
       await exportDocumentPDF(doc, businessSettings, 'export', { isPro });
       await recordSend('export_pdf');
@@ -335,10 +356,11 @@ export function SendDocumentDialog({
   };
 
   /**
-   * Trial opt-in: attach a Pay Now link to this doc before it goes out. Not
-   * connected yet → route to SquareIntegrationScreen (square_connected fires
-   * there on OAuth success) and the tradie sends after connecting. Never
-   * blocks — the plain send options above it always work.
+   * Trial opt-in, taken AFTER the doc has gone out: wire up Square so the
+   * next one can carry a Pay Now button. Not connected yet → route to
+   * SquareIntegrationScreen (square_connected fires there on OAuth success);
+   * already connected → the link lands on this doc too, so the customer can
+   * still pay from its online page.
    */
   const handleAddPayLink = async () => {
     if (isAttachingPayLink) return;
@@ -348,40 +370,35 @@ export function SendDocumentDialog({
         isInvoice ? { kind: 'invoice', doc: invoice } : { kind: 'quote', doc: quote }
       );
       trackEvent('pay_link_optin_tapped', {
-        doc_type: isInvoice ? 'invoice' : 'quote',
+        doc_type: docType,
         outcome: result.status,
       });
+      setPayLinkOfferVisible(false);
       if (result.status === 'connect_required') {
-        setActionSheetVisible(false);
         onDismiss();
         navigation.navigate('SquareIntegration' as never);
       } else if (result.status === 'attached') {
         setPayLinkAttached(true);
         Alert.alert(
           'Pay Now button added',
-          `Your customer can pay this ${isInvoice ? 'invoice' : 'quote'} by card the moment it lands. Send it whichever way suits.`
+          `Your customer can pay this ${isInvoice ? 'invoice' : 'quote'} by card from its online page.`,
+          [{ text: 'OK', onPress: onDismiss }],
         );
       } else {
-        Alert.alert("Couldn't add the pay link", result.message);
+        Alert.alert("Couldn't add the pay link", result.message, [{ text: 'OK', onPress: onDismiss }]);
       }
     } finally {
       setIsAttachingPayLink(false);
     }
   };
 
+  const dismissPayLinkOffer = () => {
+    setPayLinkOfferVisible(false);
+    onDismiss();
+  };
+
   const sendOptions: ActionSheetOption[] = [
-    ...(offerPayLink
-      ? [{
-          icon: 'credit-card-fast-outline',
-          label: isAttachingPayLink
-            ? 'Adding your Pay Now button…'
-            : isInvoice
-              ? 'Get paid on this invoice'
-              : 'Get paid on this quote',
-          onPress: handleAddPayLink,
-        }]
-      : []),
-    { icon: 'email-outline', label: 'Email', onPress: handleEmailOption, divider: offerPayLink },
+    { icon: 'email-outline', label: 'Email', onPress: handleEmailOption },
     { icon: 'message-text', label: 'SMS', onPress: handleSendSMS },
     { icon: 'share-variant', label: 'Share', onPress: handleShareFromDialog },
     { icon: 'file-pdf-box', label: 'Export PDF', onPress: handleExportFromDialog },
@@ -407,8 +424,26 @@ export function SendDocumentDialog({
         subject={emailSubject}
         onSubjectChange={setEmailSubject}
         onRegenerate={handleRegenerateEmail}
+        onMoreWaysToSend={handleMoreWaysToSend}
+        onSent={() => { emailSentRef.current = true; }}
         isPro={isPro}
         isRegenerating={isGeneratingEmail}
+      />
+
+      {/* Post-send Path B ask. Deliberately after delivery: in front of it,
+          this row cost sends outright when Square wasn't connected. */}
+      <AlertModal
+        visible={payLinkOfferVisible}
+        onDismiss={dismissPayLinkOffer}
+        type="info"
+        icon="credit-card-fast-outline"
+        title="Want a Pay Now button?"
+        message={`Connect Square and your ${isInvoice ? 'invoices' : 'quotes'} go out with a Pay Now button — your customer can pay by card the moment it lands.`}
+        primaryButtonText="Set it up"
+        primaryButtonAction={handleAddPayLink}
+        primaryButtonLoading={isAttachingPayLink}
+        secondaryButtonText="Not now"
+        secondaryButtonAction={dismissPayLinkOffer}
       />
 
       <SendGateModal

--- a/src/components/SendDocumentDialog.tsx
+++ b/src/components/SendDocumentDialog.tsx
@@ -40,7 +40,11 @@ import { AlertModal } from './AlertModal';
 import { DocumentEmailPreviewModal } from './DocumentEmailPreviewModal';
 import { SendGateModal } from './SendGateModal';
 import { trackEvent } from '../services/analyticsService';
-import { buildEmailBodySource } from '../utils/emailDraft';
+import {
+  buildEmailBodySource,
+  getWarmedEmailBody,
+  whenEmailDraftWarm,
+} from '../utils/emailDraft';
 import { hasCustomerEmail } from '../utils/sendFlow';
 
 interface SendDocumentDialogProps {
@@ -85,8 +89,12 @@ export function SendDocumentDialog({
   const [isAttachingPayLink, setIsAttachingPayLink] = useState(false);
   const [payLinkOfferVisible, setPayLinkOfferVisible] = useState(false);
   // Set by the preview modal on a successful send; gates the post-send
-  // pay-link ask so we only pitch payments to someone who just delivered.
+  // pay-link ask so we only pitch payments to someone who just delivered,
+  // and stops us re-writing the doc once it has left.
   const emailSentRef = useRef(false);
+  // The doc whose body `emailBody` currently holds. Guards against reseeding
+  // over the tradie's own edits when the preview is reopened in one session.
+  const seededDocIdRef = useRef<string | null>(null);
 
   const docType = isInvoice ? 'invoice' : 'quote';
 
@@ -164,29 +172,60 @@ export function SendDocumentDialog({
     return false;
   };
 
+  const openPreviewWithBody = (body: string, prefilled: boolean, waitMs: number) => {
+    setEmailBody(body);
+    seededDocIdRef.current = doc.id;
+    setEmailPreviewVisible(true);
+    trackEvent('email_preview_opened', { doc_type: docType, prefilled, wait_ms: waitMs });
+  };
+
   const handleEmailOption = async () => {
     if (!(await passesDeliveryGate())) return;
     setActionSheetVisible(false);
     trackEvent('send_method_chosen', { method: 'email', doc_type: docType });
-    setEmailSubject(emailHandler.draftSubject || defaultSubject);
-    // Warm body (pre-generated on JobPreview, or written on a previous open):
-    // straight into the preview, no wait at all.
-    if (emailHandler.draftBody) {
-      setEmailBody(emailHandler.draftBody);
+
+    // Coming back from "More ways to send" — `emailBody` already holds this
+    // session's copy, hand-edits and all. Reseeding from the (frozen) doc
+    // prop here would silently throw those edits away and send the old text.
+    if (seededDocIdRef.current === doc.id) {
       setEmailPreviewVisible(true);
       trackEvent('email_preview_opened', { doc_type: docType, prefilled: true, wait_ms: 0 });
       return;
     }
+
+    setEmailSubject(emailHandler.draftSubject || defaultSubject);
+
+    // Body written on a previous open, or warmed on JobPreview: straight into
+    // the preview, no wait at all.
+    if (emailHandler.draftBody) {
+      openPreviewWithBody(emailHandler.draftBody, true, 0);
+      return;
+    }
+    const warmed = getWarmedEmailBody(doc.id);
+    if (warmed) {
+      openPreviewWithBody(warmed, true, 0);
+      emailHandler.persistBody(warmed);
+      return;
+    }
+
     const startedAt = Date.now();
     setIsGeneratingEmail(true);
     setEmailPreviewVisible(true);
     try {
-      const body = isPro ? await emailHandler.generate() : emailHandler.fallback();
+      // A warm-up already running for this doc is the common case when the
+      // tradie sends straight off JobPreview — wait on it rather than paying
+      // for a second generation of the same email.
+      const warming = whenEmailDraftWarm(doc.id);
+      if (warming) await warming;
+      const body = getWarmedEmailBody(doc.id)
+        ?? (isPro ? await emailHandler.generate() : emailHandler.fallback());
       setEmailBody(body);
+      seededDocIdRef.current = doc.id;
       emailHandler.persistBody(body);
     } catch {
       const fallback = emailHandler.fallback();
       setEmailBody(fallback);
+      seededDocIdRef.current = doc.id;
       emailHandler.persistBody(fallback);
     } finally {
       setIsGeneratingEmail(false);
@@ -209,6 +248,7 @@ export function SendDocumentDialog({
       setEmailPreviewVisible(false);
       setPayLinkOfferVisible(false);
       emailSentRef.current = false;
+      seededDocIdRef.current = null;
       return;
     }
     const plan = getEffectivePlan();
@@ -241,7 +281,11 @@ export function SendDocumentDialog({
 
   const handleEmailPreviewDismiss = () => {
     setEmailPreviewVisible(false);
-    persistEmailEdits();
+    // Only worth saving while the doc is still going out. After a send there
+    // is nothing to preserve — the sent copy is already away — and this write
+    // reconstructs the legacy quote from a doc snapshot stamped `draft`,
+    // which merges straight back over the server's sent status.
+    if (!emailSentRef.current) persistEmailEdits();
     // Ask about payments only once the doc is actually out the door — the
     // ask used to sit in front of the send and cost us the send itself.
     if (emailSentRef.current && offerPayLink) {

--- a/src/screens/NewQuote/JobPreviewScreen.tsx
+++ b/src/screens/NewQuote/JobPreviewScreen.tsx
@@ -27,6 +27,7 @@ import { useNavigation, useRoute } from '@react-navigation/native';
 import { useStore } from '../../store/useStore';
 import { useDocumentMode } from '../../utils/documentMode';
 import { ensureSquareConnectedForPayment } from '../../utils/quoteDeliveryGuard';
+import { warmEmailDraft } from '../../utils/emailDraft';
 import { colors } from '../../theme';
 import { previewDocumentPDF } from '../../utils/pdfGenerator';
 // until the user actually requests a PDF preview.
@@ -244,6 +245,13 @@ export function JobPreviewScreen() {
     // saveInvoice (which assigns invoiceNumbers) and quotes through
     // saveQuote (which assigns quoteNumbers). The mirror + adapter carry
     // everything into the unified documents collection either way.
+    //
+    // Each branch then warms the customer email off the saved doc. Jul 2026
+    // send audit: tapping "Send Quote" handed the tradie a writing task they
+    // never asked for, so the body is generated here instead — by the time
+    // they tap Send it's already written. Fire-and-forget by design: it never
+    // blocks this screen, never throws into the UI, no-ops when a body
+    // already exists, and only runs after the save so it can't race it.
     const autoSave = async () => {
       try {
         setIsSaving(true);
@@ -260,10 +268,13 @@ export function JobPreviewScreen() {
             updatedAt: new Date(),
           };
           await saveInvoice(updatedInvoice);
+          void warmEmailDraft(invoiceToDocument(updatedInvoice), businessSettings, { isPro: isProForPdf });
         } else if (currentQuote) {
           // Stamps draftStep 'JobPreview' — see buildPreviewQuoteSave for
           // why the marker must survive this save.
-          await saveQuote(buildPreviewQuoteSave(currentQuote, notes, refNumber));
+          const savedQuote = buildPreviewQuoteSave(currentQuote, notes, refNumber);
+          await saveQuote(savedQuote);
+          void warmEmailDraft(quoteToDocument(savedQuote), businessSettings, { isPro: isProForPdf });
         }
         savedNotesRef.current = notes;
         setIsSaving(false);

--- a/src/services/analyticsService.test.ts
+++ b/src/services/analyticsService.test.ts
@@ -56,6 +56,25 @@ describe('trackEvent', () => {
     expect(addDocMock).not.toHaveBeenCalled();
   });
 
+  // The send funnel is assembled downstream from these exact names and prop
+  // shapes; a rename on either side silently breaks the join.
+  it('writes the send-flow funnel events under their agreed names', async () => {
+    trackEvent('send_sheet_opened', { doc_type: 'quote', has_customer_email: true, plan: 'trial' });
+    trackEvent('send_method_chosen', { method: 'email', doc_type: 'quote' });
+    trackEvent('email_preview_opened', { doc_type: 'quote', prefilled: true, wait_ms: 0 });
+    trackEvent('email_preview_abandoned', { doc_type: 'quote', had_recipient: true, edited_body: false });
+    trackEvent('quote_send_succeeded', { doc_type: 'quote', method: 'email', to_self: false });
+    await flush();
+
+    expect(addDocMock.mock.calls.map(([, payload]: any) => payload.event)).toEqual([
+      'send_sheet_opened',
+      'send_method_chosen',
+      'email_preview_opened',
+      'email_preview_abandoned',
+      'quote_send_succeeded',
+    ]);
+  });
+
   it('never throws (or leaves an unhandled rejection) when the write fails', async () => {
     addDocMock.mockRejectedValueOnce(new Error('client is offline'));
 

--- a/src/services/analyticsService.ts
+++ b/src/services/analyticsService.ts
@@ -50,6 +50,26 @@ export type AnalyticsEvent =
   | 'send_gate_abandoned'
   // User picked a path. `method` distinguishes square_connected vs pro_upgrade.
   | 'send_gate_resolved'
+  // — Send flow (Jul 2026 audit: sending IS the activation event; 113 of the
+  //   138 quote-creators never sent one and none of them ever paid) —
+  // The send flow opened, whether or not the sheet itself was shown. Carries
+  // doc_type + has_customer_email + plan; has_customer_email is what decides
+  // between the sheet and going straight to the email preview.
+  | 'send_sheet_opened'
+  // A delivery channel was picked: email / sms / share / export_pdf. Fires
+  // for the auto-routed email path too, so sheet friction is measurable as
+  // the gap between send_sheet_opened and this.
+  | 'send_method_chosen'
+  // Email preview reached a usable state. `prefilled` = the body was already
+  // warm (pre-generated on JobPreview); `wait_ms` = how long the user
+  // actually waited for generation, 0 when prefilled.
+  | 'email_preview_opened'
+  // Preview closed with nothing sent — the drop-off the audit couldn't see.
+  // had_recipient / edited_body separate "no address" from "lost their nerve".
+  | 'email_preview_abandoned'
+  // A document actually went out. `to_self` flags a send to the tradie's own
+  // account email — previously indistinguishable from a real customer send.
+  | 'quote_send_succeeded'
   // Dashboard follow-up nudge banner. `nudge_type` distinguishes
   // invoice_overdue / self_sent_quote / unsent_quote / quote_follow_up —
   // measures whether nudging moves quotes to real customers (the Jul 2026

--- a/src/utils/emailDraft.test.ts
+++ b/src/utils/emailDraft.test.ts
@@ -4,12 +4,14 @@
  * Jul 2026 send audit: 40 tradies stalled on a finished, priced quote and
  * never pressed send. Generating the email at tap time — a writing task in
  * response to an action — was a chunk of that friction, so it now runs in the
- * background when the doc is saved. The properties that matter here are all
- * about it being *safe*: never a second generation for the same doc, never a
- * throw, and never a write that rolls back an edit made while it was in
- * flight.
+ * background when the doc is saved. The properties that matter are all about
+ * it being *safe*: never a second generation for the same doc, never a throw,
+ * no store write at all (saveDraft replaces the wizard's live editing buffer),
+ * and never caching a body that is really the failure template.
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 
 const llm = vi.hoisted(() => ({
   generateQuoteEmail: vi.fn(async () => 'Written quote email'),
@@ -19,17 +21,13 @@ const llm = vi.hoisted(() => ({
 }));
 vi.mock('../services/llmService', () => llm);
 
-const store = vi.hoisted(() => ({
-  state: {
-    quotes: [] as any[],
-    invoices: [] as any[],
-    saveDraft: vi.fn(async () => {}),
-    saveInvoice: vi.fn(async () => {}),
-  },
-}));
-vi.mock('../store/useStore', () => ({ useStore: { getState: () => store.state } }));
-
-import { shouldWarmEmailDraft, warmEmailDraft } from './emailDraft';
+import {
+  getWarmedEmailBody,
+  resetWarmedEmailDrafts,
+  shouldWarmEmailDraft,
+  warmEmailDraft,
+  whenEmailDraftWarm,
+} from './emailDraft';
 import type { Document } from '../types/document';
 import type { BusinessSettings } from '../types';
 
@@ -71,15 +69,9 @@ function invoiceDoc(overrides: Partial<Document> = {}): Document {
   });
 }
 
-/** The legacy quote the store holds for the doc under test. */
-function storedQuote(overrides: Record<string, any> = {}) {
-  return { id: 'q1', notes: 'Gate code 4821', status: 'draft', ...overrides };
-}
-
 beforeEach(() => {
   vi.clearAllMocks();
-  store.state.quotes = [storedQuote()];
-  store.state.invoices = [{ id: 'i1', notes: '', status: 'draft' }];
+  resetWarmedEmailDrafts();
 });
 
 describe('shouldWarmEmailDraft', () => {
@@ -109,7 +101,7 @@ describe('shouldWarmEmailDraft', () => {
 });
 
 describe('warmEmailDraft', () => {
-  it('generates the body and persists it to draftEmailBody', async () => {
+  it('generates the body and leaves it ready for the send flow', async () => {
     await warmEmailDraft(quoteDoc(), settings, { isPro: true });
 
     expect(llm.generateQuoteEmail).toHaveBeenCalledTimes(1);
@@ -118,23 +110,19 @@ describe('warmEmailDraft', () => {
       businessName: 'Hansen Decks',
       customerName: 'Sam',
     });
-    expect(store.state.saveDraft).toHaveBeenCalledWith(
-      expect.objectContaining({ id: 'q1', draftEmailBody: 'Written quote email' }),
-    );
+    expect(getWarmedEmailBody('q1')).toBe('Written quote email');
   });
 
-  it('writes onto the LATEST stored copy, not the snapshot it started from', async () => {
-    // Simulates the tradie typing notes on JobPreview while generation runs.
-    llm.generateQuoteEmail.mockImplementationOnce(async () => {
-      store.state.quotes = [storedQuote({ notes: 'Gate code 4821 — dog on site' })];
-      return 'Written quote email';
-    });
-
-    await warmEmailDraft(quoteDoc(), settings, { isPro: true });
-
-    expect(store.state.saveDraft).toHaveBeenCalledWith(
-      expect.objectContaining({ notes: 'Gate code 4821 — dog on site' }),
-    );
+  // Guard, not decoration: saveDraft replaces `currentQuote`, the wizard's
+  // live editing buffer. A background write landing while the tradie is in
+  // MaterialsList silently reverts their unsaved line-item edits and resets
+  // that screen's dirty check, so nothing prompts on the way out.
+  it('never reaches for the store at all', () => {
+    // Comments stripped — several of them explain this very rule.
+    const code = readFileSync(resolve(__dirname, 'emailDraft.ts'), 'utf8')
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/\/\/.*$/gm, '');
+    expect(code).not.toMatch(/useStore|saveDraft|saveInvoice/);
   });
 
   it('never generates twice for the same doc while one is in flight', async () => {
@@ -149,14 +137,37 @@ describe('warmEmailDraft', () => {
     await Promise.all([first, second]);
 
     expect(llm.generateQuoteEmail).toHaveBeenCalledTimes(1);
-    expect(store.state.saveDraft).toHaveBeenCalledTimes(1);
+  });
+
+  it('exposes the in-flight run so the send flow can wait instead of re-generating', async () => {
+    let release: (body: string) => void = () => {};
+    llm.generateQuoteEmail.mockImplementationOnce(
+      () => new Promise<string>((resolve) => { release = resolve; }),
+    );
+
+    const warming = warmEmailDraft(quoteDoc(), settings, { isPro: true });
+    const pending = whenEmailDraftWarm('q1');
+    expect(pending).toBeTruthy();
+
+    release('Written quote email');
+    await Promise.all([warming, pending]);
+
+    expect(getWarmedEmailBody('q1')).toBe('Written quote email');
+    expect(whenEmailDraftWarm('q1')).toBeUndefined();
+  });
+
+  it('does not re-generate once a body is already warm', async () => {
+    await warmEmailDraft(quoteDoc(), settings, { isPro: true });
+    await warmEmailDraft(quoteDoc(), settings, { isPro: true });
+
+    expect(llm.generateQuoteEmail).toHaveBeenCalledTimes(1);
   });
 
   it('does nothing when the doc already has a body', async () => {
     await warmEmailDraft(quoteDoc({ draftEmailBody: 'Already written' }), settings, { isPro: true });
 
     expect(llm.generateQuoteEmail).not.toHaveBeenCalled();
-    expect(store.state.saveDraft).not.toHaveBeenCalled();
+    expect(getWarmedEmailBody('q1')).toBeUndefined();
   });
 
   it('does nothing on the free tier — that template is local and instant', async () => {
@@ -164,14 +175,33 @@ describe('warmEmailDraft', () => {
 
     expect(llm.generateQuoteEmail).not.toHaveBeenCalled();
     expect(llm.getDefaultEmailBody).not.toHaveBeenCalled();
-    expect(store.state.saveDraft).not.toHaveBeenCalled();
+    expect(getWarmedEmailBody('q1')).toBeUndefined();
+  });
+
+  // generateQuoteEmail swallows network/server failures and returns the plain
+  // template. Caching that would pin a Pro tradie to the generic email for
+  // good, because every later path reads "a body exists" as "nothing to do".
+  it('does not cache a body that is really the failure template', async () => {
+    llm.generateQuoteEmail.mockResolvedValueOnce('Template quote email');
+
+    await warmEmailDraft(quoteDoc(), settings, { isPro: true });
+
+    expect(getWarmedEmailBody('q1')).toBeUndefined();
+  });
+
+  it('does not cache an empty body', async () => {
+    llm.generateQuoteEmail.mockResolvedValueOnce('   ');
+
+    await warmEmailDraft(quoteDoc(), settings, { isPro: true });
+
+    expect(getWarmedEmailBody('q1')).toBeUndefined();
   });
 
   it('swallows a generation failure — the send flow still writes one on tap', async () => {
     llm.generateQuoteEmail.mockRejectedValueOnce(new Error('network down'));
 
     await expect(warmEmailDraft(quoteDoc(), settings, { isPro: true })).resolves.toBeUndefined();
-    expect(store.state.saveDraft).not.toHaveBeenCalled();
+    expect(getWarmedEmailBody('q1')).toBeUndefined();
   });
 
   it('recovers after a failure — the next warm-up for that doc still runs', async () => {
@@ -181,41 +211,25 @@ describe('warmEmailDraft', () => {
     await warmEmailDraft(quoteDoc(), settings, { isPro: true });
 
     expect(llm.generateQuoteEmail).toHaveBeenCalledTimes(2);
-    expect(store.state.saveDraft).toHaveBeenCalledTimes(1);
+    expect(getWarmedEmailBody('q1')).toBe('Written quote email');
   });
 
-  it('skips the write when the doc is not in the store yet', async () => {
-    store.state.quotes = [];
-
-    await warmEmailDraft(quoteDoc(), settings, { isPro: true });
-
-    expect(store.state.saveDraft).not.toHaveBeenCalled();
-  });
-
-  it('skips the write when a body landed while generation was running', async () => {
-    llm.generateQuoteEmail.mockImplementationOnce(async () => {
-      store.state.quotes = [storedQuote({ draftEmailBody: 'Written on tap' })];
-      return 'Written quote email';
-    });
-
-    await warmEmailDraft(quoteDoc(), settings, { isPro: true });
-
-    expect(store.state.saveDraft).not.toHaveBeenCalled();
-  });
-
-  it('never lets a store write failure escape', async () => {
-    store.state.saveDraft.mockRejectedValueOnce(new Error('offline'));
-
-    await expect(warmEmailDraft(quoteDoc(), settings, { isPro: true })).resolves.toBeUndefined();
-  });
-
-  it('routes invoices through the invoice generator and saveInvoice', async () => {
+  it('routes invoices through the invoice generator', async () => {
     await warmEmailDraft(invoiceDoc(), settings, { isPro: true });
 
     expect(llm.generateInvoiceEmail).toHaveBeenCalledTimes(1);
     expect(llm.generateQuoteEmail).not.toHaveBeenCalled();
-    expect(store.state.saveInvoice).toHaveBeenCalledWith(
-      expect.objectContaining({ id: 'i1', draftEmailBody: 'Written invoice email' }),
-    );
+    expect(getWarmedEmailBody('i1')).toBe('Written invoice email');
+  });
+
+  it('keeps the cache bounded across a long session', async () => {
+    for (let i = 0; i < 25; i++) {
+      llm.generateQuoteEmail.mockResolvedValueOnce(`Written quote email ${i}`);
+      await warmEmailDraft(quoteDoc({ id: `q-${i}` }), settings, { isPro: true });
+    }
+
+    // Oldest evicted, newest kept.
+    expect(getWarmedEmailBody('q-0')).toBeUndefined();
+    expect(getWarmedEmailBody('q-24')).toBe('Written quote email 24');
   });
 });

--- a/src/utils/emailDraft.test.ts
+++ b/src/utils/emailDraft.test.ts
@@ -1,0 +1,221 @@
+/**
+ * The JobPreview email warm-up.
+ *
+ * Jul 2026 send audit: 40 tradies stalled on a finished, priced quote and
+ * never pressed send. Generating the email at tap time — a writing task in
+ * response to an action — was a chunk of that friction, so it now runs in the
+ * background when the doc is saved. The properties that matter here are all
+ * about it being *safe*: never a second generation for the same doc, never a
+ * throw, and never a write that rolls back an edit made while it was in
+ * flight.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const llm = vi.hoisted(() => ({
+  generateQuoteEmail: vi.fn(async () => 'Written quote email'),
+  generateInvoiceEmail: vi.fn(async () => 'Written invoice email'),
+  getDefaultEmailBody: vi.fn(() => 'Template quote email'),
+  getDefaultInvoiceEmailBody: vi.fn(() => 'Template invoice email'),
+}));
+vi.mock('../services/llmService', () => llm);
+
+const store = vi.hoisted(() => ({
+  state: {
+    quotes: [] as any[],
+    invoices: [] as any[],
+    saveDraft: vi.fn(async () => {}),
+    saveInvoice: vi.fn(async () => {}),
+  },
+}));
+vi.mock('../store/useStore', () => ({ useStore: { getState: () => store.state } }));
+
+import { shouldWarmEmailDraft, warmEmailDraft } from './emailDraft';
+import type { Document } from '../types/document';
+import type { BusinessSettings } from '../types';
+
+const settings = { businessName: 'Hansen Decks' } as BusinessSettings;
+
+function quoteDoc(overrides: Partial<Document> = {}): Document {
+  return {
+    id: 'q1',
+    type: 'quote',
+    stage: 'draft',
+    number: 'Q-001',
+    createdAt: 0,
+    updatedAt: 0,
+    customerName: 'Sam',
+    customerEmail: 'sam@example.com',
+    job: { name: 'Deck restain', description: 'Sand and restain the back deck' },
+    payments: [],
+    materials: [{ name: 'Decking oil', quantity: 2, unit: 'each' }],
+    laborRate: 80,
+    laborHours: 6,
+    laborTotal: 480,
+    materialsSubtotal: 200,
+    markup: 10,
+    markupAmount: 20,
+    subtotal: 700,
+    gst: 70,
+    total: 770,
+    ...overrides,
+  } as Document;
+}
+
+function invoiceDoc(overrides: Partial<Document> = {}): Document {
+  return quoteDoc({
+    id: 'i1',
+    type: 'invoice',
+    number: 'INV-001',
+    dueDate: new Date('2026-08-12').getTime(),
+    ...overrides,
+  });
+}
+
+/** The legacy quote the store holds for the doc under test. */
+function storedQuote(overrides: Record<string, any> = {}) {
+  return { id: 'q1', notes: 'Gate code 4821', status: 'draft', ...overrides };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  store.state.quotes = [storedQuote()];
+  store.state.invoices = [{ id: 'i1', notes: '', status: 'draft' }];
+});
+
+describe('shouldWarmEmailDraft', () => {
+  it('warms a saved draft with no body yet', () => {
+    expect(shouldWarmEmailDraft(quoteDoc())).toBe(true);
+  });
+
+  it('skips a doc that already carries a body', () => {
+    expect(shouldWarmEmailDraft(quoteDoc({ draftEmailBody: 'Already written' }))).toBe(false);
+  });
+
+  it('treats a whitespace-only body as no body', () => {
+    expect(shouldWarmEmailDraft(quoteDoc({ draftEmailBody: '   ' }))).toBe(true);
+  });
+
+  it('skips docs that have left draft — those already went out', () => {
+    expect(shouldWarmEmailDraft(quoteDoc({ stage: 'quote_sent' }))).toBe(false);
+    expect(shouldWarmEmailDraft(quoteDoc({ stage: 'quote_accepted' }))).toBe(false);
+    expect(shouldWarmEmailDraft(invoiceDoc({ stage: 'invoice_sent' }))).toBe(false);
+  });
+
+  it('skips a doc with no id, and nullish input', () => {
+    expect(shouldWarmEmailDraft(quoteDoc({ id: '' }))).toBe(false);
+    expect(shouldWarmEmailDraft(null)).toBe(false);
+    expect(shouldWarmEmailDraft(undefined)).toBe(false);
+  });
+});
+
+describe('warmEmailDraft', () => {
+  it('generates the body and persists it to draftEmailBody', async () => {
+    await warmEmailDraft(quoteDoc(), settings, { isPro: true });
+
+    expect(llm.generateQuoteEmail).toHaveBeenCalledTimes(1);
+    expect(llm.generateQuoteEmail.mock.calls[0][0]).toMatchObject({
+      jobName: 'Deck restain',
+      businessName: 'Hansen Decks',
+      customerName: 'Sam',
+    });
+    expect(store.state.saveDraft).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'q1', draftEmailBody: 'Written quote email' }),
+    );
+  });
+
+  it('writes onto the LATEST stored copy, not the snapshot it started from', async () => {
+    // Simulates the tradie typing notes on JobPreview while generation runs.
+    llm.generateQuoteEmail.mockImplementationOnce(async () => {
+      store.state.quotes = [storedQuote({ notes: 'Gate code 4821 — dog on site' })];
+      return 'Written quote email';
+    });
+
+    await warmEmailDraft(quoteDoc(), settings, { isPro: true });
+
+    expect(store.state.saveDraft).toHaveBeenCalledWith(
+      expect.objectContaining({ notes: 'Gate code 4821 — dog on site' }),
+    );
+  });
+
+  it('never generates twice for the same doc while one is in flight', async () => {
+    let release: (body: string) => void = () => {};
+    llm.generateQuoteEmail.mockImplementationOnce(
+      () => new Promise<string>((resolve) => { release = resolve; }),
+    );
+
+    const first = warmEmailDraft(quoteDoc(), settings, { isPro: true });
+    const second = warmEmailDraft(quoteDoc(), settings, { isPro: true });
+    release('Written quote email');
+    await Promise.all([first, second]);
+
+    expect(llm.generateQuoteEmail).toHaveBeenCalledTimes(1);
+    expect(store.state.saveDraft).toHaveBeenCalledTimes(1);
+  });
+
+  it('does nothing when the doc already has a body', async () => {
+    await warmEmailDraft(quoteDoc({ draftEmailBody: 'Already written' }), settings, { isPro: true });
+
+    expect(llm.generateQuoteEmail).not.toHaveBeenCalled();
+    expect(store.state.saveDraft).not.toHaveBeenCalled();
+  });
+
+  it('does nothing on the free tier — that template is local and instant', async () => {
+    await warmEmailDraft(quoteDoc(), settings, { isPro: false });
+
+    expect(llm.generateQuoteEmail).not.toHaveBeenCalled();
+    expect(llm.getDefaultEmailBody).not.toHaveBeenCalled();
+    expect(store.state.saveDraft).not.toHaveBeenCalled();
+  });
+
+  it('swallows a generation failure — the send flow still writes one on tap', async () => {
+    llm.generateQuoteEmail.mockRejectedValueOnce(new Error('network down'));
+
+    await expect(warmEmailDraft(quoteDoc(), settings, { isPro: true })).resolves.toBeUndefined();
+    expect(store.state.saveDraft).not.toHaveBeenCalled();
+  });
+
+  it('recovers after a failure — the next warm-up for that doc still runs', async () => {
+    llm.generateQuoteEmail.mockRejectedValueOnce(new Error('network down'));
+    await warmEmailDraft(quoteDoc(), settings, { isPro: true });
+
+    await warmEmailDraft(quoteDoc(), settings, { isPro: true });
+
+    expect(llm.generateQuoteEmail).toHaveBeenCalledTimes(2);
+    expect(store.state.saveDraft).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips the write when the doc is not in the store yet', async () => {
+    store.state.quotes = [];
+
+    await warmEmailDraft(quoteDoc(), settings, { isPro: true });
+
+    expect(store.state.saveDraft).not.toHaveBeenCalled();
+  });
+
+  it('skips the write when a body landed while generation was running', async () => {
+    llm.generateQuoteEmail.mockImplementationOnce(async () => {
+      store.state.quotes = [storedQuote({ draftEmailBody: 'Written on tap' })];
+      return 'Written quote email';
+    });
+
+    await warmEmailDraft(quoteDoc(), settings, { isPro: true });
+
+    expect(store.state.saveDraft).not.toHaveBeenCalled();
+  });
+
+  it('never lets a store write failure escape', async () => {
+    store.state.saveDraft.mockRejectedValueOnce(new Error('offline'));
+
+    await expect(warmEmailDraft(quoteDoc(), settings, { isPro: true })).resolves.toBeUndefined();
+  });
+
+  it('routes invoices through the invoice generator and saveInvoice', async () => {
+    await warmEmailDraft(invoiceDoc(), settings, { isPro: true });
+
+    expect(llm.generateInvoiceEmail).toHaveBeenCalledTimes(1);
+    expect(llm.generateQuoteEmail).not.toHaveBeenCalled();
+    expect(store.state.saveInvoice).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'i1', draftEmailBody: 'Written invoice email' }),
+    );
+  });
+});

--- a/src/utils/emailDraft.ts
+++ b/src/utils/emailDraft.ts
@@ -5,10 +5,19 @@
  * Jul 2026 send audit: the tradie taps "Send Quote" — an action — and the app
  * answers with a writing task they never asked for. Generation is the same
  * work either way, so JobPreview kicks it off the moment the doc is saved and
- * the send flow just reads what's already there (`draftEmailBody`).
+ * the send flow reads what's already there.
  *
- * The warm-up is strictly best-effort: it never blocks a screen, never
- * surfaces an error, and never fires for a doc that already carries a body.
+ * The warmed body is held in memory here rather than written straight to
+ * `draftEmailBody`, deliberately:
+ *   - `saveDraft` replaces `currentQuote`, the wizard's live editing buffer.
+ *     A background write landing while the tradie is in MaterialsList would
+ *     revert their unsaved line-item edits AND reset that screen's dirty
+ *     check, so nothing would even prompt on the way out.
+ *   - `draftEmailBody` only reaches the unified Document the send flow is
+ *     handed after a Firestore round-trip through the server-side mirror, so
+ *     a body written here often wouldn't be visible in time anyway.
+ * It gets persisted the moment the send flow uses it, on the tradie's own
+ * tap — the same write the on-tap path has always done.
  */
 
 import type { BusinessSettings } from '../types';
@@ -20,7 +29,6 @@ import {
   getDefaultEmailBody,
   getDefaultInvoiceEmailBody,
 } from '../services/llmService';
-import { useStore } from '../store/useStore';
 
 export interface EmailBodySource {
   /** Written body — server round-trip, Pro / trial only. */
@@ -101,18 +109,43 @@ export function shouldWarmEmailDraft(
   return doc.stage === 'draft';
 }
 
-// One warm-up per doc at a time. JobPreview re-mounts every time the tradie
-// loops out to a wizard section and back; without this each loop would fire
-// another generation before the first had landed.
-const warming = new Set<string>();
+// Bodies ready to use, and the generations still running, keyed by doc id.
+// Session-scoped: a warm body is worth minutes, not days, and the persisted
+// draftEmailBody covers anything longer.
+const warmedBodies = new Map<string, string>();
+const inFlight = new Map<string, Promise<void>>();
+
+// A tradie churns through a handful of docs per session; this only exists so
+// a very long session can't grow the map without bound.
+const MAX_WARMED = 20;
+
+/** The warmed body for this doc, ready right now. */
+export function getWarmedEmailBody(docId: string): string | undefined {
+  return warmedBodies.get(docId);
+}
 
 /**
- * Generate this doc's customer email in the background and persist it to
- * `draftEmailBody`, so the send flow opens on a finished email instead of a
- * progress spinner. Fire-and-forget — resolves quietly whatever happens.
+ * The in-flight warm-up for this doc, if one is still running. The send flow
+ * awaits it rather than starting a second generation — tapping Send while the
+ * warm-up is still going is the common case, not an edge one.
+ */
+export function whenEmailDraftWarm(docId: string): Promise<void> | undefined {
+  return inFlight.get(docId);
+}
+
+/** Test seam — the caches above are module state by design. */
+export function resetWarmedEmailDrafts(): void {
+  warmedBodies.clear();
+  inFlight.clear();
+}
+
+/**
+ * Generate this doc's customer email in the background so the send flow opens
+ * on a finished email instead of a progress spinner. Fire-and-forget —
+ * resolves quietly whatever happens, and never touches the store.
  *
- * Free tier is deliberately skipped: those users get the local template, which
- * is instant, so there's nothing to warm and no write worth spending.
+ * Free tier is deliberately skipped: those users get the local template,
+ * which is instant, so there's nothing to warm.
  */
 export async function warmEmailDraft(
   doc: Document,
@@ -121,37 +154,32 @@ export async function warmEmailDraft(
 ): Promise<void> {
   if (!opts.isPro) return;
   if (!shouldWarmEmailDraft(doc)) return;
-  if (warming.has(doc.id)) return;
+  // JobPreview re-mounts every time the tradie loops out to a wizard section
+  // and back; without this each loop would fire another generation.
+  if (warmedBodies.has(doc.id) || inFlight.has(doc.id)) return;
 
-  warming.add(doc.id);
-  try {
-    persistWarmedBody(doc, await buildEmailBodySource(doc, businessSettings).generate());
-  } catch {
-    // Best effort. The send flow still generates on tap when nothing landed.
-  } finally {
-    warming.delete(doc.id);
-  }
-}
+  const run = (async () => {
+    try {
+      const source = buildEmailBodySource(doc, businessSettings);
+      const body = await source.generate();
+      // generateQuoteEmail / generateInvoiceEmail never reject — on a network
+      // or server failure they return the plain template. Caching that would
+      // hand a Pro tradie the generic email for good, since every later path
+      // reads "a body exists" as "nothing to generate". Leave it uncached so
+      // the send flow gets its own go.
+      if (!body?.trim() || body === source.fallback()) return;
+      if (warmedBodies.size >= MAX_WARMED) {
+        const oldest = warmedBodies.keys().next().value;
+        if (oldest !== undefined) warmedBodies.delete(oldest);
+      }
+      warmedBodies.set(doc.id, body);
+    } catch {
+      // Best effort. The send flow still generates on tap when nothing landed.
+    } finally {
+      inFlight.delete(doc.id);
+    }
+  })();
 
-/**
- * Merge the warmed body onto the LATEST stored copy of the doc — never the
- * snapshot generation started from. The tradie keeps editing notes and the
- * reference number on JobPreview while this is in flight, and writing back a
- * stale snapshot would roll those edits back. No stored copy yet, or a body
- * that landed first, means we leave it alone.
- */
-function persistWarmedBody(doc: Document, body: string): void {
-  if (!body?.trim()) return;
-  const state = useStore.getState();
-
-  if (doc.type === 'invoice') {
-    const latest = state.invoices.find((i) => i.id === doc.id);
-    if (!latest || latest.draftEmailBody?.trim()) return;
-    void state.saveInvoice({ ...latest, draftEmailBody: body }).catch(() => { /* best effort */ });
-    return;
-  }
-
-  const latest = state.quotes.find((q) => q.id === doc.id);
-  if (!latest || latest.draftEmailBody?.trim()) return;
-  void state.saveDraft({ ...latest, draftEmailBody: body }).catch(() => { /* best effort */ });
+  inFlight.set(doc.id, run);
+  await run;
 }

--- a/src/utils/emailDraft.ts
+++ b/src/utils/emailDraft.ts
@@ -1,0 +1,157 @@
+/**
+ * Customer-email body generation, shared by the send flow and the JobPreview
+ * warm-up.
+ *
+ * Jul 2026 send audit: the tradie taps "Send Quote" — an action — and the app
+ * answers with a writing task they never asked for. Generation is the same
+ * work either way, so JobPreview kicks it off the moment the doc is saved and
+ * the send flow just reads what's already there (`draftEmailBody`).
+ *
+ * The warm-up is strictly best-effort: it never blocks a screen, never
+ * surfaces an error, and never fires for a doc that already carries a body.
+ */
+
+import type { BusinessSettings } from '../types';
+import type { Document } from '../types/document';
+import { documentToInvoice, documentToQuote } from '../types/documentAdapter';
+import {
+  generateInvoiceEmail,
+  generateQuoteEmail,
+  getDefaultEmailBody,
+  getDefaultInvoiceEmailBody,
+} from '../services/llmService';
+import { useStore } from '../store/useStore';
+
+export interface EmailBodySource {
+  /** Written body — server round-trip, Pro / trial only. */
+  generate: () => Promise<string>;
+  /** Plain local template. No network, never throws. */
+  fallback: () => string;
+}
+
+/**
+ * The generate/fallback pair for a document, branching on type. One mapping
+ * for both callers so a warmed body is byte-for-byte what the send flow
+ * would have produced on tap.
+ */
+export function buildEmailBodySource(
+  doc: Document,
+  businessSettings: BusinessSettings | null,
+): EmailBodySource {
+  const businessName = businessSettings?.businessName || '';
+  if (doc.type === 'invoice') {
+    const invoice = documentToInvoice(doc);
+    return {
+      generate: () => generateInvoiceEmail({
+        jobName: invoice.job.name,
+        jobDescription: invoice.job.description || '',
+        materials: invoice.materials.map((m) => ({ name: m.name, quantity: m.quantity, unit: m.unit })),
+        laborHours: invoice.laborHours,
+        total: invoice.total,
+        businessName,
+        customerName: invoice.customerName,
+        dueDate: new Date(invoice.dueDate).toISOString(),
+        invoiceNumber: invoice.invoiceNumber,
+        gstRegistered: invoice.gstRegistered,
+      }),
+      fallback: () => getDefaultInvoiceEmailBody(
+        invoice.customerName,
+        invoice.job.name,
+        invoice.total,
+        businessSettings?.businessName || 'Your Business',
+        new Date(invoice.dueDate).toISOString(),
+        invoice.gstRegistered,
+      ),
+    };
+  }
+
+  const quote = documentToQuote(doc);
+  return {
+    generate: () => generateQuoteEmail({
+      jobName: quote.job.name,
+      jobDescription: quote.job.description || '',
+      materials: quote.materials.map((m) => ({ name: m.name, quantity: m.quantity, unit: m.unit })),
+      laborHours: quote.laborHours,
+      total: quote.total,
+      businessName,
+      customerName: quote.customerName,
+      gstRegistered: quote.gstRegistered,
+    }),
+    fallback: () => getDefaultEmailBody(
+      quote.customerName,
+      quote.job.name,
+      quote.total,
+      businessSettings?.businessName || 'Your Business',
+      quote.gstRegistered,
+    ),
+  };
+}
+
+/**
+ * Whether a background warm-up is worth firing. Skips a doc that already
+ * carries a body (warmed earlier, or written on a previous send) and anything
+ * that has left draft — that one already went out, and a resend reuses the
+ * body persisted at the time.
+ */
+export function shouldWarmEmailDraft(
+  doc: Pick<Document, 'id' | 'stage' | 'draftEmailBody'> | null | undefined,
+): boolean {
+  if (!doc?.id) return false;
+  if (doc.draftEmailBody?.trim()) return false;
+  return doc.stage === 'draft';
+}
+
+// One warm-up per doc at a time. JobPreview re-mounts every time the tradie
+// loops out to a wizard section and back; without this each loop would fire
+// another generation before the first had landed.
+const warming = new Set<string>();
+
+/**
+ * Generate this doc's customer email in the background and persist it to
+ * `draftEmailBody`, so the send flow opens on a finished email instead of a
+ * progress spinner. Fire-and-forget — resolves quietly whatever happens.
+ *
+ * Free tier is deliberately skipped: those users get the local template, which
+ * is instant, so there's nothing to warm and no write worth spending.
+ */
+export async function warmEmailDraft(
+  doc: Document,
+  businessSettings: BusinessSettings | null,
+  opts: { isPro: boolean },
+): Promise<void> {
+  if (!opts.isPro) return;
+  if (!shouldWarmEmailDraft(doc)) return;
+  if (warming.has(doc.id)) return;
+
+  warming.add(doc.id);
+  try {
+    persistWarmedBody(doc, await buildEmailBodySource(doc, businessSettings).generate());
+  } catch {
+    // Best effort. The send flow still generates on tap when nothing landed.
+  } finally {
+    warming.delete(doc.id);
+  }
+}
+
+/**
+ * Merge the warmed body onto the LATEST stored copy of the doc — never the
+ * snapshot generation started from. The tradie keeps editing notes and the
+ * reference number on JobPreview while this is in flight, and writing back a
+ * stale snapshot would roll those edits back. No stored copy yet, or a body
+ * that landed first, means we leave it alone.
+ */
+function persistWarmedBody(doc: Document, body: string): void {
+  if (!body?.trim()) return;
+  const state = useStore.getState();
+
+  if (doc.type === 'invoice') {
+    const latest = state.invoices.find((i) => i.id === doc.id);
+    if (!latest || latest.draftEmailBody?.trim()) return;
+    void state.saveInvoice({ ...latest, draftEmailBody: body }).catch(() => { /* best effort */ });
+    return;
+  }
+
+  const latest = state.quotes.find((q) => q.id === doc.id);
+  if (!latest || latest.draftEmailBody?.trim()) return;
+  void state.saveDraft({ ...latest, draftEmailBody: body }).catch(() => { /* best effort */ });
+}

--- a/src/utils/sendFlow.test.ts
+++ b/src/utils/sendFlow.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Rules behind the two send-flow decisions the Jul 2026 audit turned up:
+ * whether we still need to ask HOW to send (we don't, when there's an
+ * address on file), and whether a send actually reached a customer.
+ */
+import { describe, it, expect } from 'vitest';
+
+import { hasCustomerEmail, isEmailAddress, isSelfSend } from './sendFlow';
+
+describe('hasCustomerEmail', () => {
+  it('is true for a doc carrying a usable address', () => {
+    expect(hasCustomerEmail({ customerEmail: 'sam@example.com' })).toBe(true);
+  });
+
+  it('is false when the field is missing or blank', () => {
+    expect(hasCustomerEmail({})).toBe(false);
+    expect(hasCustomerEmail({ customerEmail: '' })).toBe(false);
+    expect(hasCustomerEmail({ customerEmail: '   ' })).toBe(false);
+  });
+
+  it('is false for junk that would never deliver — the sheet stays the entry point', () => {
+    expect(hasCustomerEmail({ customerEmail: 'sam' })).toBe(false);
+    expect(hasCustomerEmail({ customerEmail: 'sam@example' })).toBe(false);
+    expect(hasCustomerEmail({ customerEmail: '0412 345 678' })).toBe(false);
+  });
+
+  it('tolerates surrounding whitespace on a real address', () => {
+    expect(hasCustomerEmail({ customerEmail: '  sam@example.com ' })).toBe(true);
+  });
+});
+
+describe('isEmailAddress', () => {
+  it('rejects nullish input without throwing', () => {
+    expect(isEmailAddress(undefined)).toBe(false);
+    expect(isEmailAddress(null)).toBe(false);
+  });
+
+  it('accepts a plain address', () => {
+    expect(isEmailAddress('jo@trade.com.au')).toBe(true);
+  });
+});
+
+describe('isSelfSend', () => {
+  it('flags a send to the tradie’s own account email', () => {
+    expect(isSelfSend('jo@trade.com.au', 'jo@trade.com.au')).toBe(true);
+  });
+
+  it('ignores case and whitespace', () => {
+    expect(isSelfSend('  Jo@Trade.com.AU ', 'jo@trade.com.au')).toBe(true);
+  });
+
+  it('is false for a real customer', () => {
+    expect(isSelfSend('sam@example.com', 'jo@trade.com.au')).toBe(false);
+  });
+
+  it('is false when either side is missing — never guess a self-send', () => {
+    expect(isSelfSend('', 'jo@trade.com.au')).toBe(false);
+    expect(isSelfSend('sam@example.com', '')).toBe(false);
+    expect(isSelfSend('sam@example.com', undefined)).toBe(false);
+  });
+});

--- a/src/utils/sendFlow.ts
+++ b/src/utils/sendFlow.ts
@@ -1,0 +1,35 @@
+/**
+ * Pure rules for the send flow.
+ *
+ * Extracted from SendDocumentDialog / DocumentEmailPreviewModal so the two
+ * decisions the Jul 2026 send audit cares about are testable without
+ * rendering a modal: do we still need to ask *how* to send, and did this
+ * send actually reach a customer.
+ */
+
+/** Shape of an email address good enough to send to. */
+export function isEmailAddress(value?: string | null): boolean {
+  if (!value) return false;
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value.trim());
+}
+
+/**
+ * Whether we already know where to email this doc. When we do, the send
+ * sheet's five rows are pure friction — email is the dominant path — so the
+ * flow opens the email preview directly and leaves SMS / Share / Export PDF
+ * behind "More ways to send".
+ */
+export function hasCustomerEmail(doc: { customerEmail?: string }): boolean {
+  return isEmailAddress(doc.customerEmail);
+}
+
+/**
+ * True when the recipient is the tradie's own account email. Self-sends are
+ * a rehearsal, not activation — the audit counted them as real sends because
+ * the client never distinguished them.
+ */
+export function isSelfSend(recipient: string, ownerEmail?: string | null): boolean {
+  const to = recipient.trim().toLowerCase();
+  const own = (ownerEmail || '').trim().toLowerCase();
+  return !!to && !!own && to === own;
+}


### PR DESCRIPTION
## Why

The Jul 2026 analytics run put the biggest leak at the SEND moment, not the paywall:

- 138 users have created a quote; 25 ever sent one to a real customer. 4 of those 25 pay. 0 of the 113 non-senders do. **Sending is the activation event.**
- 40 users stalled at JobPreview holding a finished, priced quote ($59–$66k jobs) with the customer's contact details on file, in trial, with no gate in their way.
- 91% never return after signup day, so whatever fixes this has to fix it in the first session.

Core diagnosis: the tradie tapped "Send Quote" — an action — and the app answered with a writing task they never asked for, then asked for six more decisions.

## What changed, item by item

**1. Pre-generate the email body earlier.** New `src/utils/emailDraft.ts`. `JobPreviewScreen` fires `warmEmailDraft(...)` immediately after the doc's auto-save, so the email is written before the tradie ever taps Send; the send flow reads it and persists it to `draftEmailBody` when it uses it, on the tradie's own tap.

The warmed body is held **in memory**, not written to the store in the background — two reasons, both found by review of the first commit and fixed in `78b1584`:
- `saveDraft` replaces `currentQuote`, which is the wizard's *live editing buffer* (`MaterialsListScreen` edits it via `updateQuote` and diffs against a snapshot for its dirty check). A background write landing while the tradie is editing line items reverted their unsaved prices **and** reset the dirty check, so nothing prompted on the way out. There's a source-level test guarding against a store import creeping back into this module.
- `draftEmailBody` only reaches the unified `Document` the send flow is handed after a Firestore round-trip through the server-side mirror, so on JobPreview a body written there usually couldn't arrive in time to be used anyway.

Other safety properties, all tested: fire-and-forget (never awaited by the screen, never throws), skips a doc that already has a body or has left `draft`, skips the free tier (its template is local and instant), one generation per doc (a second tap or re-mount joins the in-flight run rather than paying again), a body identical to the failure template is **not** cached — `generateQuoteEmail` swallows network failures and returns that template, and caching it would pin a Pro tradie to the generic email for good — and the cache is bounded. `buildEmailBodySource` is shared with the dialog, so a warmed body is byte-for-byte what the tap path would have produced.

**2. Skip the ActionSheet when we already have the customer's email.** `visible` → if `hasCustomerEmail(doc)`, straight into the email preview; no address on file keeps the sheet as the entry point. SMS / Share / Export PDF are one tap away behind a **"More ways to send"** link in the preview footer (it swaps the preview back for the sheet, persisting body/subject edits on the way). One deviation worth flagging: **free-plan users keep the sheet**, because their delivery gate does a Square round-trip (and may mint a payment link) before anything can go out — auto-routing them would mean tapping Send and watching an unchanged screen. Trial/Pro pass the gate with no network call.

**3. Pay-link upsell off the send path.** It no longer appears in the sheet at all (where it was the first row for essentially every trial user, and where tapping it without Square connected navigated to SquareIntegration and dismissed the send entirely). It now asks *after* a successful send — "Want a Pay Now button?" — aimed at the next doc. `pay_link_optin_shown` fires when that ask appears and `pay_link_optin_tapped` still carries `outcome`, so the funnel stays continuous. Scope note: the ask is wired to the **email** send path (the dominant one). SMS/Share/Export hand off to another app and can be cancelled, so interrupting them on return would be worse than the miss. Analysts should know the impression **denominator changed meaning**: it used to be "sheet opened by a trial user without a pay link", it's now "email actually sent by one".

**4. Test Send demoted.** Now a low-emphasis text link ("Send a test to myself") under a full-width Send, instead of a half-width outlined button beside it. Behaviour unchanged (it still deliberately doesn't `recordSend` — it's not a send), but its success copy now points at the real send.

**5. Body editing behind "Edit email".** Default posture is a read-only preview of the email with Send prominent. "Edit email" (or tapping the preview) opens the full editor, and the markdown toolbar lives *inside* that mode. Regenerate moved in there too — it's an authoring action, and the default view should offer one decision.

**6. Honest loading state.** The 4-step, 1800ms-per-step scripted checklist (~5.4s that then parked on "Finalizing...") is gone; it's a spinner and "Writing your email…". With (1) warm, it usually never renders at all.

**7. $0-warning hierarchy flipped.** "Send anyway" is primary, "Go back and fix" secondary. The guard itself is unchanged — it catches real mistakes — but retreat is no longer the default for users we know don't come back.

**8. Instrumentation.** Added to the `AnalyticsEvent` union (the typo guard) with exactly the agreed shapes: `send_sheet_opened` `{doc_type, has_customer_email, plan}`, `send_method_chosen` `{method, doc_type}` (fires on the auto-routed email path too, so sheet friction reads as the gap from `send_sheet_opened`), `email_preview_opened` `{doc_type, prefilled, wait_ms}` (logged when the body actually lands, so `wait_ms` is a real wait), `email_preview_abandoned` `{doc_type, had_recipient, edited_body}` (`edited_body` tracks actual keystrokes/toolbar use, not "a body arrived after open"), `quote_send_succeeded` `{doc_type, method, to_self}` — also fired for sms/share/export_pdf. `send_gate_shown` / `_abandoned` / `_resolved` are untouched and covered by a test.

## Bugs found in review of the first commit and fixed in `78b1584`

Worth calling out because two of them were data-loss class, and one is a fix to behaviour that predates this PR but which auto-routing puts on the hot path:

1. **Warm-up clobbered unsaved line-item edits** (see item 1) — fixed by taking the store out of the warm-up entirely.
2. **"More ways to send" → Email discarded hand edits.** The host holds `doc` in `useState`, so the prop never refreshes mid-session; re-entering the email path reseeded `emailBody` from that stale prop, reverting the tradie's own words on screen and sending the pre-edit copy (the subsequent save saw "no change" and no-oped). Seeding is now tracked per doc for the session; regression tests cover both the warm and cold paths.
3. **A failed generation was cached as a real one** (see item 1).
4. **Post-send write could flip a sent quote back to draft.** Dismissing the preview re-wrote the legacy quote from a doc snapshot stamped `draft`, and `firestoreService.saveQuote` merges `status`, so it could land on top of the server's `sent` stamp. Pre-existing, but auto-routing makes the preview the guaranteed path for every doc with an email on file. Edits are now only persisted while the doc is still going out.

Each has a named regression test; I verified all five fail against the pre-fix code.

## Tests

`npm test` — 1170 passing (the one failing suite, `functions/scripts/healInflatedSections.test.ts`, is a pre-existing missing `firebase-admin` in this worktree, untouched by this change). `tsc --noEmit` clean across `src/` and `shared/`.

- `src/utils/emailDraft.test.ts` (18) — warm-up gating, no store access (source-level guard), single generation per doc, awaiting an in-flight run, failure-template and empty-body rejection, recovery after failure, free-tier skip, invoice routing, bounded cache.
- `src/utils/sendFlow.test.ts` (14) — address/self-send rules, including junk addresses falling back to the sheet.
- `src/components/SendDocumentDialog.test.tsx` (24) — auto-route vs sheet (incl. the free-plan carve-out), the four sheet rows with no pay-link upsell, warm vs cold open and their events, using a warmed body the mirrored doc hasn't caught up with, waiting on an in-flight warm-up, hand edits surviving a trip through "More ways to send", no re-write after a send, the post-send ask firing only after a send, and the send gate still working.
- `src/components/DocumentEmailPreviewModal.test.tsx` (20) — read-only default, no toolbar until edit mode, Test Send is a link not a button, indeterminate state with no scripted steps, $0-warning button roles, self-send flagging, abandonment props.
- `src/services/analyticsService.test.ts` — the five new event names/shapes.

## Copy

No "AI" anywhere user-facing; no "via QuoteMate"; Australian and gender-neutral. Net effect on the screen is fewer decisions, not more: five sheet rows → zero for the common path, and the preview defaults to one button.
