### PR TITLE
One row for every status change, plus three layout squeezes

### DIFF
--- a/src/components/JobActionsSheet.tsx
+++ b/src/components/JobActionsSheet.tsx
@@ -22,7 +22,7 @@ import { BottomSheet } from './BottomSheet';
 import { selectionTap, lightTap } from '../utils/haptics';
 import { legalStageTargets, shouldOfferSchedule } from '../utils/jobStageTargets';
 import { canRevertToQuote } from '../utils/revertToQuote';
-import { documentHasOutrunJobStage, isLiveInvoice } from '../utils/jobTimeline';
+import { isLiveInvoice, jobStatusLabel } from '../utils/jobTimeline';
 import { jobStageMetaFor } from './JobStageSheet';
 import { StageOptionRow } from './StageOptionRow';
 
@@ -344,13 +344,10 @@ export function JobActionsSheet({
         <View style={styles.rowBody}>
           <Text style={styles.rowLabel}>Change status</Text>
           <Text style={styles.rowSub}>
-            {/* The Job stage lags the document after a convert — saying
-                "Currently Quoted" under an invoice is the same lie the
-                card used to tell. */}
-            Currently{' '}
-            {documentHasOutrunJobStage(job, ctx.primaryDoc)
-              ? 'Invoiced'
-              : stageMeta[job.stage]?.chipLabel ?? 'Inquiry'}
+            {/* Same words the card prints for this job — see jobStatusLabel.
+                Naming the raw Job stage here said "Currently Quoted" under a
+                freshly converted invoice. */}
+            Currently {jobStatusLabel(job, ctx.primaryDoc)}
           </Text>
         </View>
         <MaterialCommunityIcons

--- a/src/components/JobCard.tsx
+++ b/src/components/JobCard.tsx
@@ -322,7 +322,7 @@ export const JobCard = React.memo(function JobCard({
                   style={({ pressed }) => [styles.customerPress, pressed && { opacity: 0.7 }]}
                 >
                   <Text
-                    style={[styles.customer, styles.customerInPress]}
+                    style={[styles.customerText, styles.customerInPress]}
                     numberOfLines={1}
                   >
                     {job.customerName || 'Unknown customer'}
@@ -330,7 +330,7 @@ export const JobCard = React.memo(function JobCard({
                   <Text style={styles.customerCount}>· {customerJobCount} jobs</Text>
                 </Pressable>
               ) : (
-                <Text style={styles.customer} numberOfLines={1}>
+                <Text style={[styles.customerText, styles.customer]} numberOfLines={1}>
                   {job.customerName || 'Unknown customer'}
                 </Text>
               )}
@@ -696,11 +696,17 @@ const useStyles = makeStyles((t) => ({
     fontWeight: '500',
     color: t.colors.textSecondary,
   },
-  customer: {
-    flex: 1,
+  // Type only. The two layout cases below each add their own flex, because
+  // OVERRIDING a flex shorthand is what broke the name on web — see
+  // customerInPress.
+  customerText: {
     fontSize: 17,
     fontFamily: 'Archivo-Bold',
     color: t.colors.text,
+  },
+  // One-off customer: the name owns the row up to the price.
+  customer: {
+    flex: 1,
   },
   // flexShrink, NOT flex:1. With flex:1 the row stretched to the price and the
   // name inside it stretched too, which stranded "· 4 jobs" in the middle of
@@ -713,10 +719,15 @@ const useStyles = makeStyles((t) => ({
     alignItems: 'baseline',
     gap: 4,
   },
-  // Cancels styles.customer's flex:1 for the in-pressable case, so the name
-  // truncates rather than pushing the count away.
+  // Repeat customer: the name hugs its text so "· 4 jobs" sits beside it,
+  // and truncates rather than pushing the count away.
+  //
+  // flexShrink alone, NEVER `flex: 0`. React Native reads `flex: 0` as
+  // "basis auto, don't grow" — react-native-web compiles it to
+  // `flex: 0 1 0%`, a ZERO basis that never grows, so the name rendered at
+  // 0px wide and repeat customers on the web build showed a card with no
+  // name on it (the count, flexShrink:0, stayed put and gave it away).
   customerInPress: {
-    flex: 0,
     flexShrink: 1,
   },
   customerCount: {

--- a/src/components/JobScopeCard.tsx
+++ b/src/components/JobScopeCard.tsx
@@ -236,7 +236,9 @@ export function JobScopeCard({
             />
           </View>
           <View style={styles.headerTextBlock}>
-            <Text style={styles.typeLabel}>{typeLabel}</Text>
+            {/* numberOfLines so a squeeze truncates rather than stacking
+                "INVOICE" one letter per line. */}
+            <Text style={styles.typeLabel} numberOfLines={1}>{typeLabel}</Text>
             <Text style={styles.docNumber} numberOfLines={1}>
               {doc.number || 'Unnumbered'}
             </Text>
@@ -614,19 +616,33 @@ const useStyles = makeStyles((t) => ({
                    // standard touch-target size
     borderBottomWidth: 1,
     borderBottomColor: t.colors.border,
+    // A full payment chip ("Part paid $1,303.13 / $2,606.26") is wider than
+    // what's left of a phone-width row, and the chip can't shrink — so
+    // something had to give. It used to be headerLeft, crushed to a single
+    // character so "INVOICE" ran down the card one letter per line. Now the
+    // chip drops to its own line instead. Nothing wraps where it fits: a
+    // quote's chip is short, and tablets/web have the width.
+    flexWrap: 'wrap',
   },
   headerLeft: {
     flexDirection: 'row',
     alignItems: 'center',
     gap: 10,
     flex: 1,
-    minWidth: 0,
+    // The floor that makes the wrap fire. With minWidth 0 flexbox is happy
+    // to shrink this to nothing and never wrap at all.
+    minWidth: 140,
   },
+  // Shrinkable. With flexShrink:0 a wide payment chip ("Part paid
+  // $1,303.13 / $2,606.26") took the whole row and squeezed headerLeft —
+  // which has minWidth:0 — down to about one character, so "INVOICE"
+  // rendered as a vertical column of letters down the card.
   headerRight: {
     flexDirection: 'row',
     alignItems: 'center',
     gap: 6,
-    flexShrink: 0,
+    flexShrink: 1,
+    minWidth: 0,
   },
   typeBadge: {
     width: 32,

--- a/src/components/JobStageSheet.tsx
+++ b/src/components/JobStageSheet.tsx
@@ -12,7 +12,7 @@ import { Animated } from 'react-native';
 
 import type { Job, JobStage } from '../../shared/job/types';
 import { legalStageTargets, shouldOfferSchedule } from '../utils/jobStageTargets';
-import { documentHasOutrunJobStage, isLiveInvoice } from '../utils/jobTimeline';
+import { isLiveInvoice, jobStatusLabel, STAGE_CHIP_LABELS } from '../utils/jobTimeline';
 import type { Document } from '../types/document';
 import type { Tokens } from '../theme';
 import { useThemeColors } from '../theme';
@@ -70,7 +70,7 @@ export function stageMetaFor(stage: JobStage | undefined, themeColors: Tokens): 
 
 export const jobStageMetaFor = (themeColors: Tokens): Record<JobStage, StageMeta> => ({
   inquiry: {
-    chipLabel: 'Inquiry',
+    chipLabel: STAGE_CHIP_LABELS.inquiry,
     actionLabel: 'Mark as Inquiry',
     icon: 'help-circle-outline',
     // Neutral for the same reason 'draft' is: nothing has happened on this job
@@ -80,56 +80,56 @@ export const jobStageMetaFor = (themeColors: Tokens): Record<JobStage, StageMeta
     bgColor: themeColors.neutralSubtle,
   },
   quoted: {
-    chipLabel: 'Quoted',
+    chipLabel: STAGE_CHIP_LABELS.quoted,
     actionLabel: 'Mark as Quoted',
     icon: 'send-outline',
     color: themeColors.warning,
     bgColor: themeColors.warningSubtle,
   },
   accepted: {
-    chipLabel: 'Accepted',
+    chipLabel: STAGE_CHIP_LABELS.accepted,
     actionLabel: 'Mark as Accepted',
     icon: 'check-circle-outline',
     color: themeColors.money,
     bgColor: themeColors.moneySubtle,
   },
   scheduled: {
-    chipLabel: 'Scheduled',
+    chipLabel: STAGE_CHIP_LABELS.scheduled,
     actionLabel: 'Schedule…',
     icon: 'calendar-clock-outline',
     color: themeColors.info,
     bgColor: themeColors.infoSubtle,
   },
   in_progress: {
-    chipLabel: 'In Progress',
+    chipLabel: STAGE_CHIP_LABELS.in_progress,
     actionLabel: 'Mark as In Progress',
     icon: 'hammer-wrench',
     color: themeColors.warning,
     bgColor: themeColors.warningSubtle,
   },
   completed: {
-    chipLabel: 'Completed',
+    chipLabel: STAGE_CHIP_LABELS.completed,
     actionLabel: 'Mark as Completed',
     icon: 'flag-checkered',
     color: themeColors.money,
     bgColor: themeColors.moneySubtle,
   },
   paid: {
-    chipLabel: 'Paid',
+    chipLabel: STAGE_CHIP_LABELS.paid,
     actionLabel: 'Mark as Paid',
     icon: 'cash-check',
     color: themeColors.money,
     bgColor: themeColors.moneySubtle,
   },
   closed: {
-    chipLabel: 'Closed',
+    chipLabel: STAGE_CHIP_LABELS.closed,
     actionLabel: 'Archive',
     icon: 'archive-outline',
     color: themeColors.textDisabled,
     bgColor: themeColors.surfacePressed,
   },
   cancelled: {
-    chipLabel: 'Cancelled',
+    chipLabel: STAGE_CHIP_LABELS.cancelled,
     actionLabel: 'Cancel Job',
     icon: 'close-octagon-outline',
     color: themeColors.error,
@@ -175,11 +175,8 @@ export function JobStageSheet({
     onSchedule?.();
   };
 
-  // Same wording as the kebab's "Currently …" line, invoice correction and
-  // all — a job still sitting at `quoted` under an invoice isn't "Quoted".
-  const currentLabel = documentHasOutrunJobStage(job, primaryDoc)
-    ? 'Invoiced'
-    : JOB_STAGE_META[job.stage]?.chipLabel ?? 'Inquiry';
+  // Echoes the pill the tradie just tapped — see jobStatusLabel.
+  const currentLabel = jobStatusLabel(job, primaryDoc);
 
   // Schedule first when offered, then the legal stages — the order the
   // kebab's submenu lists them in.

--- a/src/components/StageSheet.tsx
+++ b/src/components/StageSheet.tsx
@@ -160,7 +160,16 @@ export function StageSheet({
               <StageOptionRow
                 icon={meta.icon}
                 color={meta.color}
-                label={meta.actionLabel}
+                // "Cancel" alone was fine as a chunky row with a red icon
+                // circle; as a plain row at the bottom of a sheet it reads
+                // as "dismiss this sheet", which is the opposite of what it
+                // does. Name what gets cancelled — the job sheet's
+                // equivalent already says "Cancel Job".
+                label={
+                  target === 'cancelled'
+                    ? `Cancel ${doc.type === 'invoice' ? 'Invoice' : 'Quote'}`
+                    : meta.actionLabel
+                }
                 onPress={() => handleSelect(target)}
               />
             </Animated.View>

--- a/src/components/jobCardRepeatCustomer.test.tsx
+++ b/src/components/jobCardRepeatCustomer.test.tsx
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+/**
+ * Regression test for the web-only vanishing customer name.
+ *
+ * A repeat customer's name got `flex: 0` to cancel the one-off case's
+ * `flex: 1`. React Native reads that as "basis auto, don't grow";
+ * react-native-web compiles it to `flex: 0 1 0%` — a ZERO basis that never
+ * grows. So on the web build every card for a customer with 2+ jobs
+ * rendered the name at 0px wide: the card showed "· 3 jobs" and no name.
+ * Native was fine, which is why it survived.
+ *
+ * These tests render through react-native-web (the same mapping the Expo
+ * web build uses) and assert against the CSS actually applied.
+ */
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+
+vi.mock('@expo/vector-icons/MaterialCommunityIcons', () => ({ default: () => null }));
+vi.mock('react-native-paper', async () => {
+  const { Text, View } = await import('react-native');
+  return {
+    MD3DarkTheme: { colors: {} },
+    Text,
+    Card: Object.assign(
+      ({ children, ...props }: { children?: React.ReactNode }) => <View {...props}>{children}</View>,
+      { Content: ({ children }: { children?: React.ReactNode }) => <View>{children}</View> },
+    ),
+  };
+});
+vi.mock('./ShimmerOverlay', () => ({ ShimmerOverlay: () => null }));
+vi.mock('./BottomSheet', () => ({ BottomSheet: () => null, useStaggeredEntrance: () => [] }));
+vi.mock('../utils/haptics', () => ({ selectionTap: vi.fn() }));
+vi.mock('../utils/openJobPreview', () => ({ openJobPreview: vi.fn() }));
+vi.mock('../hooks/useIsAppActive', () => ({ useIsAppActive: () => true }));
+vi.mock('@react-navigation/native', () => ({ useNavigation: () => ({ navigate: vi.fn() }) }));
+vi.mock('../store/useStore', () => ({
+  useStore: (selector: (s: { documents: never[] }) => unknown) => selector({ documents: [] }),
+}));
+
+import { JobCard } from './JobCard';
+import type { Job } from '../../shared/job/types';
+
+const job = {
+  id: 'job-1',
+  stage: 'quoted',
+  name: 'Lounge Room Paint',
+  customerName: 'Jennifer Lynn',
+  createdAt: 1,
+  updatedAt: 1,
+} as unknown as Job;
+
+/** The leaf element rendering exactly this text. */
+function leafWithText(container: HTMLElement, text: string): HTMLElement {
+  const el = Array.from(container.querySelectorAll('*')).find(
+    (n) => n.textContent === text && n.children.length === 0,
+  );
+  if (!el) throw new Error(`no element rendering "${text}"`);
+  return el as HTMLElement;
+}
+
+/**
+ * react-native-web emits atomic CSS classes rather than inline styles, so
+ * the declarations have to be read back out of the stylesheet.
+ */
+function cssFor(el: HTMLElement): string {
+  const classes = el.className.split(/\s+/).filter(Boolean);
+  const out: string[] = [];
+  for (const sheet of Array.from(document.styleSheets)) {
+    for (const rule of Array.from(sheet.cssRules) as CSSStyleRule[]) {
+      const sel = rule.selectorText || '';
+      if (classes.some((c) => sel.includes(`.${c}`))) out.push(rule.cssText);
+    }
+  }
+  return out.join('\n');
+}
+
+describe('JobCard customer name on web', () => {
+  it('gives a repeat customer’s name a real width', () => {
+    const { container } = render(
+      <JobCard
+        job={job}
+        onPress={() => {}}
+        customerJobCount={3}
+        onCustomerPress={() => {}}
+      />,
+    );
+    const name = leafWithText(container, 'Jennifer Lynn');
+    const css = cssFor(name);
+
+    // The bug, exactly: a zero flex-basis that can never grow back.
+    expect(css).not.toMatch(/flex:\s*0\s+1\s+0%/);
+    expect(css).not.toMatch(/flex-basis:\s*0%/);
+    // It still has to give way to "· 3 jobs" rather than shove it off.
+    expect(css).toMatch(/flex-shrink:\s*1/);
+    // And the count is still there beside it.
+    expect(leafWithText(container, '· 3 jobs')).toBeTruthy();
+  });
+
+  it('still lets a one-off customer’s name own the row', () => {
+    const { container } = render(<JobCard job={job} onPress={() => {}} />);
+    // flex:1 → `flex: 1 1 0%`: grows into the space up to the price.
+    expect(cssFor(leafWithText(container, 'Jennifer Lynn'))).toMatch(
+      /flex:\s*1\s+1\s+0%/,
+    );
+  });
+});

--- a/src/components/statusRowParity.test.tsx
+++ b/src/components/statusRowParity.test.tsx
@@ -168,6 +168,26 @@ describe('status change UI parity', () => {
     expect(q.getByText('Mark as Accepted')).toBeTruthy();
   });
 
+  it('names what the cancel row cancels', () => {
+    // Bare "Cancel" at the foot of a sheet reads as "dismiss", not "cancel
+    // the quote" — the chunky red icon circle used to carry that meaning.
+    const quote = render(
+      <StageSheet visible onDismiss={() => {}} doc={doc} onSelect={() => {}} />,
+    );
+    expect(within(quote.container).getByText('Cancel Quote')).toBeTruthy();
+    expect(within(quote.container).queryByText('Cancel')).toBeNull();
+
+    const invoice = render(
+      <StageSheet
+        visible
+        onDismiss={() => {}}
+        doc={{ ...doc, type: 'invoice', stage: 'invoice_sent' } as unknown as Document}
+        onSelect={() => {}}
+      />,
+    );
+    expect(within(invoice.container).getByText('Cancel Invoice')).toBeTruthy();
+  });
+
   it('still fires the stage the tradie picked', () => {
     const onSelect = vi.fn();
     const { container } = render(

--- a/src/screens/RecordPaymentScreen.tsx
+++ b/src/screens/RecordPaymentScreen.tsx
@@ -25,6 +25,7 @@ import { makeStyles, useThemeColors } from '../theme';
 import { formatCurrency } from '../utils/quoteCalculator';
 import { getAmountDue } from '../utils/invoiceCalculator';
 import { GridBackground } from '../components/GridBackground';
+import { WebContainer } from '../components/WebContainer';
 
 /**
  * Ledger method → the radio option that represents it. Lossy on purpose:
@@ -232,6 +233,12 @@ export function RecordPaymentScreen() {
 
   return (
     <ScrollView style={styles.container} contentContainerStyle={styles.scrollContent}>
+      {/* This is a `presentation: 'modal'` screen, and on web that modal is
+          as wide as the browser — a payment form with a $ field and four
+          radios stretched across a 27" display. 600 matches the other
+          payment surfaces (TakePaymentSheet, StripeCheckoutModal). No-op on
+          native. */}
+      <WebContainer maxWidth={600}>
       {/* Invoice Summary */}
       <Surface style={styles.summaryCard}>
         <View style={styles.sectionHeader}>
@@ -446,6 +453,7 @@ export function RecordPaymentScreen() {
           Remove this payment
         </Button>
       ) : null}
+      </WebContainer>
     </ScrollView>
   );
 }

--- a/src/screens/recordPaymentWebWidth.test.tsx
+++ b/src/screens/recordPaymentWebWidth.test.tsx
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+/**
+ * Record Payment is a `presentation: 'modal'` route with no width of its
+ * own, so on the web build the form — a dollar field, four radios, a date
+ * menu — stretched the full width of the browser. Every other payment
+ * surface caps at 600 (TakePaymentSheet, StripeCheckoutModal).
+ *
+ * Renders through react-native-web (the same mapping the Expo web build
+ * uses) and asserts the cap is really applied to the content, not just
+ * that a component was imported.
+ */
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+
+vi.mock('@expo/vector-icons/MaterialCommunityIcons', () => ({ default: () => null }));
+vi.mock('../components/GridBackground', () => ({ GridBackground: () => null }));
+vi.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: vi.fn(), goBack: vi.fn(), setOptions: vi.fn() }),
+  useRoute: () => ({ params: { invoiceId: 'doc-1' } }),
+}));
+vi.mock('react-native-paper', async () => {
+  const { Text, View, TextInput: RNTextInput } = await import('react-native');
+  const passthrough =
+    (Tag: any) =>
+    ({ children, ...props }: { children?: React.ReactNode }) => <Tag {...props}>{children}</Tag>;
+  const TextInput: any = passthrough(RNTextInput);
+  TextInput.Affix = () => null;
+  const RadioButton: any = passthrough(View);
+  RadioButton.Group = passthrough(View);
+  RadioButton.Item = ({ label }: { label?: string }) => <Text>{label}</Text>;
+  const Menu: any = passthrough(View);
+  Menu.Item = ({ title }: { title?: string }) => <Text>{title}</Text>;
+  return {
+    MD3DarkTheme: { colors: {} },
+    Text,
+    Title: passthrough(Text),
+    Button: ({ children, ...props }: { children?: React.ReactNode }) => (
+      <View {...props}>
+        <Text>{children}</Text>
+      </View>
+    ),
+    Surface: passthrough(View),
+    TextInput,
+    RadioButton,
+    Menu,
+  };
+});
+
+const invoiceDoc = {
+  id: 'doc-1',
+  type: 'invoice',
+  number: 'INV-005',
+  total: 2606.26,
+  paidTotal: 1303.13,
+  customerName: 'Aaron Ngoi',
+  payments: [],
+};
+
+const state = {
+  invoices: [],
+  currentInvoice: null,
+  documents: [invoiceDoc],
+  xeroConnection: null,
+  recordPayment: vi.fn(),
+  recordDocumentPayment: vi.fn(),
+  pushPaymentToXero: vi.fn(),
+  updateDocumentPayment: vi.fn(),
+  deleteDocumentPayment: vi.fn(),
+};
+
+vi.mock('../store/useStore', () => ({
+  useStore: (selector: (s: typeof state) => unknown) => selector(state),
+  PAYMENT_METHOD_TO_LEDGER: {},
+}));
+
+import { RecordPaymentScreen } from './RecordPaymentScreen';
+
+/**
+ * Every declaration in force on an element. react-native-web puts
+ * StyleSheet styles in atomic CSS classes and dynamic ones (WebContainer's
+ * `{ maxWidth }`) in the inline style attribute, so both have to be read.
+ */
+function cssFor(el: Element): string {
+  const node = el as HTMLElement;
+  const classes = node.className.split(/\s+/).filter(Boolean);
+  const out: string[] = [node.getAttribute('style') ?? ''];
+  for (const sheet of Array.from(document.styleSheets)) {
+    for (const rule of Array.from(sheet.cssRules) as CSSStyleRule[]) {
+      const sel = rule.selectorText || '';
+      if (classes.some((c) => sel.includes(`.${c}`))) out.push(rule.cssText);
+    }
+  }
+  return out.join('\n');
+}
+
+describe('RecordPaymentScreen on web', () => {
+  it('caps the form width instead of filling the browser', () => {
+    const { container } = render(<RecordPaymentScreen />);
+
+    // Sanity: the real form rendered, not the "Invoice not found" branch.
+    expect(container.textContent).toContain('Invoice Summary');
+    expect(container.textContent).toContain('INV-005');
+
+    const capped = Array.from(container.querySelectorAll('*')).filter((el) =>
+      /max-width:\s*600px/.test(cssFor(el)),
+    );
+    expect(capped.length).toBeGreaterThan(0);
+    // And the cap has to sit ABOVE the form, not on some leaf inside it.
+    expect(capped[0].textContent).toContain('Invoice Summary');
+  });
+});

--- a/src/utils/jobStatusLabel.test.ts
+++ b/src/utils/jobStatusLabel.test.ts
@@ -1,0 +1,69 @@
+/**
+ * The "Currently …" line on both status doors.
+ *
+ * The pill door prints this a centimetre under the pill you just tapped, so
+ * naming the raw job stage made them contradict each other out loud: an
+ * `in_progress` job under a sent invoice shows "Invoice Sent" on the pill,
+ * and the sheet it opened said "Currently In Progress".
+ */
+import { describe, it, expect } from 'vitest';
+
+import { getJobSubStatus, jobStatusLabel } from './jobTimeline';
+import type { Job } from '../../shared/job/types';
+import type { Document } from '../types/document';
+
+const job = (stage: string, extra: Record<string, unknown> = {}) =>
+  ({ id: 'j1', stage, createdAt: 1, updatedAt: 1, ...extra }) as unknown as Job;
+const doc = (stage: string, extra: Record<string, unknown> = {}) =>
+  ({ id: 'd1', type: 'invoice', stage, invoicedAt: 1, ...extra }) as unknown as Document;
+
+describe('jobStatusLabel', () => {
+  it('says what the pill says', () => {
+    // The whole point: same input, same words as the card's timeline pill.
+    const cases: Array<[Job, Document | null]> = [
+      [job('in_progress'), doc('invoice_sent')],
+      [job('in_progress'), null],
+      [job('accepted'), null],
+      [job('accepted'), doc('draft', { type: 'quote', invoicedAt: 0, depositPaid: 50 })],
+      [job('completed'), null],
+      [job('paid'), null],
+    ];
+    for (const [j, d] of cases) {
+      expect(jobStatusLabel(j, d)).toBe(getJobSubStatus(j, d).label);
+    }
+  });
+
+  it('puts the bare-noun markers into sentence form', () => {
+    // The pill marks "a quote exists" as just "Quote" — fine as a step
+    // marker on the rail, reads as a typo after "Currently".
+    expect(getJobSubStatus(job('quoted'), null).label).toBe('Quote');
+    expect(jobStatusLabel(job('quoted'), null)).toBe('Quoted');
+    expect(jobStatusLabel(job('quoted'), doc('draft'))).toBe('Invoiced');
+    // Anything already phrased as a status is left alone.
+    expect(jobStatusLabel(job('quoted'), { type: 'quote', stage: 'quote_sent' } as any)).toBe(
+      'Quote Sent',
+    );
+  });
+
+  it('names the document once it has outrun the job stage', () => {
+    // The bug this replaced: "Currently Quoted" under a converted invoice.
+    expect(jobStatusLabel(job('quoted'), doc('invoice_sent'))).toBe('Invoice Sent');
+    expect(jobStatusLabel(job('in_progress'), doc('partially_paid'))).toBe('Invoice Sent');
+  });
+
+  it('uses the stage word for terminal jobs', () => {
+    // No pill on a terminal card, and getJobSubStatus falls through to
+    // "Draft" for them — which would be a flat lie on a cancelled job.
+    expect(jobStatusLabel(job('cancelled'), null)).toBe('Cancelled');
+    expect(jobStatusLabel(job('closed'), null)).toBe('Closed');
+    expect(jobStatusLabel(job('cancelled'), doc('invoice_sent'))).toBe('Cancelled');
+  });
+
+  it('says "Scheduled" rather than reading back the date', () => {
+    // The pill prints "Fri 5 Sep · 9am"; "Currently Fri 5 Sep · 9am" isn't
+    // a sentence.
+    const scheduled = job('scheduled', { scheduledStartDate: Date.UTC(2026, 8, 5, 23, 0) });
+    expect(getJobSubStatus(scheduled, null).label).not.toBe('Scheduled');
+    expect(jobStatusLabel(scheduled, null)).toBe('Scheduled');
+  });
+});

--- a/src/utils/jobTimeline.ts
+++ b/src/utils/jobTimeline.ts
@@ -516,3 +516,56 @@ export function sortJobsForList<T extends Job>(jobs: T[]): T[] {
     return String(a.id).localeCompare(String(b.id));
   });
 }
+
+/** Chip wording per stage. Colour-free, so jobStatusLabel can reach it
+ *  without a theme — jobStageMetaFor builds its chipLabels from this. */
+export const STAGE_CHIP_LABELS: Record<JobStage, string> = {
+  inquiry: 'Inquiry',
+  quoted: 'Quoted',
+  accepted: 'Accepted',
+  scheduled: 'Scheduled',
+  in_progress: 'In Progress',
+  completed: 'Completed',
+  paid: 'Paid',
+  closed: 'Closed',
+  cancelled: 'Cancelled',
+};
+
+/**
+ * What the app currently calls this job's status — the same words the
+ * card's timeline pill prints.
+ *
+ * Both status doors print this under "Currently …", and the pill door
+ * prints it a centimetre below the pill you just tapped. Naming the raw
+ * job stage there made them disagree out loud: a job at `in_progress`
+ * under a sent invoice shows "Invoice Sent" on the pill, and the sheet it
+ * opened answered "Currently In Progress".
+ *
+ * Three places the pill isn't printing a status word, where the sentence
+ * form is the honest answer:
+ * - terminal jobs have no pill at all (the card shows a stage chip), and
+ *   getJobSubStatus falls through to "Draft" for them, which is a lie.
+ * - a scheduled job's pill prints the date ("Fri 5 Sep · 9am"), and
+ *   "Currently Fri 5 Sep · 9am" is not a sentence.
+ * - the pill marks "a quote/invoice exists" with the bare noun, so the
+ *   past participle is the same status read aloud (see STATUS_WORD).
+ */
+export function jobStatusLabel(job: Job, primaryDoc?: Document | null): string {
+  if (job.stage === 'cancelled' || job.stage === 'closed') {
+    return STAGE_CHIP_LABELS[job.stage];
+  }
+  const sub = getJobSubStatus(job, primaryDoc);
+  if (sub.slot === 'scheduled') return STAGE_CHIP_LABELS.scheduled;
+  return STATUS_WORD[sub.label] ?? sub.label;
+}
+
+/**
+ * Pill step marker → the word for it in a sentence. Only the bare nouns
+ * need this: "Currently Quote" reads as a typo, "Currently Quote Sent"
+ * doesn't. Same status either way — this is tense, not a different answer.
+ */
+const STATUS_WORD: Record<string, string> = {
+  Quote: 'Quoted',
+  Invoice: 'Invoiced',
+};
+

--- a/src/utils/pdfGenerator.ts
+++ b/src/utils/pdfGenerator.ts
@@ -18,6 +18,7 @@ import { Quote, BusinessSettings, Invoice, BusinessCredential } from '../types';
 import { Document } from '../types/document';
 import { quoteToDocument, invoiceToDocument } from '../types/documentAdapter';
 import { formatPaymentTerms, getAmountDue } from './invoiceCalculator';
+import { isPrintDismissal } from './printDismissal';
 import { formatCurrency } from './quoteCalculator';
 import { Platform, Alert } from 'react-native';
 import {
@@ -675,6 +676,8 @@ export async function previewReportPDF(
     // bridge is the closest equivalent.
     await Print.printAsync({ html });
   } catch (error) {
+    // Closing the preview is how a reader finishes, not a failure to open it.
+    if (isPrintDismissal(error)) return;
     reserved?.close();
     throw error;
   }
@@ -790,9 +793,15 @@ export async function previewDocumentPDF(
     writeToPrintWindow(reserved, html, 'Preview', false);
     return;
   }
-  // iOS: shows the AirPrint-style preview with zoom + share.
+  // iOS: shows the AirPrint-style preview with zoom + share. Closing that
+  // sheet rejects — for a preview, that's the reader finishing, not a failure.
+  // See isPrintDismissal.
   if (Platform.OS === 'ios') {
-    await Print.printAsync({ html });
+    try {
+      await Print.printAsync({ html });
+    } catch (error) {
+      if (!isPrintDismissal(error)) throw error;
+    }
     return;
   }
   // Android: the print bridge renders the HTML in a WebView and can stall
@@ -807,6 +816,8 @@ export async function previewDocumentPDF(
       ),
     ]);
   } catch (error) {
+    // Don't answer a dismissal by pushing a share sheet at them.
+    if (isPrintDismissal(error)) return;
     try {
       const { uri } = await Print.printToFileAsync({ html });
       const namedUri = `${FileSystem.cacheDirectory}QuoteMate-Preview.pdf`;

--- a/src/utils/printDismissal.test.ts
+++ b/src/utils/printDismissal.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Tapping "Preview PDF", reading the quote, then closing the sheet showed
+ * "Preview failed — Couldn't open the PDF". expo-print rejects printAsync when
+ * iOS's print controller completes with `completed == false`, which is exactly
+ * what dismissing it does — so the successful path reported a failure.
+ *
+ * The risk in fixing it is over-matching: swallowing a genuine failure leaves
+ * the tradie staring at a button that does nothing. These pin both directions.
+ */
+import { describe, it, expect } from 'vitest';
+
+import { isPrintDismissal } from './printDismissal';
+
+/** What expo-print's iOS PrintIncompleteException arrives as in JS. */
+const dismissal = () =>
+  Object.assign(new Error('Printing did not complete'), { code: 'ERR_PRINT_INCOMPLETE' });
+
+describe('isPrintDismissal', () => {
+  it('REGRESSION: recognises the rejection raised when the sheet is closed', () => {
+    expect(isPrintDismissal(dismissal())).toBe(true);
+  });
+
+  it('recognises it from the code alone, if the wording changes', () => {
+    expect(isPrintDismissal({ code: 'ERR_PRINT_INCOMPLETE', message: 'Something else' })).toBe(true);
+  });
+
+  it('recognises it from the reason alone, if the code changes', () => {
+    expect(isPrintDismissal(new Error('Printing did not complete'))).toBe(true);
+  });
+
+  it('is case-insensitive about both', () => {
+    expect(isPrintDismissal({ code: 'err_print_incomplete' })).toBe(true);
+    expect(isPrintDismissal(new Error('PRINTING DID NOT COMPLETE'))).toBe(true);
+  });
+
+  // The other direction: a real failure must still reach the tradie.
+  it('does not swallow a printing job that genuinely errored', () => {
+    const failed = Object.assign(
+      new Error("Printing job encountered an error: 'out of paper'"),
+      { code: 'ERR_PRINTING_JOB_FAILED' },
+    );
+    expect(isPrintDismissal(failed)).toBe(false);
+  });
+
+  it('does not swallow the Android preview timeout that triggers the share fallback', () => {
+    expect(isPrintDismissal(new Error('PDF preview timed out'))).toBe(false);
+  });
+
+  it('does not swallow a failure to build the document', () => {
+    expect(isPrintDismissal(new Error('No data to print. You must specify `uri` or `html` option')))
+      .toBe(false);
+  });
+
+  it('handles junk without throwing', () => {
+    expect(isPrintDismissal(null)).toBe(false);
+    expect(isPrintDismissal(undefined)).toBe(false);
+    expect(isPrintDismissal('Printing did not complete')).toBe(false);
+    expect(isPrintDismissal({})).toBe(false);
+    expect(isPrintDismissal({ code: 42, message: 7 })).toBe(false);
+  });
+});

--- a/src/utils/printDismissal.ts
+++ b/src/utils/printDismissal.ts
@@ -1,0 +1,32 @@
+/**
+ * Did the user simply close the preview, rather than hit a failure?
+ *
+ * "Preview PDF" on iOS opens UIPrintInteractionController — the AirPrint sheet
+ * with the rendered document in it. Reading the quote and tapping Cancel is
+ * the ENTIRE point of a preview, but expo-print rejects `printAsync` whenever
+ * that controller completes with `completed == false`, which is what a
+ * dismissal is. So every successful preview ended in
+ * "Preview failed — Couldn't open the PDF".
+ *
+ * Matched on the coded error first (`ERR_PRINT_INCOMPLETE`, which expo-modules
+ * derives from the Swift class name `PrintIncompleteException`), falling back
+ * to the reason string — either could shift if expo-print renames the
+ * exception, and treating a real failure as a dismissal is the worse mistake,
+ * so both are checked rather than assumed.
+ */
+
+const DISMISSAL_CODE = 'ERR_PRINT_INCOMPLETE';
+const DISMISSAL_REASON = 'printing did not complete';
+
+export function isPrintDismissal(error: unknown): boolean {
+  if (!error) return false;
+  const err = error as { code?: unknown; message?: unknown };
+
+  if (typeof err.code === 'string' && err.code.toUpperCase() === DISMISSAL_CODE) {
+    return true;
+  }
+  if (typeof err.message === 'string') {
+    return err.message.toLowerCase().includes(DISMISSAL_REASON);
+  }
+  return false;
+}


### PR DESCRIPTION
## Why

Three surfaces let a tradie change a status, and each drew its own list. The kebab's "Change status" submenu used compact icon+label rows; the card pill's sheet and the document sheet used 42px icon circles with chevrons. Same action, two faces, depending on which door you came through.

Consolidating them shook out a handful of real bugs, which are the rest of this PR.

## What changed

**`refactor(status)`** — all three sheets now render a shared `StageOptionRow`, and the sheets pick up the kebab's header wording. Two things fell out of the restyle:

- The document sheet's cancel row read just **"Cancel"**. As a chunky row with a red icon circle that was unambiguous; as a plain row at the foot of a bottom sheet it reads as *dismiss*, which is the opposite of what it does. Now "Cancel Quote" / "Cancel Invoice", matching the job sheet's "Cancel Job".
- Naming the raw job stage under "Currently" made the pill door contradict itself out loud — a job at `in_progress` under a sent invoice shows **"Invoice Sent"** on the pill, and the sheet it opened answered **"Currently In Progress"**. New `jobStatusLabel` feeds both doors from the same place the pill gets its words, and supersedes the `documentHasOutrunJobStage` subtitle hack that fixed one case of this by hand.

**`fix(layout)`** — three squeezes, all reported from the web build or a phone-width card:

- **A vanished customer name (web only).** A repeat customer's name used `flex: 0` to cancel the one-off case's `flex: 1`. React Native reads that as "basis auto, don't grow"; react-native-web compiles it to `flex: 0 1 0%` — a zero basis that never grows. Every card for a customer with 2+ jobs drew the name at 0px wide, showing the job count and nothing else. Native was fine, which is why it survived. It was the only `flex: 0` in the repo.
- **"INVOICE" running down the card one letter per line.** A payment chip carrying both figures can't shrink and is wider than what's left of a phone row, so `headerLeft` (`flex: 1, minWidth: 0`) absorbed the whole deficit. The header now wraps the chip to its own line — the `minWidth` floor is what makes that fire, since flexbox will otherwise crush the left block to nothing and never wrap.
- **The Record Payment modal spanning the browser.** A `presentation: 'modal'` route with no width of its own; capped at 600 like the other payment surfaces.

**`fix(pdf)`** — unrelated, and not authored in this session: closing the iOS AirPrint preview rejects `printAsync`, so every successful preview ended in "Preview failed — Couldn't open the PDF", and on Android it pushed a share sheet at someone who had just closed the thing. Kept as its own commit so it can be dropped or cherry-picked independently.

## Testing

2049 tests passing, `tsc --noEmit` clean.

New tests render through **react-native-web** — the same mapping the Expo web build uses — and assert against the CSS actually applied, not against style objects. Both new web tests fail on the old code; I verified the width test is load-bearing by stubbing out the wrapper.

Verified by hand on an iPhone 17 Pro simulator: pill sheet and kebab submenu render an identical option list, pill and sheet now agree on the status, the invoice header reads across with the chip on its own line, and a quote header (short chip) still stays on one line.

**Not verified:** neither web fix has been looked at in a real browser at a real window width — the tests prove the mechanism, not the aesthetics. Whether 600px suits that form, and how the wrapped chip looks on a wide screen, are still judgement calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)