### PR TITLE
fix(receipts): fire payment receipts for document-collection invoices

### DIFF
--- a/functions/src/documentMirror.ts
+++ b/functions/src/documentMirror.ts
@@ -66,7 +66,13 @@ function mirrorIdForQuote(quoteId: string): string {
   return quoteId;
 }
 
-function mirrorIdForInvoice(invoice: AnyData, invoiceId: string): string {
+/**
+ * Exported because the payment-receipt triggers need the same answer: given a
+ * legacy invoice, which unified document is its mirror? Deriving it twice
+ * would be a correctness bug waiting to happen — a receipt would be sent
+ * twice, or not at all, the moment the two rules drifted.
+ */
+export function mirrorIdForInvoice(invoice: AnyData, invoiceId: string): string {
   return typeof invoice.sourceQuoteId === 'string' && invoice.sourceQuoteId
     ? invoice.sourceQuoteId
     : invoiceId;

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -10652,19 +10652,39 @@ export const onQuoteViewed = functions.firestore
 // -----------------------------------------------------------
 
 /**
- * True when the legacy invoice has a unified mirror document, i.e. when the
- * documents-collection triggers own its notifications. Uses the mirror's own
- * id rule so the two can't disagree.
+ * True when the legacy invoice has a mirror document that could ACTUALLY send
+ * the receipt itself — i.e. when the documents-collection trigger owns its
+ * notifications. Uses the mirror's own id rule so the two can't disagree.
+ *
+ * Existence alone is not enough, and getting this wrong is silent. Square
+ * reconciliation calls applyPaymentToDocument → setDocumentStage, which does
+ * a merge write of only {stage, payments, paidTotal, balanceDue, updatedAt}.
+ * When no mirror existed yet (loadDocument falls back to the legacy row
+ * rather than creating one), that write CREATES a stub carrying no `type`
+ * and no `customerEmail`. onDocumentPaymentReceived rejects it, so deferring
+ * on `snap.exists` would silence the receipt — permanently, since the stub
+ * then blocks every future payment on that invoice too. Require the fields
+ * the documents trigger needs before handing over.
  */
 async function legacyInvoiceHasMirror(
   userId: string,
   invoice: Record<string, any>,
   invoiceId: string,
+  // The two triggers need different things of the mirror: a receipt needs a
+  // customer email, the tradie's push does not. Handing the push over on the
+  // stricter test would double-push an invoice with no customer email (the
+  // legacy trigger would not defer, and the documents trigger pushes anyway).
+  need: 'receipt' | 'push',
 ): Promise<boolean> {
   try {
     const mirrorId = mirrorIdForInvoice(invoice, invoiceId);
     const snap = await db.doc(`users/${userId}/documents/${mirrorId}`).get();
-    return snap.exists;
+    if (!snap.exists) return false;
+    const mirror = snap.data() as Record<string, any>;
+    if (mirror?.type !== 'invoice') return false;
+    if (need === 'push') return true;
+    const email = typeof mirror?.customerEmail === 'string' ? mirror.customerEmail.trim() : '';
+    return email !== '';
   } catch (err: any) {
     // Read failure: assume no mirror and send. A missing receipt is the bug
     // we're fixing; a duplicate is worse, but a Firestore read failing here
@@ -10737,7 +10757,7 @@ export const onInvoiceStatusChanged = functions.firestore
 
     // Mirrored invoices are the documents trigger's job — otherwise the
     // tradie gets two "you've been paid" pushes for one payment.
-    if (await legacyInvoiceHasMirror(userId, after, invoiceId)) return;
+    if (await legacyInvoiceHasMirror(userId, after, invoiceId, 'push')) return;
 
     await sendAussiePush(userId, 'invoice_paid', {
       customer: after.customerName || 'A customer',
@@ -10764,7 +10784,7 @@ export const onInvoicePaymentReceived = functions.firestore
 
     // Single delivery: defer to onDocumentPaymentReceived when this invoice
     // is mirrored into the unified collection (the normal case today).
-    if (await legacyInvoiceHasMirror(userId, after, invoiceId)) return;
+    if (await legacyInvoiceHasMirror(userId, after, invoiceId, 'receipt')) return;
 
     try {
       await deliverPaymentReceipt({
@@ -10817,29 +10837,48 @@ export const onDocumentPaymentReceived = functions.firestore
         // email in flight. Firestore triggers are at-least-once, so without
         // this a redelivery would bill the customer's inbox twice.
         const ref = db.doc(`users/${userId}/documents/${docId}`);
+        let previousMark = 0;
         const claimed = await db.runTransaction(async (tx) => {
           const snap = await tx.get(ref);
           if (!snap.exists) return false;
-          if (!claimsReceipt(snap.data()?.receiptSentPaidCents, receipt.receiptedPaidCents)) {
-            return false;
-          }
+          const current = Number(snap.data()?.receiptSentPaidCents) || 0;
+          if (!claimsReceipt(current, receipt.receiptedPaidCents)) return false;
+          previousMark = current;
           tx.update(ref, { receiptSentPaidCents: receipt.receiptedPaidCents });
           return true;
         });
 
         if (claimed) {
-          await deliverPaymentReceipt({
-            userId,
-            receipt,
-            customerName: after.customerName,
-            invoiceNumber: receipt.invoiceNumber,
-            jobName: after.job?.name,
-            paidAt: new Date(receipt.paidAtMs),
-          });
+          try {
+            await deliverPaymentReceipt({
+              userId,
+              receipt,
+              customerName: after.customerName,
+              invoiceNumber: receipt.invoiceNumber,
+              jobName: after.job?.name,
+              paidAt: new Date(receipt.paidAtMs),
+            });
+          } catch (sendErr: any) {
+            // Claim-before-send is what makes redelivery safe, but a claim we
+            // never cashed would wedge this paid total shut forever — a
+            // transient Brevo 5xx would become a permanently missing receipt,
+            // the exact failure this trigger exists to fix. Release the claim
+            // so a retry or replay can take it, and shout: nothing else will.
+            await db.runTransaction(async (tx) => {
+              const snap = await tx.get(ref);
+              if (!snap.exists) return;
+              // Compare-and-set: only roll back OUR claim. A later payment
+              // may have already moved the mark past it.
+              if (Number(snap.data()?.receiptSentPaidCents) === receipt.receiptedPaidCents) {
+                tx.update(ref, { receiptSentPaidCents: previousMark });
+              }
+            }).catch(() => undefined);
+            throw sendErr;
+          }
         }
       } catch (err: any) {
         // Best-effort: a receipt failure must never block the payment write.
-        functions.logger.warn('payment_receipt_email_failed', {
+        functions.logger.error('payment_receipt_email_failed', {
           userId, docId, message: err?.message, collection: 'documents',
         });
       }

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -38,7 +38,11 @@ import {
   isPaymentAlreadyApplied,
   applySquarePaymentToInvoice,
   evaluatePaymentReceipt,
+  evaluateDocumentPaymentReceipt,
+  shouldSendInvoicePaidPush,
+  type PaymentReceiptEvaluation,
 } from './paymentReceipt.helpers';
+import { mirrorIdForInvoice } from './documentMirror';
 import { shouldReadyToSendNudge, toMs } from './draftNudge.helpers';
 import { onboardingTipDue } from './onboardingDrip.helpers';
 export * from './adminCrm';
@@ -10628,6 +10632,94 @@ export const onQuoteViewed = functions.firestore
   });
 
 // -----------------------------------------------------------
+// Payment receipts — one delivery per payment across two collections
+//
+// Every invoice exists in the legacy `users/{uid}/invoices` collection, the
+// unified `users/{uid}/documents` collection, or both. Modern invoices
+// (convertDocumentToInvoice) are document-only; older ones and the legacy
+// fallback in createInvoiceFromQuote have a legacy row that the mirror
+// trigger projects into `documents`. Naively triggering on both collections
+// would send the customer TWO receipts for one payment on every
+// dual-written invoice.
+//
+// Ownership rule: the unified `documents` trigger is the sender. The legacy
+// triggers defer to it whenever the invoice HAS a mirror document — which,
+// post-Phase-1 dual-write, is every invoice — and remain as the fallback for
+// any legacy invoice whose mirror is missing. Deferral is safe because every
+// legacy write cascades into `documents` via onInvoiceWritten, so the
+// documents trigger always gets its turn.
+// -----------------------------------------------------------
+
+/**
+ * True when the legacy invoice has a unified mirror document, i.e. when the
+ * documents-collection triggers own its notifications. Uses the mirror's own
+ * id rule so the two can't disagree.
+ */
+async function legacyInvoiceHasMirror(
+  userId: string,
+  invoice: Record<string, any>,
+  invoiceId: string,
+): Promise<boolean> {
+  try {
+    const mirrorId = mirrorIdForInvoice(invoice, invoiceId);
+    const snap = await db.doc(`users/${userId}/documents/${mirrorId}`).get();
+    return snap.exists;
+  } catch (err: any) {
+    // Read failure: assume no mirror and send. A missing receipt is the bug
+    // we're fixing; a duplicate is worse, but a Firestore read failing here
+    // means the documents trigger most likely didn't run either.
+    functions.logger.warn('payment_receipt_mirror_lookup_failed', {
+      userId, invoiceId, message: err?.message,
+    });
+    return false;
+  }
+}
+
+/**
+ * Load the tradie's branding and email the customer their receipt. Shared by
+ * the legacy and unified triggers so the two shapes produce an identical
+ * customer-facing email.
+ */
+async function deliverPaymentReceipt(input: {
+  userId: string;
+  receipt: PaymentReceiptEvaluation;
+  customerName?: string;
+  invoiceNumber?: string;
+  jobName?: string;
+  paidAt: Date;
+}): Promise<void> {
+  const { userId, receipt } = input;
+  const businessDoc = await db.doc(`users/${userId}/settings/business`).get();
+  const business = (businessDoc.exists ? businessDoc.data() : {}) as Record<string, any>;
+  const businessName = business.businessName || 'Your Tradie';
+  const rawLogo = business.logoStorageUrl || business.logoUri || '';
+  const logoUrl = /^https?:\/\//.test(rawLogo) ? rawLogo : undefined;
+
+  const paidDateText = input.paidAt.toLocaleDateString('en-AU', {
+    day: 'numeric', month: 'long', year: 'numeric', timeZone: 'Australia/Sydney',
+  });
+
+  const replyToEmail = await resolveTradieReplyEmail(userId, business.email);
+  await sendPaymentReceiptEmail({
+    to: receipt.customerEmail,
+    userId,
+    business: { businessName, brandColor: business.brandColor, logoUrl },
+    replyToEmail,
+    receipt: {
+      customerName: input.customerName,
+      businessName,
+      invoiceNumber: input.invoiceNumber,
+      jobName: input.jobName,
+      amountReceived: receipt.amountReceived,
+      isFullyPaid: receipt.isFullyPaid,
+      balanceDue: receipt.balanceDue,
+      paymentMethod: receipt.paymentMethod,
+      paidDateText,
+    },
+  });
+}
+
+// -----------------------------------------------------------
 // onInvoiceStatusChanged — Firestore trigger: when invoice status changes to paid
 // -----------------------------------------------------------
 export const onInvoiceStatusChanged = functions.firestore
@@ -10642,6 +10734,10 @@ export const onInvoiceStatusChanged = functions.firestore
       return;
     }
 
+    // Mirrored invoices are the documents trigger's job — otherwise the
+    // tradie gets two "you've been paid" pushes for one payment.
+    if (await legacyInvoiceHasMirror(userId, after, invoiceId)) return;
+
     await sendAussiePush(userId, 'invoice_paid', {
       customer: after.customerName || 'A customer',
       job: after.job?.name || 'the job',
@@ -10650,9 +10746,10 @@ export const onInvoiceStatusChanged = functions.firestore
 
 // -----------------------------------------------------------
 // onInvoicePaymentReceived — Firestore trigger: email the customer a receipt
-// whenever a payment lands on an invoice. Fires on any paidAmount increase,
-// which covers every payment path — manual Record Payment (app syncs the
-// invoice doc), Square pay link, and Tap to Pay (webhook writes the doc).
+// whenever a payment lands on a legacy invoice that has no unified mirror.
+// Fires on any paidAmount increase, which covers every legacy payment path —
+// manual Record Payment (app syncs the invoice doc), Square pay link, and
+// Tap to Pay (webhook writes the doc).
 // -----------------------------------------------------------
 export const onInvoicePaymentReceived = functions.firestore
   .document('users/{userId}/invoices/{invoiceId}')
@@ -10664,41 +10761,102 @@ export const onInvoicePaymentReceived = functions.firestore
     const receipt = evaluatePaymentReceipt(before, after);
     if (!receipt) return;
 
+    // Single delivery: defer to onDocumentPaymentReceived when this invoice
+    // is mirrored into the unified collection (the normal case today).
+    if (await legacyInvoiceHasMirror(userId, after, invoiceId)) return;
+
     try {
-      const businessDoc = await db.doc(`users/${userId}/settings/business`).get();
-      const business = (businessDoc.exists ? businessDoc.data() : {}) as Record<string, any>;
-      const businessName = business.businessName || 'Your Tradie';
-      const rawLogo = business.logoStorageUrl || business.logoUri || '';
-      const logoUrl = /^https?:\/\//.test(rawLogo) ? rawLogo : undefined;
-
-      const paidDateValue = after.paidDate?.toDate?.() ?? new Date();
-      const paidDateText = paidDateValue.toLocaleDateString('en-AU', {
-        day: 'numeric', month: 'long', year: 'numeric', timeZone: 'Australia/Sydney',
-      });
-
-      const replyToEmail = await resolveTradieReplyEmail(userId, business.email);
-      await sendPaymentReceiptEmail({
-        to: receipt.customerEmail,
+      await deliverPaymentReceipt({
         userId,
-        business: { businessName, brandColor: business.brandColor, logoUrl },
-        replyToEmail,
-        receipt: {
-          customerName: after.customerName,
-          businessName,
-          invoiceNumber: after.invoiceNumber,
-          jobName: after.job?.name,
-          amountReceived: receipt.amountReceived,
-          isFullyPaid: receipt.isFullyPaid,
-          balanceDue: receipt.balanceDue,
-          paymentMethod: receipt.paymentMethod,
-          paidDateText,
-        },
+        receipt,
+        customerName: after.customerName,
+        invoiceNumber: after.invoiceNumber,
+        jobName: after.job?.name,
+        paidAt: after.paidDate?.toDate?.() ?? new Date(),
       });
     } catch (err: any) {
       // Best-effort: a receipt failure must never block the payment write.
       functions.logger.warn('payment_receipt_email_failed', {
         userId, invoiceId, message: err?.message,
       });
+    }
+  });
+
+// -----------------------------------------------------------
+// onDocumentPaymentReceived — Firestore trigger on the UNIFIED collection:
+// email the customer a receipt and push the tradie when a payment lands on
+// `users/{uid}/documents/{docId}` with type 'invoice'.
+//
+// This is the path that actually carries payments today: an invoice created
+// by convertDocumentToInvoice has no legacy row at all, so the legacy
+// triggers above never saw its payments and neither the receipt nor the
+// push ever fired.
+//
+// onUpdate (not onWrite) on purpose. A document that arrives already paid is
+// a mirror/backfill projection of history, not a payment event, and must not
+// spray receipts at customers who paid months ago. It also closes the race
+// with the legacy fallback: a legacy invoice paid before its mirror exists
+// gets its receipt from onInvoicePaymentReceived, and the mirror's creation
+// can't produce a second one.
+// -----------------------------------------------------------
+export const onDocumentPaymentReceived = functions.firestore
+  .document('users/{userId}/documents/{docId}')
+  .onUpdate(async (change, context) => {
+    const before = change.before.data();
+    const after = change.after.data();
+    const { userId, docId } = context.params;
+
+    const receipt = evaluateDocumentPaymentReceipt(before, after);
+    if (receipt) {
+      try {
+        // Claim the receipt before sending. The high-water mark doubles as
+        // the idempotency key: a transaction that finds the mark already at
+        // (or past) this paid total means another invocation — a retry, or
+        // an at-least-once redelivery of this very event — already has the
+        // email in flight. Firestore triggers are at-least-once, so without
+        // this a redelivery would bill the customer's inbox twice.
+        const ref = db.doc(`users/${userId}/documents/${docId}`);
+        const claimed = await db.runTransaction(async (tx) => {
+          const snap = await tx.get(ref);
+          if (!snap.exists) return false;
+          const current = Number(snap.data()?.receiptSentPaidCents) || 0;
+          if (current >= receipt.receiptedPaidCents) return false;
+          tx.update(ref, { receiptSentPaidCents: receipt.receiptedPaidCents });
+          return true;
+        });
+
+        if (claimed) {
+          await deliverPaymentReceipt({
+            userId,
+            receipt,
+            customerName: after.customerName,
+            invoiceNumber: receipt.invoiceNumber,
+            jobName: after.job?.name,
+            paidAt: new Date(receipt.paidAtMs),
+          });
+        }
+      } catch (err: any) {
+        // Best-effort: a receipt failure must never block the payment write.
+        functions.logger.warn('payment_receipt_email_failed', {
+          userId, docId, message: err?.message, collection: 'documents',
+        });
+      }
+    }
+
+    // Tradie push on the stage → 'paid' edge, the unified twin of
+    // onInvoiceStatusChanged. Separate from the receipt because an invoice
+    // with no customer email still earns the tradie a notification.
+    if (shouldSendInvoicePaidPush(before, after)) {
+      try {
+        await sendAussiePush(userId, 'invoice_paid', {
+          customer: after.customerName || 'A customer',
+          job: after.job?.name || 'the job',
+        }, { invoiceId: docId });
+      } catch (err: any) {
+        functions.logger.warn('invoice_paid_push_failed', {
+          userId, docId, message: err?.message,
+        });
+      }
     }
   });
 

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -40,6 +40,7 @@ import {
   evaluatePaymentReceipt,
   evaluateDocumentPaymentReceipt,
   shouldSendInvoicePaidPush,
+  claimsReceipt,
   type PaymentReceiptEvaluation,
 } from './paymentReceipt.helpers';
 import { mirrorIdForInvoice } from './documentMirror';
@@ -10819,8 +10820,9 @@ export const onDocumentPaymentReceived = functions.firestore
         const claimed = await db.runTransaction(async (tx) => {
           const snap = await tx.get(ref);
           if (!snap.exists) return false;
-          const current = Number(snap.data()?.receiptSentPaidCents) || 0;
-          if (current >= receipt.receiptedPaidCents) return false;
+          if (!claimsReceipt(snap.data()?.receiptSentPaidCents, receipt.receiptedPaidCents)) {
+            return false;
+          }
           tx.update(ref, { receiptSentPaidCents: receipt.receiptedPaidCents });
           return true;
         });

--- a/functions/src/paymentReceipt.helpers.test.ts
+++ b/functions/src/paymentReceipt.helpers.test.ts
@@ -254,6 +254,64 @@ describe('evaluateDocumentPaymentReceipt — receipts for document-collection in
     expect(r!.isFullyPaid).toBe(true);
   });
 
+  // A deposit paid against the source quote survives onto the invoice ledger,
+  // but the invoice `total` was already reduced by that deposit when the
+  // quote was converted. Subtracting the raw paidTotal would charge the
+  // deposit twice — against the customer, in an email they act on.
+  describe('deposit credit — total is already net of it, so the ledger must not subtract it twice', () => {
+    // $1,100 quote, $100 deposit paid → invoice total $1,000, ledger opens at 100.
+    const withDeposit = {
+      ...docBase,
+      total: 1000,
+      paidTotal: 100,
+      balanceDue: 900,
+      payments: [{ id: 'deposit-credit-q1', kind: 'deposit', amount: 100, paidAt: PAID_AT, method: 'square' }],
+    };
+
+    it('reports the true balance owing on a part payment, not one short by the deposit', () => {
+      const after = {
+        ...withDeposit,
+        stage: 'partially_paid',
+        paidTotal: 600,
+        payments: [...withDeposit.payments, manualPayment('pay-1', 500)],
+      };
+      const r = evaluateDocumentPaymentReceipt(withDeposit, after);
+      expect(r!.amountReceived).toBe(500);
+      expect(r!.balanceDue).toBe(500); // not $400 — the deposit is not owed twice
+      expect(r!.isFullyPaid).toBe(false);
+    });
+
+    it('does not claim "paid in full" while the deposit-sized remainder is outstanding', () => {
+      // paidTotal hits the invoice total, and recordDocumentPayment's own
+      // arithmetic flips stage to 'paid' — but $100 is genuinely still owed.
+      const after = {
+        ...withDeposit,
+        stage: 'paid',
+        paidTotal: 1000,
+        balanceDue: 0,
+        payments: [...withDeposit.payments, manualPayment('pay-1', 900)],
+      };
+      const r = evaluateDocumentPaymentReceipt(withDeposit, after);
+      expect(r!.amountReceived).toBe(900);
+      expect(r!.balanceDue).toBe(100);
+      expect(r!.isFullyPaid).toBe(false);
+    });
+
+    it('does flag paid in full once the real balance closes', () => {
+      const before = {
+        ...withDeposit, stage: 'partially_paid', paidTotal: 600,
+        payments: [...withDeposit.payments, manualPayment('pay-1', 500)],
+      };
+      const after = {
+        ...before, stage: 'paid', paidTotal: 1100,
+        payments: [...before.payments, manualPayment('pay-2', 500)],
+      };
+      const r = evaluateDocumentPaymentReceipt(before, after);
+      expect(r!.balanceDue).toBe(0);
+      expect(r!.isFullyPaid).toBe(true);
+    });
+  });
+
   it('skips a payment correction that lowers paidTotal', () => {
     const before = {
       ...docBase, stage: 'partially_paid', paidTotal: 400,

--- a/functions/src/paymentReceipt.helpers.test.ts
+++ b/functions/src/paymentReceipt.helpers.test.ts
@@ -4,6 +4,10 @@ import {
   isPaymentAlreadyApplied,
   applySquarePaymentToInvoice,
   evaluatePaymentReceipt,
+  evaluateDocumentPaymentReceipt,
+  documentPaymentMethodToLegacy,
+  shouldSendInvoicePaidPush,
+  claimsReceipt,
   paymentMethodLabel,
   formatAud,
   buildPaymentReceiptContentHtml,
@@ -117,6 +121,353 @@ describe('evaluatePaymentReceipt — when an invoice update earns the customer a
   it('skips a zero-total invoice', () => {
     const zero = { ...base, total: 0 };
     expect(evaluatePaymentReceipt(zero, { ...zero, paidAmount: 100 })).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unified `documents` shape — the collection modern invoices actually live in
+// ---------------------------------------------------------------------------
+
+/**
+ * A document-collection invoice mid-life: sent to the customer, nothing paid.
+ * Shaped like a real `users/{uid}/documents/{docId}` record — `paidTotal` /
+ * `stage` / `number` / `payments[]`, not the legacy `paidAmount` / `status` /
+ * `invoiceNumber`.
+ */
+const PAID_AT = 1_760_000_000_000; // fixed ms epoch — keeps assertions stable
+const docBase = {
+  type: 'invoice',
+  stage: 'invoice_sent',
+  number: 'IN-0042',
+  customerName: 'Sarah',
+  customerEmail: 'sarah@bribiecabinets.com.au',
+  total: 1000,
+  paidTotal: 0,
+  balanceDue: 1000,
+  payments: [] as any[],
+};
+
+const manualPayment = (id: string, amount: number, method = 'bank') => ({
+  id, kind: 'manual', amount, paidAt: PAID_AT, method,
+});
+
+describe('evaluateDocumentPaymentReceipt — receipts for document-collection invoices', () => {
+  it('REGRESSION: a payment on a document-only invoice (no legacy row) earns a receipt', () => {
+    // Before the documents trigger existed this produced nothing at all —
+    // convertDocumentToInvoice writes no legacy row, so the legacy trigger
+    // never saw the payment and the customer got silence.
+    const after = {
+      ...docBase,
+      stage: 'partially_paid',
+      paidTotal: 400,
+      balanceDue: 600,
+      payments: [manualPayment('pay-1', 400)],
+    };
+    const r = evaluateDocumentPaymentReceipt(docBase, after);
+    expect(r).not.toBeNull();
+    expect(r!.customerEmail).toBe('sarah@bribiecabinets.com.au');
+    expect(r!.amountReceived).toBe(400);
+    expect(r!.isFullyPaid).toBe(false);
+    expect(r!.balanceDue).toBe(600);
+    expect(r!.paymentMethod).toBe('bank_transfer');
+    expect(r!.invoiceNumber).toBe('IN-0042');
+    expect(r!.paidAtMs).toBe(PAID_AT);
+    expect(r!.receiptedPaidCents).toBe(40000);
+  });
+
+  it('a part payment reports the balance still owing and is not "paid in full"', () => {
+    const after = {
+      ...docBase, stage: 'partially_paid', paidTotal: 250.5, balanceDue: 749.5,
+      payments: [manualPayment('pay-1', 250.5, 'cash')],
+    };
+    const r = evaluateDocumentPaymentReceipt(docBase, after);
+    expect(r!.amountReceived).toBe(250.5);
+    expect(r!.balanceDue).toBe(749.5);
+    expect(r!.isFullyPaid).toBe(false);
+    expect(r!.paymentMethod).toBe('cash');
+  });
+
+  it('the final payment closing the balance flags paid in full and charges only the delta', () => {
+    const before = {
+      ...docBase, stage: 'partially_paid', paidTotal: 400, balanceDue: 600,
+      payments: [manualPayment('pay-1', 400)],
+      receiptSentPaidCents: 40000,
+    };
+    const after = {
+      ...before, stage: 'paid', paidTotal: 1000, balanceDue: 0,
+      payments: [manualPayment('pay-1', 400), manualPayment('pay-2', 600, 'square')],
+      paidInFullAt: PAID_AT,
+    };
+    const r = evaluateDocumentPaymentReceipt(before, after);
+    expect(r!.amountReceived).toBe(600);
+    expect(r!.isFullyPaid).toBe(true);
+    expect(r!.balanceDue).toBe(0);
+    expect(r!.paymentMethod).toBe('card'); // 'square' → the legacy label 'Card'
+    expect(r!.receiptedPaidCents).toBe(100000);
+  });
+
+  it('NO-OP: a resync write that does not increase paidTotal sends nothing', () => {
+    const paid = {
+      ...docBase, stage: 'paid', paidTotal: 1000, balanceDue: 0,
+      payments: [manualPayment('pay-1', 1000)],
+    };
+    expect(evaluateDocumentPaymentReceipt(paid, { ...paid })).toBeNull();
+    // ...including a write that only touches unrelated fields.
+    expect(evaluateDocumentPaymentReceipt(paid, { ...paid, jobId: 'job-9' })).toBeNull();
+  });
+
+  it('REDELIVERY: an at-least-once replay of the paying event does not re-send', () => {
+    // Firestore triggers are at-least-once. The second delivery carries the
+    // same before/after, but the mark stamped by the first has landed.
+    const after = {
+      ...docBase, stage: 'paid', paidTotal: 1000, balanceDue: 0,
+      payments: [manualPayment('pay-1', 1000)],
+      receiptSentPaidCents: 100000,
+    };
+    expect(evaluateDocumentPaymentReceipt(docBase, after)).toBeNull();
+  });
+
+  it('the trigger stamping its own mark does not loop back into another receipt', () => {
+    const paid = {
+      ...docBase, stage: 'paid', paidTotal: 1000, balanceDue: 0,
+      payments: [manualPayment('pay-1', 1000)],
+    };
+    // before = pre-stamp, after = post-stamp; paidTotal never moved.
+    expect(evaluateDocumentPaymentReceipt(paid, { ...paid, receiptSentPaidCents: 100000 })).toBeNull();
+  });
+
+  it('still fires when the mirror rebuilds payments with its own synthetic ids', () => {
+    // The legacy→documents mirror derives payments as `manual-{invoiceId}` —
+    // a STABLE id across part payments. Keying off ids alone would miss the
+    // second payment, so the money (paidTotal) is what decides.
+    const before = {
+      ...docBase, stage: 'partially_paid', paidTotal: 400, balanceDue: 600,
+      payments: [{ id: 'manual-inv1', kind: 'manual', amount: 400, paidAt: PAID_AT, method: 'bank' }],
+      receiptSentPaidCents: 40000,
+    };
+    const after = {
+      ...before, stage: 'paid', paidTotal: 1000, balanceDue: 0,
+      payments: [{ id: 'manual-inv1', kind: 'manual', amount: 1000, paidAt: PAID_AT, method: 'bank' }],
+    };
+    const r = evaluateDocumentPaymentReceipt(before, after);
+    expect(r!.amountReceived).toBe(600);
+    expect(r!.isFullyPaid).toBe(true);
+  });
+
+  it('skips a payment correction that lowers paidTotal', () => {
+    const before = {
+      ...docBase, stage: 'partially_paid', paidTotal: 400,
+      payments: [manualPayment('pay-1', 400)],
+    };
+    expect(evaluateDocumentPaymentReceipt(before, { ...before, paidTotal: 200 })).toBeNull();
+  });
+
+  it('skips quote documents — only invoices produce receipts', () => {
+    const before = { ...docBase, type: 'quote', stage: 'quote_sent' };
+    const after = { ...before, paidTotal: 400, payments: [manualPayment('pay-1', 400)] };
+    expect(evaluateDocumentPaymentReceipt(before, after)).toBeNull();
+  });
+
+  it.each(['draft', 'quote_sent', 'quote_accepted', 'quote_rejected', 'cancelled'])(
+    'skips stage %s — the customer was never sent this invoice',
+    (stage) => {
+      const before = { ...docBase, stage };
+      const after = {
+        ...before, stage: 'paid', paidTotal: 1000, payments: [manualPayment('pay-1', 1000)],
+      };
+      expect(evaluateDocumentPaymentReceipt(before, after)).toBeNull();
+    },
+  );
+
+  it('skips when the customer has no email address', () => {
+    const before = { ...docBase, customerEmail: '   ' };
+    const after = { ...before, stage: 'paid', paidTotal: 1000, payments: [manualPayment('p', 1000)] };
+    expect(evaluateDocumentPaymentReceipt(before, after)).toBeNull();
+  });
+
+  it('skips a zero-total invoice', () => {
+    const before = { ...docBase, total: 0 };
+    const after = { ...before, paidTotal: 100, payments: [manualPayment('p', 100)] };
+    expect(evaluateDocumentPaymentReceipt(before, after)).toBeNull();
+  });
+
+  it('tolerates a missing payments array (mirror projections without a ledger)', () => {
+    const { payments: _drop, ...noLedger } = docBase;
+    const after = { ...noLedger, stage: 'paid', paidTotal: 1000, balanceDue: 0 };
+    const r = evaluateDocumentPaymentReceipt(noLedger, after);
+    expect(r!.amountReceived).toBe(1000);
+    expect(r!.paymentMethod).toBeUndefined();
+    expect(typeof r!.paidAtMs).toBe('number');
+  });
+});
+
+describe('documentPaymentMethodToLegacy — unified method vocabulary → receipt labels', () => {
+  it('maps the unified methods onto the labels the receipt email speaks', () => {
+    expect(documentPaymentMethodToLegacy('square')).toBe('card');
+    expect(documentPaymentMethodToLegacy('bank')).toBe('bank_transfer');
+    expect(documentPaymentMethodToLegacy('cash')).toBe('cash');
+  });
+  it('hides the row for other/unknown/missing methods', () => {
+    expect(documentPaymentMethodToLegacy('other')).toBeUndefined();
+    expect(documentPaymentMethodToLegacy(undefined)).toBeUndefined();
+  });
+  it('round-trips through paymentMethodLabel to a human label', () => {
+    expect(paymentMethodLabel(documentPaymentMethodToLegacy('square'))).toBe('Card');
+    expect(paymentMethodLabel(documentPaymentMethodToLegacy('bank'))).toBe('Bank transfer');
+  });
+});
+
+describe('claimsReceipt — the transactional high-water claim', () => {
+  it('claims when this payment advances the mark', () => {
+    expect(claimsReceipt(0, 40000)).toBe(true);
+    expect(claimsReceipt(40000, 100000)).toBe(true);
+    expect(claimsReceipt(undefined, 100)).toBe(true);
+  });
+  it('refuses when the mark already covers this total (redelivery / concurrent retry)', () => {
+    expect(claimsReceipt(100000, 100000)).toBe(false);
+    expect(claimsReceipt(100000, 40000)).toBe(false);
+  });
+});
+
+describe('shouldSendInvoicePaidPush — tradie push on the stage → paid edge', () => {
+  it('fires when an invoice document becomes paid', () => {
+    expect(shouldSendInvoicePaidPush(
+      { ...docBase, stage: 'partially_paid' },
+      { ...docBase, stage: 'paid' },
+    )).toBe(true);
+  });
+  it('does not re-fire on later writes to an already-paid invoice', () => {
+    expect(shouldSendInvoicePaidPush(
+      { ...docBase, stage: 'paid' },
+      { ...docBase, stage: 'paid', paidInFullAt: PAID_AT },
+    )).toBe(false);
+  });
+  it('ignores part payments and quotes', () => {
+    expect(shouldSendInvoicePaidPush(docBase, { ...docBase, stage: 'partially_paid' })).toBe(false);
+    expect(shouldSendInvoicePaidPush(
+      { ...docBase, type: 'quote', stage: 'quote_sent' },
+      { ...docBase, type: 'quote', stage: 'paid' },
+    )).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Single delivery across both collections
+// ---------------------------------------------------------------------------
+
+type SimulatedWrite =
+  | { collection: 'documents'; before: Record<string, any>; after: Record<string, any> }
+  | { collection: 'invoices'; before: Record<string, any>; after: Record<string, any> };
+
+/**
+ * Replays a sequence of Firestore writes through the same composition the two
+ * triggers use in index.ts:
+ *   - onDocumentPaymentReceived: evaluate → claim the high-water mark → send;
+ *   - onInvoicePaymentReceived:  evaluate → send ONLY if the invoice has no
+ *     unified mirror document (otherwise the documents trigger owns it).
+ * Returns the receipts that would actually reach the customer's inbox.
+ */
+function replayThroughTriggers(
+  writes: SimulatedWrite[],
+  hasMirrorDocument: boolean,
+): number[] {
+  const sent: number[] = [];
+  let mark = 0; // receiptSentPaidCents as persisted on the document
+
+  for (const write of writes) {
+    if (write.collection === 'documents') {
+      const receipt = evaluateDocumentPaymentReceipt(
+        write.before,
+        { ...write.after, receiptSentPaidCents: mark },
+      );
+      if (!receipt) continue;
+      if (!claimsReceipt(mark, receipt.receiptedPaidCents)) continue;
+      mark = receipt.receiptedPaidCents;
+      sent.push(receipt.amountReceived);
+    } else {
+      const receipt = evaluatePaymentReceipt(write.before, write.after);
+      if (!receipt) continue;
+      if (hasMirrorDocument) continue; // legacyInvoiceHasMirror() → defer
+      sent.push(receipt.amountReceived);
+    }
+  }
+  return sent;
+}
+
+describe('exactly one receipt per payment across the documents + invoices collections', () => {
+  // What recordDocumentPayment produces for a DUAL-WRITTEN invoice: the
+  // document ledger, then the legacy mirror row, then the legacy→documents
+  // mirror trigger re-projecting the same money with its own payment ids.
+  const dualWriteSequence: SimulatedWrite[] = [
+    {
+      collection: 'documents',
+      before: docBase,
+      after: {
+        ...docBase, stage: 'partially_paid', paidTotal: 400, balanceDue: 600,
+        payments: [manualPayment('pay-1', 400)],
+      },
+    },
+    {
+      collection: 'invoices',
+      before: { status: 'sent', customerEmail: docBase.customerEmail, total: 1000, paidAmount: 0 },
+      after: {
+        status: 'partial', customerEmail: docBase.customerEmail, total: 1000,
+        paidAmount: 400, paymentMethod: 'bank_transfer',
+      },
+    },
+    {
+      collection: 'documents',
+      before: {
+        ...docBase, stage: 'partially_paid', paidTotal: 400, balanceDue: 600,
+        payments: [manualPayment('pay-1', 400)],
+      },
+      after: {
+        ...docBase, stage: 'partially_paid', paidTotal: 400, balanceDue: 600,
+        payments: [{ id: 'manual-inv1', kind: 'manual', amount: 400, paidAt: PAID_AT, method: 'bank' }],
+      },
+    },
+  ];
+
+  it('DOUBLE-SEND: an invoice with BOTH a document and a legacy row sends exactly ONE receipt', () => {
+    expect(replayThroughTriggers(dualWriteSequence, true)).toEqual([400]);
+  });
+
+  it('proves the deferral is load-bearing: without it the same payment sends TWO receipts', () => {
+    // This is the failure mode the ownership rule exists to prevent — two
+    // receipts to a real customer is worse than the missing-receipt bug.
+    expect(replayThroughTriggers(dualWriteSequence, false)).toHaveLength(2);
+  });
+
+  it('a document-only invoice (no legacy row, so no legacy write at all) still gets its one receipt', () => {
+    expect(replayThroughTriggers([dualWriteSequence[0]], true)).toEqual([400]);
+  });
+
+  it('a legacy-only invoice with no mirror keeps its receipt via the legacy fallback', () => {
+    expect(replayThroughTriggers([dualWriteSequence[1]], false)).toEqual([400]);
+  });
+
+  it('two part payments then the balance produce three receipts, one per payment', () => {
+    const step = (paidBefore: number, paidAfter: number, ids: string[]): SimulatedWrite => ({
+      collection: 'documents',
+      before: {
+        ...docBase,
+        stage: paidBefore > 0 ? 'partially_paid' : 'invoice_sent',
+        paidTotal: paidBefore,
+        payments: ids.slice(0, -1).map((id, i) => manualPayment(id, [300, 300][i] ?? 0)),
+      },
+      after: {
+        ...docBase,
+        stage: paidAfter >= 1000 ? 'paid' : 'partially_paid',
+        paidTotal: paidAfter,
+        payments: ids.map((id, i) => manualPayment(id, [300, 300, 400][i])),
+      },
+    });
+    const sent = replayThroughTriggers([
+      step(0, 300, ['p1']),
+      step(300, 600, ['p1', 'p2']),
+      step(600, 1000, ['p1', 'p2', 'p3']),
+    ], true);
+    expect(sent).toEqual([300, 300, 400]);
   });
 });
 

--- a/functions/src/paymentReceipt.helpers.ts
+++ b/functions/src/paymentReceipt.helpers.ts
@@ -243,6 +243,19 @@ export function evaluateDocumentPaymentReceipt(
 }
 
 /**
+ * Pure core of the receipt claim the documents trigger runs inside a
+ * transaction: does this evaluation beat the mark already on the document?
+ * `>=` would be the wrong comparison — a redelivered event carries the mark's
+ * exact value and must NOT re-send, so only a strict advance claims.
+ */
+export function claimsReceipt(
+  storedReceiptSentPaidCents: unknown,
+  receiptedPaidCents: number,
+): boolean {
+  return (Number(storedReceiptSentPaidCents) || 0) < receiptedPaidCents;
+}
+
+/**
  * True when this document write is the moment an invoice became fully paid —
  * the unified analogue of `onInvoiceStatusChanged`'s status → 'paid' edge,
  * used to fire the tradie's `invoice_paid` push exactly once.

--- a/functions/src/paymentReceipt.helpers.ts
+++ b/functions/src/paymentReceipt.helpers.ts
@@ -216,8 +216,20 @@ export function evaluateDocumentPaymentReceipt(
   const deltaCents = paidAfterCents - floorCents;
   if (deltaCents < 1) return null;
 
-  const paidAfter = paidAfterCents / 100;
-  const balanceDue = round2(Math.max(0, total - paidAfter));
+  // Balance is computed against NON-deposit money. `total` on an invoice
+  // converted from a quote is already net of the deposit credit (see
+  // convertDocumentToInvoice), while the deposit stays on the ledger and in
+  // `paidTotal` — the mirror even re-adds it as a `deposit-credit-*` payment.
+  // Subtracting the raw paidTotal from an already-net total would count the
+  // deposit twice: a $100 deposit on a $1,100 quote would tell the customer
+  // they owe $400 when they owe $500, and call a $1,000 invoice "paid in
+  // full" while $100 was still outstanding. The legacy receipt used
+  // `total − paidAmount`, which excluded the deposit; this keeps that.
+  const depositPaidCents = (Array.isArray(after.payments) ? after.payments : [])
+    .filter((p: any) => p?.kind === 'deposit')
+    .reduce((acc: number, p: any) => acc + toCents(p?.amount), 0);
+  const paidAgainstInvoice = Math.max(0, paidAfterCents - depositPaidCents) / 100;
+  const balanceDue = round2(Math.max(0, total - paidAgainstInvoice));
 
   // Attribute the receipt to the payments this write actually added, falling
   // back to the newest one on the ledger when the ids are unchanged (the
@@ -233,7 +245,11 @@ export function evaluateDocumentPaymentReceipt(
   return {
     customerEmail,
     amountReceived: round2(deltaCents / 100),
-    isFullyPaid: after.stage === 'paid' || balanceDue <= EPSILON,
+    // Deliberately NOT `stage === 'paid' || ...`: recordDocumentPayment sets
+    // that stage from the same deposit-double-counting arithmetic corrected
+    // above, so trusting it would tell a customer with an outstanding
+    // deposit balance that they're square. The money decides.
+    isFullyPaid: balanceDue <= EPSILON,
     balanceDue,
     paymentMethod: documentPaymentMethodToLegacy(source?.method),
     receiptedPaidCents: paidAfterCents,

--- a/functions/src/paymentReceipt.helpers.ts
+++ b/functions/src/paymentReceipt.helpers.ts
@@ -126,6 +126,135 @@ export function evaluatePaymentReceipt(
   };
 }
 
+// ---------------------------------------------------------------------------
+// Customer payment receipt — unified `documents` shape
+// ---------------------------------------------------------------------------
+
+/**
+ * Stages an invoice-type Document can be in and still earn its customer a
+ * receipt. Deliberately the mirror image of the legacy `draft`/`cancelled`
+ * skip: an invoice the customer has never been sent (still `draft`, or one
+ * of the quote-side stages) must not produce an unsolicited receipt, and a
+ * cancelled one must not either. `stageToInvoiceStatus` collapses every
+ * excluded stage to legacy status 'draft' or 'cancelled', so the two shapes
+ * agree on which payments are receiptable.
+ */
+const RECEIPTABLE_DOCUMENT_STAGES = new Set(['invoice_sent', 'partially_paid', 'paid']);
+
+/** Dollars → whole cents. Cents keep the high-water mark float-noise free. */
+function toCents(amount: unknown): number {
+  return Math.round((Number(amount) || 0) * 100);
+}
+
+/**
+ * Map a unified `DocumentPayment.method` onto the legacy method vocabulary
+ * that `paymentMethodLabel` (and therefore the receipt email) speaks.
+ * 'other' has no label of its own, which correctly hides the row.
+ */
+export function documentPaymentMethodToLegacy(method?: unknown): string | undefined {
+  switch (method) {
+    case 'square': return 'card';
+    case 'bank': return 'bank_transfer';
+    case 'cash': return 'cash';
+    default: return undefined;
+  }
+}
+
+export interface DocumentPaymentReceiptEvaluation extends PaymentReceiptEvaluation {
+  /**
+   * `paidTotal` after this payment, in whole cents. Persisted back onto the
+   * document as `receiptSentPaidCents` once the receipt is away, so it
+   * becomes the high-water mark the next evaluation has to clear.
+   */
+  receiptedPaidCents: number;
+  /** ms epoch of the payment that triggered this receipt, for the date line. */
+  paidAtMs: number;
+  /** Invoice number as the unified doc spells it (`number`, not `invoiceNumber`). */
+  invoiceNumber?: string;
+}
+
+/**
+ * Decide whether a write to `users/{uid}/documents/{docId}` represents a
+ * customer payment that deserves a receipt email. The document analogue of
+ * `evaluatePaymentReceipt`, adapted to the unified shape: `paidTotal` instead
+ * of `paidAmount`, `stage` instead of `status`, `number` instead of
+ * `invoiceNumber`, and a `payments[]` ledger instead of a single payment.
+ *
+ * Single delivery rests on a monotonic high-water mark rather than a plain
+ * before→after delta. We only fire when `paidTotal` clears BOTH the previous
+ * value and `receiptSentPaidCents` (the paid total at the last receipt), so:
+ *   - a resync / no-op write sends nothing (no increase);
+ *   - the trigger's own write-back of the mark sends nothing (paidTotal
+ *     unchanged), which is what stops it looping on itself;
+ *   - an at-least-once redelivery of the same Firestore event sends nothing,
+ *     because the mark already sits at the post-payment total;
+ *   - the legacy→documents mirror re-deriving the same payments array sends
+ *     nothing, since the totals it projects are the ones already receipted.
+ * A genuine second part payment still clears the mark and gets its own
+ * receipt.
+ */
+export function evaluateDocumentPaymentReceipt(
+  before: Record<string, any>,
+  after: Record<string, any>,
+): DocumentPaymentReceiptEvaluation | null {
+  if (after.type !== 'invoice') return null;
+
+  const customerEmail = typeof after.customerEmail === 'string' ? after.customerEmail.trim() : '';
+  if (!customerEmail) return null;
+
+  // Judge "was this invoice ever sent?" on the BEFORE stage, matching the
+  // legacy helper — the paying write itself moves the stage to paid/partial.
+  if (!RECEIPTABLE_DOCUMENT_STAGES.has(String(before.stage))) return null;
+
+  const total = Number(after.total) || 0;
+  if (total <= 0) return null;
+
+  const paidBeforeCents = toCents(before.paidTotal);
+  const paidAfterCents = toCents(after.paidTotal);
+  const alreadyReceiptedCents = Number(after.receiptSentPaidCents) || 0;
+  const floorCents = Math.max(paidBeforeCents, alreadyReceiptedCents);
+  const deltaCents = paidAfterCents - floorCents;
+  if (deltaCents < 1) return null;
+
+  const paidAfter = paidAfterCents / 100;
+  const balanceDue = round2(Math.max(0, total - paidAfter));
+
+  // Attribute the receipt to the payments this write actually added, falling
+  // back to the newest one on the ledger when the ids are unchanged (the
+  // mirror rebuilds them with synthetic, stable ids — see
+  // shared/document/adapter.buildInvoicePayments).
+  const beforeIds = new Set(
+    (Array.isArray(before.payments) ? before.payments : []).map((p: any) => p?.id),
+  );
+  const afterPayments = Array.isArray(after.payments) ? after.payments : [];
+  const added = afterPayments.filter((p: any) => !beforeIds.has(p?.id));
+  const source = (added.length ? added : afterPayments).slice(-1)[0];
+
+  return {
+    customerEmail,
+    amountReceived: round2(deltaCents / 100),
+    isFullyPaid: after.stage === 'paid' || balanceDue <= EPSILON,
+    balanceDue,
+    paymentMethod: documentPaymentMethodToLegacy(source?.method),
+    receiptedPaidCents: paidAfterCents,
+    paidAtMs: Number(source?.paidAt) || Number(after.paidInFullAt) || Date.now(),
+    invoiceNumber: typeof after.number === 'string' ? after.number : undefined,
+  };
+}
+
+/**
+ * True when this document write is the moment an invoice became fully paid —
+ * the unified analogue of `onInvoiceStatusChanged`'s status → 'paid' edge,
+ * used to fire the tradie's `invoice_paid` push exactly once.
+ */
+export function shouldSendInvoicePaidPush(
+  before: Record<string, any>,
+  after: Record<string, any>,
+): boolean {
+  if (after.type !== 'invoice') return false;
+  return before.stage !== 'paid' && after.stage === 'paid';
+}
+
 /** Human label for the stored payment method; undefined hides the row. */
 export function paymentMethodLabel(method?: string): string | undefined {
   switch (method) {

--- a/functions/src/paymentReceipt.triggers.guard.test.ts
+++ b/functions/src/paymentReceipt.triggers.guard.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+/**
+ * Wiring guard for payment receipts. The delivery LOGIC is unit-tested in
+ * paymentReceipt.helpers.test.ts, but the "exactly one receipt per payment"
+ * guarantee also depends on how index.ts composes those helpers — and index.ts
+ * can't be imported in a unit test (it registers triggers and initialises
+ * firebase-admin on load). So we assert the composition structurally.
+ *
+ * These aren't style rules. Each one, if it regressed, would either email a
+ * real customer twice for one payment or go back to emailing them nothing:
+ *   - the documents trigger must exist, on the unified collection, or
+ *     document-only invoices (the default path since Phase 5) send nothing;
+ *   - it must be onUpdate — onWrite would fire receipts at every customer
+ *     whose invoice gets mirrored or backfilled into `documents`;
+ *   - both legacy triggers must defer to it when a mirror exists, or a
+ *     dual-written invoice fires both and the customer gets two receipts;
+ *   - the send must sit behind the transactional high-water claim.
+ */
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const indexSrc = readFileSync(join(HERE, 'index.ts'), 'utf8');
+
+/** The body of a top-level `export const <name> = ...` trigger declaration. */
+function triggerBody(name: string): string {
+  const start = indexSrc.indexOf(`export const ${name} = functions.firestore`);
+  expect(start, `${name} should be declared in index.ts`).toBeGreaterThan(-1);
+  const next = indexSrc.indexOf('\nexport const ', start + 1);
+  return indexSrc.slice(start, next === -1 ? undefined : next);
+}
+
+describe('onDocumentPaymentReceived — receipts reach document-collection invoices', () => {
+  const body = triggerBody('onDocumentPaymentReceived');
+
+  it('triggers on the unified documents collection', () => {
+    expect(body).toContain("functions.firestore\n  .document('users/{userId}/documents/{docId}')");
+  });
+
+  it('is onUpdate, not onWrite — a doc arriving already paid is history, not a payment', () => {
+    expect(body).toContain('.onUpdate(');
+    expect(body).not.toContain('.onWrite(');
+  });
+
+  it('evaluates with the document-shape helper and sends through the shared deliverer', () => {
+    expect(body).toContain('evaluateDocumentPaymentReceipt(before, after)');
+    expect(body).toContain('deliverPaymentReceipt(');
+  });
+
+  it('claims the high-water mark in a transaction before sending', () => {
+    expect(body).toContain('db.runTransaction(');
+    expect(body).toContain('claimsReceipt(');
+    expect(body).toContain('receiptSentPaidCents: receipt.receiptedPaidCents');
+    // The send is gated on the claim — never unconditional.
+    expect(body).toContain('if (claimed)');
+    expect(body.indexOf('claimsReceipt(')).toBeLessThan(body.indexOf('deliverPaymentReceipt('));
+  });
+
+  it('pushes the tradie on the stage → paid edge', () => {
+    expect(body).toContain('shouldSendInvoicePaidPush(before, after)');
+    expect(body).toContain("'invoice_paid'");
+  });
+});
+
+describe.each(['onInvoicePaymentReceived', 'onInvoiceStatusChanged'])(
+  '%s — the legacy trigger defers to the documents trigger',
+  (name) => {
+    const body = triggerBody(name);
+
+    it('still watches the legacy invoices collection', () => {
+      expect(body).toContain("functions.firestore\n  .document('users/{userId}/invoices/{invoiceId}')");
+    });
+
+    it('bails out when the invoice has a unified mirror document', () => {
+      expect(body).toContain('if (await legacyInvoiceHasMirror(userId, after, invoiceId)) return;');
+    });
+
+    it('checks for the mirror BEFORE sending anything', () => {
+      const guard = body.indexOf('legacyInvoiceHasMirror');
+      const send = Math.min(
+        ...[body.indexOf('deliverPaymentReceipt('), body.indexOf('sendAussiePush(')]
+          .filter((i) => i > -1),
+      );
+      expect(guard).toBeGreaterThan(-1);
+      expect(guard).toBeLessThan(send);
+    });
+  },
+);
+
+describe('legacyInvoiceHasMirror — resolves the mirror id the mirror itself uses', () => {
+  it('reuses documentMirror.mirrorIdForInvoice rather than re-deriving the rule', () => {
+    expect(indexSrc).toContain("import { mirrorIdForInvoice } from './documentMirror'");
+    const start = indexSrc.indexOf('async function legacyInvoiceHasMirror');
+    const body = indexSrc.slice(start, indexSrc.indexOf('\n}', start));
+    expect(start).toBeGreaterThan(-1);
+    expect(body).toContain('mirrorIdForInvoice(invoice, invoiceId)');
+    expect(body).toContain('users/${userId}/documents/${mirrorId}');
+  });
+});

--- a/functions/src/paymentReceipt.triggers.guard.test.ts
+++ b/functions/src/paymentReceipt.triggers.guard.test.ts
@@ -73,8 +73,10 @@ describe.each(['onInvoicePaymentReceived', 'onInvoiceStatusChanged'])(
       expect(body).toContain("functions.firestore\n  .document('users/{userId}/invoices/{invoiceId}')");
     });
 
-    it('bails out when the invoice has a unified mirror document', () => {
-      expect(body).toContain('if (await legacyInvoiceHasMirror(userId, after, invoiceId)) return;');
+    it('bails out when the invoice has a mirror capable of doing the job itself', () => {
+      expect(body).toMatch(
+        /if \(await legacyInvoiceHasMirror\(userId, after, invoiceId, '(receipt|push)'\)\) return;/,
+      );
     });
 
     it('checks for the mirror BEFORE sending anything', () => {
@@ -97,5 +99,29 @@ describe('legacyInvoiceHasMirror — resolves the mirror id the mirror itself us
     expect(start).toBeGreaterThan(-1);
     expect(body).toContain('mirrorIdForInvoice(invoice, invoiceId)');
     expect(body).toContain('users/${userId}/documents/${mirrorId}');
+  });
+
+  it('requires a receipt-CAPABLE mirror, not bare existence', () => {
+    // applyPaymentToDocument can create a stub document carrying no `type`
+    // and no `customerEmail`; deferring to it silences the receipt forever.
+    const start = indexSrc.indexOf('async function legacyInvoiceHasMirror');
+    const body = indexSrc.slice(start, indexSrc.indexOf('\n}', start));
+    expect(body).toContain("mirror?.type !== 'invoice'");
+    expect(body).toContain('customerEmail');
+    expect(body).not.toMatch(/return snap\.exists;/);
+  });
+});
+
+describe('receipt claim is reversible — a failed send must not wedge the mark', () => {
+  const body = triggerBody('onDocumentPaymentReceived');
+
+  it('rolls the mark back when delivery throws, under compare-and-set', () => {
+    expect(body).toContain('previousMark');
+    expect(body).toContain('receiptSentPaidCents: previousMark');
+    expect(body).toContain('=== receipt.receiptedPaidCents');
+  });
+
+  it('logs a failed receipt at error level so it is alertable', () => {
+    expect(body).toContain("functions.logger.error('payment_receipt_email_failed'");
   });
 });

--- a/src/services/documentService.ts
+++ b/src/services/documentService.ts
@@ -222,8 +222,14 @@ class DocumentService {
       logLabourUnitCanary(rawDocument);
     }
     const docRef = doc(db, 'users', userId, 'documents', document.id);
+    // `receiptSentPaidCents` is the server's payment-receipt idempotency mark
+    // (functions/src/index.ts onDocumentPaymentReceived). We round-trip every
+    // field we read, so writing it back from a copy loaded before the last
+    // payment would rewind the mark and re-send the customer a receipt they
+    // already have. The server owns it; never echo it.
+    const { receiptSentPaidCents: _serverOwned, ...clientOwned } = document as any;
     const payload = stripUndefined({
-      ...document,
+      ...clientOwned,
       updatedAt: document.updatedAt ?? Date.now(),
       syncedAt: new Date().toISOString(),
     });

--- a/src/store/useStore.ts
+++ b/src/store/useStore.ts
@@ -1469,8 +1469,12 @@ export const useStore = create<AppState>((set, get) => ({
     }
 
     // Phase-5: prefer the unified convertDocumentToInvoice path when a
-    // matching document exists (server canonicalises via setDocumentStage,
-    // mirror trigger projects to the legacy invoices collection).
+    // matching document exists (server canonicalises via setDocumentStage).
+    // Note: this mints a document-only invoice — the mirror triggers run
+    // legacy → documents, never the other way, so there is no legacy
+    // invoices row until a client-side saveDocument writes one. Anything
+    // that needs to react to these invoices (payment receipts, for one)
+    // has to trigger on users/{uid}/documents.
     //
     // Only fire `quote_started` once we know we're actually minting a new
     // invoice (idempotency below short-circuits if this quote has already


### PR DESCRIPTION
## The bug

A tradie records a payment on an invoice. The app shows "Paid". The customer receives nothing, and the tradie gets no `invoice_paid` push.

## Root cause

`onInvoicePaymentReceived` and `onInvoiceStatusChanged` are Firestore triggers on `users/{userId}/invoices/{invoiceId}` — the **legacy** collection. `sendPaymentReceiptEmail` had exactly one caller: that legacy trigger.

But since Phase 5, `createInvoiceFromQuote` prefers `convertDocumentToInvoice`, which writes **only** `users/{uid}/documents/{docId}` (the doc keeps its own id and gets `legacyInvoiceId: docId` pointing at a row that does not exist). `functions/src/documentMirror.ts` mirrors legacy → documents one way; there is no documents → legacy projection. `recordDocumentPayment` mirrors into the legacy row only when one already exists — its own comment notes "Absent legacy row is the normal case now".

So on the default path the payment lands somewhere no trigger was watching.

Two things I found while verifying that are worth recording, because they shape the fix:

- **The client does write a legacy row.** `documentService.saveDocument` (`src/services/documentService.ts:211`) writes `documents/{id}` *and* `invoices/{id}` with `merge: true`. That row is often created for the first time by the paying write itself — and both legacy triggers are `.onUpdate`, which does not fire on create. Where the row does already exist, `documentRecordToInvoiceRecord` sets `paidAmount: paid?.amount` from `payments.find(...)` — the **first** payment, not the cumulative total — so a second part payment never moves `paidAmount` and never earns a receipt either. Both sub-cases present identically to the tradie: silence.
- Consequently a naive documents trigger really would double-send on a large share of invoices, not a rare few.

Also fixed the stale comment at `src/store/useStore.ts:1473`, which claimed the mirror trigger projects to the legacy invoices collection. It does not.

## The fix

New `onDocumentPaymentReceived` trigger on `users/{userId}/documents/{docId}`, reusing `evaluatePaymentReceipt`'s sibling helper, `sendPaymentReceiptEmail` and `sendAussiePush`. The receipt-sending body that was inline in the legacy trigger is extracted to `deliverPaymentReceipt()` and shared, so both shapes produce a byte-identical customer email.

## Single delivery — how, and why this way

Two independent layers, because the failure they prevent (a real customer billed two receipts for one payment) is worse than the bug being fixed.

**1. Ownership: the legacy triggers defer to the documents trigger.**

Both legacy triggers now bail via `legacyInvoiceHasMirror()` when the invoice has a mirror document that could actually send the notification itself, resolved with `documentMirror.mirrorIdForInvoice` — exported rather than re-derived, so the two rules cannot drift. Bare existence is *not* sufficient; see audit finding 1 below.

I picked ownership-by-mirror-existence over a shared idempotency key because **there is no key both shapes can compute for the same payment**. The legacy row carries no payment id, and the obvious money-derived keys don't line up either: with a deposit credit, legacy `paidAmount` = P while document `paidTotal` = D + P for the same payment, so a `(lineage, cumulative-paid)` key would mismatch and both triggers would fire. Delta-based keys collide on repeated equal part payments. Existence of the mirror is the one fact both sides can agree on, and it is the same fact `recordDocumentPayment` already keys its own mirroring on.

Deferral is safe because every legacy write cascades into `documents` via `onInvoiceWritten`, so the documents trigger always gets its turn. The legacy triggers stay live as the fallback for any legacy invoice whose mirror is missing.

**2. Idempotency: a monotonic high-water mark on the document.**

`evaluateDocumentPaymentReceipt` fires only when `paidTotal` clears **both** the previous value and `receiptSentPaidCents` (the paid total at the last receipt), claimed in a Firestore transaction via `claimsReceipt()` *before* the email goes out. This handles:

- resync / no-op writes — no increase, nothing sent;
- the trigger's own write-back of the mark — `paidTotal` unchanged, so it cannot loop;
- **at-least-once redelivery** of the same Firestore event — the mark already sits at the post-payment total (the existing legacy trigger has this hole; the new code does not);
- the mirror re-deriving the same payments array over the top.

Deliberately keyed on money rather than on `DocumentPayment.id` set-difference. Payment ids are the natural key for the client's own writes, but the legacy→documents mirror rebuilds the ledger with **stable synthetic ids** (`manual-{invoiceId}` — see `shared/document/adapter.buildInvoicePayments`), so a second part payment on a mirrored invoice reuses the same id and pure id-diffing would silently drop its receipt. There's a named test for that. Payment ids are still used to attribute the payment *method* and date to the right ledger entry.

**`.onUpdate`, not `.onWrite`, on purpose.** A document arriving already-paid is a mirror or backfill projection of history, not a payment event — `onWrite` would spray receipts at customers who paid months ago. It also means the mirror's *creation* can never produce a second receipt. Note that it does not, as I first claimed, fully close the create-race in the other direction — see "Create race" under the audit section.

## Square pay link and Tap to Pay

Both index into `squarePaymentOrders/{orderId}` keyed by the **legacy** `invoiceId` (`index.ts:13792` for hosted links, `index.ts:14743` for Tap to Pay), and the webhook handler returns early at `index.ts:14430` if `users/{userId}/invoices/{invoiceId}` doesn't exist. So they only ever reconcile legacy-backed invoices, and for those the sequence is:

- legacy `invoiceRef.set(...)` → legacy trigger evaluates, sees the mirror, defers;
- `onInvoiceWritten` projects into `documents`, and `applyPaymentToDocument` writes the same payment with id `square-{paymentId}` — whichever lands first sends the one receipt, and the second is a no-op (either no `paidTotal` increase, or `applyPaymentToDocument`'s own `alreadyOnLedger` guard).

## Paths I could not verify

- **Square on a document-only invoice.** `createSquarePaymentLinkInternal` returns `null` when the legacy row is absent (`index.ts:13707`), and the webhook bails at `index.ts:14430`. As far as I can tell a Square payment cannot currently reconcile against a document-only invoice at all — a pre-existing gap, untouched here, and not something this PR can fix without changing the order index. Worth a separate ticket; I did not test it against a live Square sandbox.
- **`documentRecordToInvoiceRecord` writes non-cumulative `paidAmount`.** This also makes `invoiceLinkAmountDue` under-charge a pay link on a document invoice with more than one part payment. Adjacent bug, deliberately out of scope.
- Residual (narrow) miss: a legacy invoice whose mirror exists but whose payment projection is skipped by `writeMirror`'s `newer-on-disk` guard would get no receipt. I could not construct a realistic write ordering that triggers it — client and mirror both write the same `updatedAt` — but it is not provably impossible.
- Out-of-order delivery of two payments seconds apart: if the event for payment B is processed before the event for payment A, B's receipt claims the mark and A's is then dropped. The customer gets one receipt instead of two, showing the correct final balance. A miss, never a duplicate — consistent with the ordering of harms above.
- Client-side changes (`src/store/useStore.ts` comment, and stripping `receiptSentPaidCents` in `src/services/documentService.ts`) were **not typechecked** — there is no root `node_modules` in this worktree. Both are small and local, but that verification gap is real.
- Not deployed, and not tested against the emulator. Verified by unit tests, typecheck, and static tracing only.

## Tests

`functions/src/paymentReceipt.helpers.test.ts` (+37 cases, following the existing patterns) and a new `functions/src/paymentReceipt.triggers.guard.test.ts` wiring guard (15 cases) — the delivery logic is pure and unit-tested, but `index.ts` can't be imported in a unit test, so the trigger *composition* is asserted structurally (documents trigger exists on the right collection, is `onUpdate`, sends only behind the claim; both legacy triggers check the mirror before sending). All fixtures are synthetic.

Named cases the brief asked for:

- `REGRESSION: a payment on a document-only invoice (no legacy row) earns a receipt`
- `DOUBLE-SEND: an invoice with BOTH a document and a legacy row sends exactly ONE receipt`
- `proves the deferral is load-bearing: without it the same payment sends TWO receipts`
- `NO-OP: a resync write that does not increase paidTotal sends nothing`
- `REDELIVERY: an at-least-once replay of the paying event does not re-send`
- `a part payment reports the balance still owing and is not "paid in full"` / `the final payment closing the balance flags paid in full and charges only the delta`
- `still fires when the mirror rebuilds payments with its own synthetic ids`
- plus stage gating, quote-vs-invoice, missing email, zero total, lowered `paidTotal`, method mapping, and a three-part-payment sequence asserting `[300, 300, 400]`.

**Mutation-checked**: stubbing `evaluateDocumentPaymentReceipt` to return `null` (i.e. pre-fix behaviour) fails 9 tests including both the regression and the double-send cases, so they are load-bearing rather than tautological.

```
$ cd functions && npx tsc --noEmit
TSC EXIT: 0

$ npm test
 Test Files  51 passed (51)
      Tests  752 passed (752)
```

## Adversarial audit — findings and what changed

An adversarial review pass was run over this diff specifically hunting double-send orderings and mirror races. It found four real defects, since fixed in `74dada0`:

**1. Blocker — deferring on bare existence silenced receipts permanently.** `legacyInvoiceHasMirror` returned `snap.exists`. But `applyPaymentToDocument` → `setDocumentStage` does a `merge` write of only `{stage, payments, paidTotal, balanceDue, updatedAt}`, and `loadDocument` falls back to the legacy row rather than creating a document — so when no mirror existed, that write **creates a stub carrying no `type` and no `customerEmail`**. `onDocumentPaymentReceived` rejects it, the legacy trigger deferred to it, and nobody sent — permanently, because the stub then blocked every later payment on that invoice too. Verified in `documentHandlers.ts:279-292` and `loadDocument`. Now requires a mirror that can actually do the job, split by what each trigger needs: the push deferral checks only `type`, because requiring `customerEmail` there would double-push an invoice that has none.

**2. Money bug, customer-facing — the receipt understated the balance.** `total` on an invoice converted from a quote is already net of the deposit credit, while the deposit stays on `payments`/`paidTotal` (the mirror even re-adds it as `deposit-credit-*`). `total − paidTotal` therefore counted the deposit twice. On a $1,100 quote with a $100 deposit, a $500 payment told the customer they owed **$400 when they owed $500**, and $900 more would have said **"This invoice is now paid in full"** with $100 outstanding. The legacy receipt used `total − paidAmount` and was correct, so this was a regression in what customers are told. Balance now excludes deposit-kind payments, and `isFullyPaid` follows the money rather than `stage === 'paid'` — that flag is set from the same faulty arithmetic in `recordDocumentPayment`. Three named tests added.

**3. A failed send wedged the mark shut.** Claim-before-send is what makes redelivery safe, but the claim was committed and never released, so a transient Brevo 5xx became a permanently missing receipt — the exact failure this PR exists to fix. The claim now rolls back under compare-and-set (only reverting *our* claim, so a later payment that moved the mark is untouched), and the failure logs at `error` rather than `warn`.

**4. The idempotency mark was client-writable and round-tripped.** `documentService.saveDocument` echoes every field it read, so a client holding a copy from between two payments would rewind `receiptSentPaidCents`. Now stripped on the client write; the server owns it.

### Audit findings NOT fixed here

**Create race (real, unresolved).** `onInvoicePaymentReceived` and `onInvoiceWritten` fire from the same legacy write with no ordering guarantee. If the mirror's *create* lands first, the legacy trigger defers and the documents trigger doesn't fire (it's `onUpdate`) — **zero receipts**, where `main` sent one. This needs a legacy invoice with no mirror at payment time, which post-backfill means an invoice created and paid near-simultaneously, or a user missed by the backfill.

I did not adopt the reviewer's suggested fix — having both triggers claim the same mark keyed on `paidAmount*100` — because it reintroduces the double-send it's meant to prevent: legacy `paidAmount` = P while document `paidTotal` = D + P for the same payment under a deposit credit, so the two triggers would compute different keys and both fire. The sound version is to run the *document-shape* evaluation against the live mirror from both triggers, which is a larger refactor than I wanted to land unreviewed on top of an already-substantial diff. Flagging it explicitly rather than papering over it.

**Stage gating can over-send.** `deriveStage` returns `partially_paid` for a legacy invoice whose status is `draft` when `paidTotal > 0`, so a never-sent invoice carrying a deposit could now get a receipt where legacy skipped it. The fix is to gate on `sentAt` as well as stage, which I did not do blind — if `sentAt` isn't stamped on every send path it would re-break the primary bug, and I ran out of room to verify that.

**Undocumented load-bearing behaviour.** The reviewer notes that `recordDocumentPayment` deliberately not bumping `updatedAt` is what stops the legacy row double-counting via `preserveSnapshotIdentity` — and that bumping it would inflate `paidAmount` and push a second receipt. I did not independently verify this and have not added the comment it deserves; worth a follow-up.

## Trade-offs

- Sending a receipt now costs one extra document write (the mark). It re-enters `onDocumentPaymentReceived` once as a no-op and touches the other `documents` triggers, whose own guards reject it (`onDocumentAcceptedSyncXero` needs a transition into `quote_accepted`; the stage is unchanged).
- Where a legacy row exists but its trigger doesn't fire, we now prefer a missed receipt over a duplicate. That's the explicit ordering of harms for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
