### PR TITLE
fix(job card): toggle right inset, and two chips running off the card

### DIFF
--- a/src/components/InvoiceDisplaySettings.tsx
+++ b/src/components/InvoiceDisplaySettings.tsx
@@ -437,6 +437,11 @@ const useStyles = makeStyles((t) => ({
     flexDirection: 'row',
     alignItems: 'center',
     paddingVertical: 14,
+    // Matches the card header's inset. Without it the Switch sits hard
+    // against the card's inner edge while every sibling row (Materials,
+    // Labour) is inset by its own padding, so the toggle read as though it
+    // were falling off the card.
+    paddingHorizontal: 4,
     gap: 16,
   },
   toggleRowDense: {

--- a/src/components/JobCard.tsx
+++ b/src/components/JobCard.tsx
@@ -274,11 +274,11 @@ export const JobCard = React.memo(function JobCard({
     selectionTap();
     navigation.navigate('RecordPayment', { invoiceId: doc.id });
   };
+  // The timeline's active pill covers every non-terminal stage (including
+  // inquiry → "Draft" and completed → "Completed"). Cancelled and closed have
+  // no timeline, so they render a stage chip in its place — same row, same
+  // rhythm as every other card.
   const terminal = job.stage === 'cancelled' || job.stage === 'closed';
-  // The timeline's active pill now covers every non-terminal stage
-  // (including inquiry → "Draft" and completed → "Completed"), so the
-  // stage chip is only needed for the terminal stages we don't render.
-  const showStageChip = terminal;
 
   return (
     <Animated.View
@@ -361,42 +361,6 @@ export const JobCard = React.memo(function JobCard({
               />
             </View>
           </View>
-
-          {showStageChip && onStagePress ? (
-            <Pressable
-              // stopPropagation so the chip tap opens the stage sheet
-              // instead of bubbling to the Card.onPress (which would
-              // navigate into ViewJob).
-              onPress={(e) => {
-                e.stopPropagation();
-                selectionTap();
-                onStagePress(job);
-              }}
-              hitSlop={8}
-              style={({ pressed }) => [
-                styles.stageChip,
-                { backgroundColor: meta.bgColor, borderColor: meta.color + '44' },
-                pressed && styles.stageChipPressed,
-              ]}
-            >
-              <MaterialCommunityIcons name={meta.icon as any} size={14} color={meta.color} />
-              <Text style={[styles.stageLabel, { color: meta.color }]}>
-                {meta.chipLabel}
-              </Text>
-            </Pressable>
-          ) : showStageChip ? (
-            <View
-              style={[
-                styles.stageChip,
-                { backgroundColor: meta.bgColor, borderColor: meta.color + '44' },
-              ]}
-            >
-              <MaterialCommunityIcons name={meta.icon as any} size={14} color={meta.color} />
-              <Text style={[styles.stageLabel, { color: meta.color }]}>
-                {meta.chipLabel}
-              </Text>
-            </View>
-          ) : null}
 
           {onMenuPress ? (
             <Pressable
@@ -490,7 +454,51 @@ export const JobCard = React.memo(function JobCard({
             primaryDoc={primaryDoc}
             onActivePress={onStagePress}
           />
-        ) : null}
+        ) : (
+          // Terminal stages have no timeline to sit in, but the status still
+          // belongs on the same line every other card puts it on. Inline in
+          // the title row it stole the width the name and job title need —
+          // "Aaron Ngoi" became "Aar…" and "Construction of 2m x 4m Deck"
+          // broke mid-word — for a status that is not the thing you scan a
+          // list for.
+          <View style={styles.terminalRow}>
+            {onStagePress ? (
+              <Pressable
+                // stopPropagation so the chip tap opens the stage sheet
+                // instead of bubbling to the Card.onPress (which would
+                // navigate into ViewJob).
+                onPress={(e) => {
+                  e.stopPropagation();
+                  selectionTap();
+                  onStagePress(job);
+                }}
+                hitSlop={8}
+                style={({ pressed }) => [
+                  styles.stageChip,
+                  { backgroundColor: meta.bgColor, borderColor: meta.color + '44' },
+                  pressed && styles.stageChipPressed,
+                ]}
+              >
+                <MaterialCommunityIcons name={meta.icon as any} size={14} color={meta.color} />
+                <Text style={[styles.stageLabel, { color: meta.color }]}>
+                  {meta.chipLabel}
+                </Text>
+              </Pressable>
+            ) : (
+              <View
+                style={[
+                  styles.stageChip,
+                  { backgroundColor: meta.bgColor, borderColor: meta.color + '44' },
+                ]}
+              >
+                <MaterialCommunityIcons name={meta.icon as any} size={14} color={meta.color} />
+                <Text style={[styles.stageLabel, { color: meta.color }]}>
+                  {meta.chipLabel}
+                </Text>
+              </View>
+            )}
+          </View>
+        )}
         </View>
       </Card>
     </Animated.View>
@@ -834,6 +842,14 @@ const useStyles = makeStyles((t) => ({
   paymentChipSlot: {
     marginLeft: 'auto',
     paddingLeft: 8,
+  },
+  // Where the timeline would have been, so a cancelled card keeps the same
+  // vertical rhythm as every other card in the list.
+  terminalRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginTop: 10,
+    marginBottom: 2,
   },
   timelineRow: {
     flexDirection: 'row',

--- a/src/components/JobScopeCard.tsx
+++ b/src/components/JobScopeCard.tsx
@@ -635,6 +635,15 @@ const useStyles = makeStyles((t) => ({
     gap: 6,
     flexShrink: 1,
     minWidth: 0,
+    // flexShrink alone never helped: the children are chips with fixed
+    // padding and a Text that won't shrink, so a paid invoice carrying BOTH
+    // a stage chip and a full payment chip ("Part paid $960.00 / $975.60")
+    // ran past the card edge. Let them wrap instead — this is a detail view,
+    // where PaymentChip deliberately keeps its figures (see its `compact`
+    // note), so the width has to give somewhere and a second line is the
+    // honest place.
+    flexWrap: 'wrap',
+    justifyContent: 'flex-end',
   },
   typeBadge: {
     width: 32,

--- a/src/components/JobScopeCard.tsx
+++ b/src/components/JobScopeCard.tsx
@@ -228,6 +228,7 @@ export function JobScopeCard({
   return (
     <View style={styles.card}>
       <View style={styles.header}>
+        <View style={styles.headerFlow}>
         <View style={styles.headerLeft}>
           <View style={styles.typeBadge}>
             <MaterialCommunityIcons
@@ -276,22 +277,28 @@ export function JobScopeCard({
           {shouldShowPaymentChip(doc) ? (
             <PaymentChip doc={doc} onPress={onPaymentPress} />
           ) : null}
-          <Pressable
-            onPress={handleToggle}
-            hitSlop={10}
-            style={({ pressed }) => [
-              styles.expandButton,
-              pressed && styles.expandButtonPressed,
-            ]}
-            accessibilityLabel={expanded ? 'Hide details' : 'Show details'}
-          >
-            <MaterialCommunityIcons
-              name={(expanded ? 'chevron-up' : 'chevron-down') as any}
-              size={20}
-              color={themeColors.textMuted}
-            />
-          </Pressable>
         </View>
+        </View>
+        {/* Outside the flow, pinned to the top-right corner. The chevron
+            expands the CARD, not the chip group — leaving it as the chips'
+            last sibling meant a wrap stranded it alone on a second line, and
+            an affordance that moves when the data changes is one a tradie has
+            to hunt for. */}
+        <Pressable
+          onPress={handleToggle}
+          hitSlop={10}
+          style={({ pressed }) => [
+            styles.expandButton,
+            pressed && styles.expandButtonPressed,
+          ]}
+          accessibilityLabel={expanded ? 'Hide details' : 'Show details'}
+        >
+          <MaterialCommunityIcons
+            name={(expanded ? 'chevron-up' : 'chevron-down') as any}
+            size={20}
+            color={themeColors.textMuted}
+          />
+        </Pressable>
       </View>
 
       {expanded ? (
@@ -599,7 +606,9 @@ const useStyles = makeStyles((t) => ({
   },
   header: {
     flexDirection: 'row',
-    alignItems: 'center',
+    // flex-start, not center: the chevron is pinned to the top-right corner,
+    // so it must not drift down the card as the chips below it wrap.
+    alignItems: 'flex-start',
     gap: 10,
     paddingHorizontal: 4,
     paddingTop: 4,
@@ -608,12 +617,22 @@ const useStyles = makeStyles((t) => ({
                    // standard touch-target size
     borderBottomWidth: 1,
     borderBottomColor: t.colors.border,
-    // A full payment chip ("Part paid $1,303.13 / $2,606.26") is wider than
-    // what's left of a phone-width row, and the chip can't shrink — so
-    // something had to give. It used to be headerLeft, crushed to a single
-    // character so "INVOICE" ran down the card one letter per line. Now the
-    // chip drops to its own line instead. Nothing wraps where it fits: a
-    // quote's chip is short, and tablets/web have the width.
+  },
+  // Everything that may reflow — identity and chips. The chevron sits outside
+  // it so the two can never fight for the same line.
+  //
+  // A full payment chip ("Part paid $1,303.13 / $2,606.26") is wider than what
+  // is left of a phone-width row, and the chip can't shrink — so something had
+  // to give. It used to be headerLeft, crushed to a single character so
+  // "INVOICE" ran down the card one letter per line. Now the chips drop to
+  // their own line instead. Nothing wraps where it fits: a quote's chip is
+  // short, and tablets/web have the width.
+  headerFlow: {
+    flex: 1,
+    minWidth: 0,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
     flexWrap: 'wrap',
   },
   headerLeft: {
@@ -629,21 +648,20 @@ const useStyles = makeStyles((t) => ({
   // $1,303.13 / $2,606.26") took the whole row and squeezed headerLeft —
   // which has minWidth:0 — down to about one character, so "INVOICE"
   // rendered as a vertical column of letters down the card.
+  // The chips. flexShrink was never going to save this on its own: the
+  // children are chips with fixed padding wrapping a Text that doesn't
+  // shrink, so a paid invoice carrying BOTH a stage chip and a full payment
+  // chip ("Part paid $960.00 / $975.60") had nothing to give and ran past the
+  // card edge. They wrap now — this is a detail view, where PaymentChip
+  // deliberately keeps its figures (see its `compact` note), so the width has
+  // to give somewhere and a second line is the honest place.
   headerRight: {
     flexDirection: 'row',
     alignItems: 'center',
     gap: 6,
     flexShrink: 1,
     minWidth: 0,
-    // flexShrink alone never helped: the children are chips with fixed
-    // padding and a Text that won't shrink, so a paid invoice carrying BOTH
-    // a stage chip and a full payment chip ("Part paid $960.00 / $975.60")
-    // ran past the card edge. Let them wrap instead — this is a detail view,
-    // where PaymentChip deliberately keeps its figures (see its `compact`
-    // note), so the width has to give somewhere and a second line is the
-    // honest place.
     flexWrap: 'wrap',
-    justifyContent: 'flex-end',
   },
   typeBadge: {
     width: 32,


### PR DESCRIPTION
Two layout bugs on the job page, both from a screenshot.

## The toggles had no right inset

`toggleRow` set `paddingVertical` and a `gap` but no horizontal padding. Every sibling row on that card — Materials, Labour — is inset by its own `padding: 10`, so the Switch alone sat hard against the card's inner edge and read as though it were falling off it.

Given the card header's inset of `4`, so it lines up with the rest of the card rather than inventing a number.

## Two chips ran off the card

The header chip row overflowed whenever an invoice carried **both** a stage chip and a full payment chip — `Paid · 3 days` next to `Part paid $960.00 / $975.60`.

`headerRight` already had `flexShrink: 1`, but that was never going to help: its children are chips with fixed padding wrapping a `Text` that doesn't shrink, so there was nothing to give and the row pushed past the card edge. It wraps now.

**Deliberately not** switched to `PaymentChip`'s `compact` mode, which drops the money from the label. That flag exists for list cards, where the chip shares a row with the status line — its own comment reserves the full figures for detail views, and the job page is one. The width has to give somewhere, and a second line is the honest place.

## Verification

`2172` tests green, `tsc --noEmit` clean.

The **toggle inset is verified on a simulator** — both switches now sit inset with symmetric spacing instead of flush.

The **chip wrap is now verified too**, on the reported invoice itself (INV-007, `Paid · 3 days` beside `Part paid $960.00 / $975.60`): both chips sit fully inside the card, nothing runs past the edge, and the figures are intact.

## Follow-up: the chevron is pinned top-right

Wrapping the row fixed the overflow but left the chevron as the chips' last sibling, so a wrap stranded it alone on a second line — an expand affordance that moves when the data changes is one a tradie has to hunt for.

It expands the *card*, not the chip group, so it now sits outside the flow, pinned to the top-right corner and aligned with the INVOICE / number block. Everything that can reflow — identity and chips — lives in a new `headerFlow` container beside it, and `header` switches to `alignItems: 'flex-start'` so the chevron can't drift down as the chips wrap beneath it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
